### PR TITLE
Move ineven indent rule and rename it to uneven rule

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ Main features
     --reports rules_by_id,rules_by_error_type
 
     Issues by ids:
-    W0902 (ineven-indent)                : 5
+    W1007 (uneven-indent)                : 5
     E0904 (nested-for-loop)              : 4
     W0302 (not-capitalized-keyword-name) : 4
 
@@ -147,7 +147,7 @@ Main features
 
 - configurable lint rules::
 
-    --configure 0507:line_length:100 -c ineven-indent:severity:W
+    --configure 0507:line_length:100 -c uneven-indent:severity:W
 
 - external rules support::
 

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -55,7 +55,7 @@ class ReturnChecker(VisitorChecker):
 class EqualSignChecker(VisitorChecker):
     """ Checker for redundant equal signs when assigning return values. """
     rules = {
-        "0904": (
+        "0906": (
             "redundant-equal-sign",
             "Redundant equal sign in return value assignment",
             RuleSeverity.WARNING
@@ -72,7 +72,7 @@ class EqualSignChecker(VisitorChecker):
 class NestedForLoopsChecker(VisitorChecker):
     """ Checker for not supported nested FOR loops. """
     rules = {
-        "0905": (
+        "0907": (
             "nested-for-loop",
             "Nested for loops are not supported. You can use keyword with for loop instead",
             RuleSeverity.ERROR

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -1,9 +1,7 @@
 """
 Miscellaneous checkers
 """
-from collections import Counter
-from robot.parsing.model.statements import Return, KeywordCall, EmptyLine
-from robot.parsing.model.blocks import ForLoop
+from robot.parsing.model.statements import Return, KeywordCall
 from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
 from robocop.utils import normalize_robot_name
@@ -54,95 +52,10 @@ class ReturnChecker(VisitorChecker):
             )
 
 
-class InevenIndentChecker(VisitorChecker):
-    """ Checker for ineven indendation. """
-    rules = {
-        "0904": (
-            "ineven-indent",
-            "Line is %s-indented",
-            RuleSeverity.WARNING
-        ),
-        "0905": (
-            "bad-indent",
-            "Indent expected",
-            RuleSeverity.ERROR
-        )
-    }
-
-    def __init__(self, *args):
-        self.headers = {'arguments', 'documentation', 'setup', 'timeout', 'teardown', 'template', 'tags'}
-        super().__init__(*args)
-
-    def visit_TestCase(self, node):  # noqa
-        self.check_indents(node)
-
-    def visit_Keyword(self, node):  # noqa
-        if not node.name.lstrip().startswith('#'):
-            self.check_indents(node)
-        self.generic_visit(node)
-
-    def visit_ForLoop(self, node):  # noqa
-        column_index = 2 if node.end is None else 0
-        self.check_indents(node, node.header.tokens[1].col_offset + 1, column_index)
-
-    @staticmethod
-    def get_indent(node, column_index):
-        if isinstance(node, ForLoop):
-            separator = node.header.tokens[column_index]
-        else:
-            separator = node.tokens[column_index]
-        if separator.type == 'SEPARATOR':
-            return len(separator.value.expandtabs(4))
-        if separator.type in ('COMMENT', 'EOL'):
-            return None
-        return 0
-
-    def check_indents(self, node, req_indent=0, column_index=0):
-        indents = []
-        header_indents = []
-        for child in node.body:
-            if hasattr(child, 'type') and child.type == 'TEMPLATE':
-                templated = True
-                break
-        else:
-            templated = False
-        for child in node.body:
-            if isinstance(child, EmptyLine):
-                continue
-            indent_len = self.get_indent(child, column_index)
-            if indent_len is None:
-                continue
-            if hasattr(child, 'type') and child.type.strip().lower() in self.headers:
-                if templated:
-                    header_indents.append((indent_len, child))
-                else:
-                    indents.append((indent_len, child))
-            else:
-                indents.append((indent_len, child))
-                if not column_index and (indent_len < req_indent):
-                    self.report("bad-indent", node=child)
-        self.validate_indent_lists(indents)
-        if templated:
-            self.validate_indent_lists(header_indents)
-
-    def validate_indent_lists(self, indents):
-        if len(indents) < 2:
-            return
-        counter = Counter(indent[0] for indent in indents)
-        if len(counter) == 1:  # everything have the same indent
-            return
-        common_indent = counter.most_common(1)[0][0]
-        for indent in indents:
-            if indent[0] != common_indent:
-                self.report("ineven-indent", 'over' if indent[0] > common_indent else 'under',
-                            node=indent[1],
-                            col=indent[0] + 1)
-
-
 class EqualSignChecker(VisitorChecker):
     """ Checker for redundant equal signs when assigning return values. """
     rules = {
-        "0906": (
+        "0904": (
             "redundant-equal-sign",
             "Redundant equal sign in return value assignment",
             RuleSeverity.WARNING
@@ -159,7 +72,7 @@ class EqualSignChecker(VisitorChecker):
 class NestedForLoopsChecker(VisitorChecker):
     """ Checker for not supported nested FOR loops. """
     rules = {
-        "0907": (
+        "0905": (
             "nested-for-loop",
             "Nested for loops are not supported. You can use keyword with for loop instead",
             RuleSeverity.ERROR

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -1,8 +1,9 @@
 """
 Spacing checkers
 """
+from collections import Counter
 from robot.api import get_tokens
-from robot.parsing.model.blocks import TestCase, Keyword
+from robot.parsing.model.blocks import TestCase, Keyword, ForLoop
 from robot.parsing.model.statements import EmptyLine, Comment
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import RuleSeverity
@@ -150,3 +151,88 @@ class InconsistentUseOfTabsAndSpacesChecker(VisitorChecker):
             if tabs and spaces:
                 self.report("mixed-tabs-and-spaces", node=node)
                 break
+
+
+class UnevenIndentChecker(VisitorChecker):
+    """ Checker for uneven indendation. """
+    rules = {
+        "1007": (
+            "uneven-indent",
+            "Line is %s-indented",
+            RuleSeverity.WARNING
+        ),
+        "1008": (
+            "bad-indent",
+            "Indent expected",
+            RuleSeverity.ERROR
+        )
+    }
+
+    def __init__(self, *args):
+        self.headers = {'arguments', 'documentation', 'setup', 'timeout', 'teardown', 'template', 'tags'}
+        super().__init__(*args)
+
+    def visit_TestCase(self, node):  # noqa
+        self.check_indents(node)
+
+    def visit_Keyword(self, node):  # noqa
+        if not node.name.lstrip().startswith('#'):
+            self.check_indents(node)
+        self.generic_visit(node)
+
+    def visit_ForLoop(self, node):  # noqa
+        column_index = 2 if node.end is None else 0
+        self.check_indents(node, node.header.tokens[1].col_offset + 1, column_index)
+
+    @staticmethod
+    def get_indent(node, column_index):
+        if isinstance(node, ForLoop):
+            separator = node.header.tokens[column_index]
+        else:
+            separator = node.tokens[column_index]
+        if separator.type == 'SEPARATOR':
+            return len(separator.value.expandtabs(4))
+        if separator.type in ('COMMENT', 'EOL'):
+            return None
+        return 0
+
+    def check_indents(self, node, req_indent=0, column_index=0):
+        indents = []
+        header_indents = []
+        for child in node.body:
+            if hasattr(child, 'type') and child.type == 'TEMPLATE':
+                templated = True
+                break
+        else:
+            templated = False
+        for child in node.body:
+            if isinstance(child, EmptyLine):
+                continue
+            indent_len = self.get_indent(child, column_index)
+            if indent_len is None:
+                continue
+            if hasattr(child, 'type') and child.type.strip().lower() in self.headers:
+                if templated:
+                    header_indents.append((indent_len, child))
+                else:
+                    indents.append((indent_len, child))
+            else:
+                indents.append((indent_len, child))
+                if not column_index and (indent_len < req_indent):
+                    self.report("bad-indent", node=child)
+        self.validate_indent_lists(indents)
+        if templated:
+            self.validate_indent_lists(header_indents)
+
+    def validate_indent_lists(self, indents):
+        if len(indents) < 2:
+            return
+        counter = Counter(indent[0] for indent in indents)
+        if len(counter) == 1:  # everything have the same indent
+            return
+        common_indent = counter.most_common(1)[0][0]
+        for indent in indents:
+            if indent[0] != common_indent:
+                self.report("uneven-indent", 'over' if indent[0] > common_indent else 'under',
+                            node=indent[1],
+                            col=indent[0] + 1)


### PR DESCRIPTION
1. Move ineven indent rule from misc to spacing checker groups. It's not backward compatible change (if someone have configuration covering affected rules it will break). But it's making a lot more sense to have indent related checks in `spacing`

2. "ineven-indent" was typo and it should be "uneven-indent"