### PR TITLE
List configurable parameters for rules

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -18,7 +18,7 @@ source code. More in :ref:`including-rules`.
 
 Listing available rules
 -----------------------
-To get list of available rules (with enabled/disabled status) use --list option::
+To get list of available rules (with enabled/disabled status) use ``--list`` option::
 
     robocop --list
     Rule - 0201 [W]: missing-doc-keyword: Missing documentation in keyword (enabled)
@@ -42,7 +42,7 @@ Rules list can be filtered out by glob pattern::
     Rule - 0603 [W]: tag-with-reserved: Tag prefixed with reserved word `robot:`. Only allowed tag with this prefix is robot:no-dry-run (enabled)
     Rule - 0606 [I]: tag-already-set-in-force-tags: This tag is already set by Force Tags in suite settings (enabled)
 
- Use --list-configurables argument to list rules together with available configurable parameters. Optional pattern argument is also supported::
+Use ``--list-configurables`` argument to list rules together with available configurable parameters. Optional pattern argument is also supported::
 
     robocop --list-configurables empty-lines-between-section
     Rule - 1003 [W]: empty-lines-between-sections: Invalid number of empty lines between sections (%d/%d) (enabled). Available configurable(s) for this rule:

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -16,6 +16,39 @@ Including or excluding rules
 Rules can be included or excluded from command line. It is also possible to disable rule(s) from Robot Framework
 source code. More in :ref:`including-rules`.
 
+Listing available rules
+-----------------------
+To get list of available rules (with enabled/disabled status) use --list option::
+
+    robocop --list
+    Rule - 0201 [W]: missing-doc-keyword: Missing documentation in keyword (enabled)
+    Rule - 0202 [W]: missing-doc-testcase: Missing documentation in test case (enabled)
+    Rule - 0203 [W]: missing-doc-suite: Missing documentation in suite (enabled)
+    (...)
+
+If some of the rules are disabled from CLI it will be reflected in output::
+
+    robocop --exclude 02* --list
+    Rule - 0201 [W]: missing-doc-keyword: Missing documentation in keyword (disabled)
+    Rule - 0202 [W]: missing-doc-testcase: Missing documentation in test case (disabled)
+    Rule - 0203 [W]: missing-doc-suite: Missing documentation in suite (enabled)
+    (...)
+
+Rules list can be filtered out by glob pattern::
+
+    robocop --list setting-name*
+    Rule - 0601 [W]: tag-with-space: Tags should not contain spaces (enabled)
+    Rule - 0602 [I]: tag-with-or-and: Tag with reserved word OR/AND. Hint: make sure to include this tag using lowercase name to avoid issues (enabled)
+    Rule - 0603 [W]: tag-with-reserved: Tag prefixed with reserved word `robot:`. Only allowed tag with this prefix is robot:no-dry-run (enabled)
+    Rule - 0606 [I]: tag-already-set-in-force-tags: This tag is already set by Force Tags in suite settings (enabled)
+
+ Use --list-configurables argument to list rules together with available configurable parameters. Optional pattern argument is also supported::
+
+    robocop --list-configurables empty-lines-between-section
+    Rule - 1003 [W]: empty-lines-between-sections: Invalid number of empty lines between sections (%d/%d) (enabled). Available configurable(s) for this rule:
+    severity
+    empty_lines
+
 Ignoring file
 -------------
 Path matching glob pattern can be ignored (or *skipped* during scan). You can pass list of patterns::

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -88,8 +88,9 @@ class Config:
                             '-c message_name_or_id:param_name:param_value\nExample:\n'
                             '-c line-too-long:line_length:150\n'
                             '--configure 0101:severity:E',
-        'help_list':        'List all available rules',
-        'help_list_confs':  'List all configurable parameters for rules matching given glob pattern',
+        'help_list':        'List all available rules. You can use optional pattern argument',
+        'help_list_confs':  'List all available rules with configurable parameters. '
+                            'You can use optional pattern argument',
         'help_output':      'Path to output file',
         'help_filetypes':   'Comma separated list of file extensions to be scanned by Robocop',
         'help_threshold':    f'Disable rules below given threshold. Available message levels: '
@@ -172,9 +173,9 @@ class Config:
         optional.add_argument('-c', '--configure', action=ParseCheckerConfig, default=self.configure,
                               metavar='CONFIGURABLE', help=self.HELP_MSGS['help_configure'])
         optional.add_argument('-l', '--list', action=SetListOption, nargs='?', const='', default=self.list,
-                              help=self.HELP_MSGS['help_list'])
+                              metavar='PATTERN', help=self.HELP_MSGS['help_list'])
         optional.add_argument('--list-configurables', action=SetListOption, nargs='?', const='', default=self.list_configurables,
-                              help=self.HELP_MSGS['help_list_confs'])
+                              metavar='PATTERN', help=self.HELP_MSGS['help_list_confs'])
         optional.add_argument('-o', '--output', type=argparse.FileType('w'), default=self.output,
                               metavar='PATH', help=self.HELP_MSGS['help_output'])
         optional.add_argument('--filetypes', action=ParseFileTypes, default=self.filetypes,

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -110,7 +110,7 @@ class Config:
     def translate_patterns(self):
         self.include_patterns = self._translate_patterns(self.include)
         self.exclude_patterns = self._translate_patterns(self.exclude)
-        self.list_configurables = self._translate_pattern(self.list_configurables)
+        self.list_configurables = self._translate_pattern(self.list_configurables) if self.list_configurables else None
 
     def preparse(self, args):
         args = sys.argv[1:] if args is None else args

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -237,10 +237,3 @@ class Config:
             for char in sev:
                 message = message.replace(char, '')
         return message
-
-"""
-no --list-configurables: set to '' and skip it later
---list-configurables, no patterns - set to '*'
---list-configurables pattern - set to pattern
---list-configurables pattern pattern - error
-"""

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -91,8 +91,8 @@ class Rule:
 
     def available_configurables(self):
         configurables = ['severity'] + [conf[0] for conf in self.configurable]
-        names = '\n'.join(configurables)
-        return f"Available configurable(s) for this rule:\n{names}"
+        names = '\n        '.join(configurables)
+        return f"Available configurable(s) for this rule:\n        {names}"
 
     def parse_body(self, body):
         if isinstance(body, tuple) and len(body) >= 3:

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -106,6 +106,12 @@ class Rule:
     def prepare_message(self, *args, source, node, lineno, col):
         return Message(*args, rule=self, source=source, node=node, lineno=lineno, col=col)
 
+    def matches_pattern(self, pattern):
+        """ check if this rule matches given pattern """
+        if isinstance(pattern, str):
+            return pattern in (self.name, self.rule_id)
+        return pattern.match(self.name) or pattern.match(self.rule_id)
+
 
 class Message:
     def __init__(self, *args, rule, source, node, lineno, col):

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -89,6 +89,11 @@ class Rule:
                 return configurable
         return None
 
+    def available_configurables(self):
+        configurables = ['severity'] + [conf[0] for conf in self.configurable]
+        names = '\n'.join(configurables)
+        return f"Available configurable(s) for this rule:\n{names}"
+
     def parse_body(self, body):
         if isinstance(body, tuple) and len(body) >= 3:
             self.name, self.desc, self.severity, *self.configurable = body

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -118,23 +118,20 @@ class Robocop:
         checkers.init(self)
 
     def list_checkers(self):
-        if self.config.list:
-            rule_by_id = {msg.rule_id: msg for checker in self.checkers for msg in checker.rules_map.values()}
-            rule_ids = sorted([key for key in rule_by_id])
-            for rule_id in rule_ids:
+        if not (self.config.list or self.config.list_configurables):
+            return
+        rule_by_id = {msg.rule_id: msg for checker in self.checkers for msg in checker.rules_map.values()}
+        rule_ids = sorted([key for key in rule_by_id])
+        for rule_id in rule_ids:
+            if self.config.list:
+                if not rule_by_id[rule_id].matches_pattern(self.config.list):
+                    continue
                 print(rule_by_id[rule_id])
-            sys.exit()
-        if self.config.list_configurables:
-            rule_by_id = {msg.rule_id: msg for checker in self.checkers for msg in checker.rules_map.values()}
-            rule_ids = []
-            for rule_id in rule_by_id:
-                if self.config.list_configurables.match(rule_id) or \
-                        self.config.list_configurables.match(rule_by_id[rule_id].name):
-                    rule_ids.append(rule_id)
-            rule_ids = sorted(rule_ids)
-            for rule_id in rule_ids:
+            else:
+                if not rule_by_id[rule_id].matches_pattern(self.config.list_configurables):
+                    continue
                 print(f"{rule_by_id[rule_id]}. {rule_by_id[rule_id].available_configurables()}")
-            sys.exit()
+        sys.exit()
 
     def load_reports(self):
         classes = inspect.getmembers(reports, inspect.isclass)

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -124,6 +124,17 @@ class Robocop:
             for rule_id in rule_ids:
                 print(rule_by_id[rule_id])
             sys.exit()
+        if self.config.list_configurables:
+            rule_by_id = {msg.rule_id: msg for checker in self.checkers for msg in checker.rules_map.values()}
+            rule_ids = []
+            for rule_id in rule_by_id:
+                if self.config.list_configurables.match(rule_id) or \
+                        self.config.list_configurables.match(rule_by_id[rule_id].name):
+                    rule_ids.append(rule_id)
+            rule_ids = sorted(rule_ids)
+            for rule_id in rule_ids:
+                print(f"{rule_by_id[rule_id]}. {rule_by_id[rule_id].available_configurables()}")
+            sys.exit()
 
     def load_reports(self):
         classes = inspect.getmembers(reports, inspect.isclass)

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -130,7 +130,7 @@ class Robocop:
             else:
                 if not rule_by_id[rule_id].matches_pattern(self.config.list_configurables):
                     continue
-                print(f"{rule_by_id[rule_id]}. {rule_by_id[rule_id].available_configurables()}")
+                print(f"{rule_by_id[rule_id]}\n    {rule_by_id[rule_id].available_configurables()}")
         sys.exit()
 
     def load_reports(self):

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -197,8 +197,9 @@ class Robocop:
                 else:
                     configurable = msg.get_configurable(param)
                     if configurable is None:
+                        available_conf = msg.available_configurables()
                         raise robocop.exceptions.ConfigGeneralError(
-                            f"Provided param '{param}' for rule '{rule_or_report}' does not exist")
+                            f"Provided param '{param}' for rule '{rule_or_report}' does not exist. {available_conf}")
                     checker.configure(configurable[1], configurable[2](value))
             elif any(rule_or_report == report.name for report in self.reports):
                 for report in self.reports:

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -167,7 +167,8 @@ class TestE2E:
         robocop_instance.config = config
         with pytest.raises(ConfigGeneralError) as err:
             robocop_instance.configure_checkers_or_reports()
-        assert "Provided param 'idontexist' for rule '0202' does not exist" in str(err)
+        assert r"Provided param 'idontexist' for rule '0202' does not exist. " \
+               r"Available configurable(s) for this rule:\nseverity" in str(err)
 
     def test_configure_invalid_config(self, robocop_instance):
         config = Config()

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -168,7 +168,7 @@ class TestE2E:
         with pytest.raises(ConfigGeneralError) as err:
             robocop_instance.configure_checkers_or_reports()
         assert r"Provided param 'idontexist' for rule '0202' does not exist. " \
-               r"Available configurable(s) for this rule:\nseverity" in str(err)
+               r"Available configurable(s) for this rule:\n        severity" in str(err)
 
     def test_configure_invalid_config(self, robocop_instance):
         config = Config()

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -100,8 +100,8 @@ class TestListingRules:
         with pytest.raises(SystemExit):
             robocop_pre_load.list_checkers()
         out, _ = capsys.readouterr()
-        assert out == 'Rule - 0101 [W]: some-message: Some description (enabled). ' \
-                      'Available configurable(s) for this rule:\nseverity\n'
+        assert out == 'Rule - 0101 [W]: some-message: Some description (enabled)\n' \
+                      '    Available configurable(s) for this rule:\n        severity\n'
 
     def test_list_configurables_filtered(self, robocop_pre_load, msg_0101, msg_0102_0204, capsys):
         robocop_pre_load.config.list_configurables = 'another-message'
@@ -111,12 +111,12 @@ class TestListingRules:
             robocop_pre_load.list_checkers()
         out, _ = capsys.readouterr()
         not_exp_msg = (
-            'Rule - 0101 [W]: some-message: Some description (enabled). '
-            'Available configurable(s) for this rule:\nseverity\n',
-            'Rule - 0102 [E]: other-message: this is description (disabled). '
-            'Available configurable(s) for this rule:\nseverity\n'
+            'Rule - 0101 [W]: some-message: Some description (enabled)\n'
+            '    Available configurable(s) for this rule:\n        severity\n',
+            'Rule - 0102 [E]: other-message: this is description (disabled)\n'
+            '    Available configurable(s) for this rule:\n        severity\n'
         )
-        exp_msg = 'Rule - 0204 [I]: another-message: Message with meaning 4 (disabled). ' \
-                      'Available configurable(s) for this rule:\nseverity\n'
+        exp_msg = 'Rule - 0204 [I]: another-message: Message with meaning 4 (disabled)\n' \
+                  '    Available configurable(s) for this rule:\n        severity\n'
         assert all(msg not in out for msg in not_exp_msg)
         assert exp_msg in out

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -1,5 +1,6 @@
 import pytest
 
+import robocop.config
 from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
 
@@ -29,7 +30,7 @@ def msg_0102_0204():
             RuleSeverity.ERROR
         ),
         '0204': (
-            "another message",
+            "another-message",
             f"Message with meaning {4}",
             RuleSeverity.INFO
         )
@@ -49,7 +50,7 @@ def init_empty_checker(robocop_instance_pre_load, rule, exclude=False):
 
 class TestListingRules:
     def test_list_rule(self, robocop_pre_load, msg_0101, capsys):
-        robocop_pre_load.config.list = True
+        robocop_pre_load.config.list = robocop.config.translate_pattern('*')
         init_empty_checker(robocop_pre_load, msg_0101)
         with pytest.raises(SystemExit):
             robocop_pre_load.list_checkers()
@@ -57,7 +58,7 @@ class TestListingRules:
         assert out == 'Rule - 0101 [W]: some-message: Some description (enabled)\n'
 
     def test_list_disabled_rule(self, robocop_pre_load, msg_0101, capsys):
-        robocop_pre_load.config.list = True
+        robocop_pre_load.config.list = robocop.config.translate_pattern('*')
         init_empty_checker(robocop_pre_load, msg_0101, exclude=True)
         with pytest.raises(SystemExit):
             robocop_pre_load.list_checkers()
@@ -65,7 +66,7 @@ class TestListingRules:
         assert out == 'Rule - 0101 [W]: some-message: Some description (disabled)\n'
 
     def test_multiple_checkers(self, robocop_pre_load, msg_0101, msg_0102_0204, capsys):
-        robocop_pre_load.config.list = True
+        robocop_pre_load.config.list = robocop.config.translate_pattern('*')
         init_empty_checker(robocop_pre_load, msg_0102_0204, exclude=True)
         init_empty_checker(robocop_pre_load, msg_0101)
         with pytest.raises(SystemExit):
@@ -74,6 +75,48 @@ class TestListingRules:
         exp_msg = (
             'Rule - 0101 [W]: some-message: Some description (enabled)\n',
             'Rule - 0102 [E]: other-message: this is description (disabled)\n',
-            'Rule - 0204 [I]: another message: Message with meaning 4 (disabled)\n'
+            'Rule - 0204 [I]: another-message: Message with meaning 4 (disabled)\n'
         )
         assert all(msg in out for msg in exp_msg)
+
+    def test_list_filtered(self, robocop_pre_load, msg_0101, msg_0102_0204, capsys):
+        robocop_pre_load.config.list = robocop.config.translate_pattern('01*')
+        init_empty_checker(robocop_pre_load, msg_0102_0204, exclude=True)
+        init_empty_checker(robocop_pre_load, msg_0101)
+        with pytest.raises(SystemExit):
+            robocop_pre_load.list_checkers()
+        out, _ = capsys.readouterr()
+        exp_msg = (
+            'Rule - 0101 [W]: some-message: Some description (enabled)\n',
+            'Rule - 0102 [E]: other-message: this is description (disabled)\n'
+        )
+        not_exp_msg = 'Rule - 0204 [I]: another-message: Message with meaning 4 (disabled)\n'
+        assert all(msg in out for msg in exp_msg)
+        assert not_exp_msg not in out
+
+    def test_list_configurables(self, robocop_pre_load, msg_0101, capsys):
+        robocop_pre_load.config.list_configurables = robocop.config.translate_pattern('*')
+        init_empty_checker(robocop_pre_load, msg_0101)
+        with pytest.raises(SystemExit):
+            robocop_pre_load.list_checkers()
+        out, _ = capsys.readouterr()
+        assert out == 'Rule - 0101 [W]: some-message: Some description (enabled). ' \
+                      'Available configurable(s) for this rule:\nseverity\n'
+
+    def test_list_configurables_filtered(self, robocop_pre_load, msg_0101, msg_0102_0204, capsys):
+        robocop_pre_load.config.list_configurables = 'another-message'
+        init_empty_checker(robocop_pre_load, msg_0102_0204, exclude=True)
+        init_empty_checker(robocop_pre_load, msg_0101)
+        with pytest.raises(SystemExit):
+            robocop_pre_load.list_checkers()
+        out, _ = capsys.readouterr()
+        not_exp_msg = (
+            'Rule - 0101 [W]: some-message: Some description (enabled). '
+            'Available configurable(s) for this rule:\nseverity\n',
+            'Rule - 0102 [E]: other-message: this is description (disabled). '
+            'Available configurable(s) for this rule:\nseverity\n'
+        )
+        exp_msg = 'Rule - 0204 [I]: another-message: Message with meaning 4 (disabled). ' \
+                      'Available configurable(s) for this rule:\nseverity\n'
+        assert all(msg not in out for msg in not_exp_msg)
+        assert exp_msg in out


### PR DESCRIPTION
Add --list-configurables option that prints out all rules together with configurable parameters
Add support for --list [PATTERN] and --list-configurables [PATTERN] that filter outs printed list by given glob pattern

Closes #207 