### PR TITLE
Fix 'not-capitalized-keyword-name' rule to ignore special characters & fix keyword name with filename prefix

### DIFF
--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -144,8 +144,9 @@ class KeywordNamingChecker(VisitorChecker):
                     )
         elif self.check_if_keyword_is_reserved(keyword_name, node):
             return
-        keyword_name_no_vars = self.var_pattern.sub('', keyword_name)
-        words = self.letter_pattern.sub(' ', keyword_name_no_vars).split(' ')
+        keyword_name = keyword_name.split('.')[-1]  # remove any imports ie ExternalLib.SubLib.Log -> Log
+        keyword_name = self.var_pattern.sub('', keyword_name)  # remove any embedded variables from name
+        words = self.letter_pattern.sub(' ', keyword_name).split(' ')
         if any(not (word.istitle() or word.isupper()) for word in words if word):
             self.report("not-capitalized-keyword-name", node=node)
 

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -89,12 +89,11 @@ class KeywordNamingChecker(VisitorChecker):
         'else',
         'else if'
     }
-    variable_identifier = {
-        '$',
-        '@',
-        '&',
-        '%'
-    }
+
+    def __init__(self,*args):
+        self.letter_pattern = re.compile('[^a-zA-Z]')
+        self.var_pattern = re.compile(r'[$@%&]{.+}')
+        super().__init__(*args)
 
     def visit_SuiteSetup(self, node):  # noqa
         self.check_keyword_naming(node.name, node)
@@ -145,14 +144,10 @@ class KeywordNamingChecker(VisitorChecker):
                     )
         elif self.check_if_keyword_is_reserved(keyword_name, node):
             return
-        words = keyword_name.replace('_', ' ').split(' ')
-        if any(not (word.istitle() or word.isupper()) for word in words if not self.is_variable(word)):
+        keyword_name_no_vars = self.var_pattern.sub('', keyword_name)
+        words = self.letter_pattern.sub(' ', keyword_name_no_vars).split(' ')
+        if any(not (word.istitle() or word.isupper()) for word in words if word):
             self.report("not-capitalized-keyword-name", node=node)
-
-    def is_variable(self, name):
-        if len(name) < 4:
-            return False
-        return name[0] in self.variable_identifier and name[1] == '{' and name[-1] == '}'
 
     def check_if_keyword_is_reserved(self, keyword_name, node):
         if keyword_name.lower() not in self.reserved_words:  # if there is typo in syntax, it is interpreted as keyword

--- a/tests/atest/rules/not-capitalized-keyword-name/test.robot
+++ b/tests/atest/rules/not-capitalized-keyword-name/test.robot
@@ -35,3 +35,7 @@ Keyword With ${var} Variable
 
 Keyword-With_Special $ Chars 10
     Should Pass
+
+Keyword With Library Import
+    SeleniumLibrary.Input Text    ${txt_welcome}    Hello
+    Input Text    ${txt_welcome}    Hello

--- a/tests/atest/rules/not-capitalized-keyword-name/test.robot
+++ b/tests/atest/rules/not-capitalized-keyword-name/test.robot
@@ -29,3 +29,9 @@ keyword
     Fail
 
  # special case
+
+Keyword With ${var} Variable
+    Should Pass
+
+Keyword-With_Special $ Chars 10
+    Should Pass

--- a/tests/atest/test_rule.py
+++ b/tests/atest/test_rule.py
@@ -25,7 +25,7 @@ def configure_robocop_with_rule(runner, rule, path):
 
 
 def replace_paths(line, rules_dir):
-    return line.replace('${rules_dir}', rules_dir).replace('${\}', os.path.sep).rstrip('\n')
+    return line.replace('${rules_dir}', rules_dir).replace(r'${\}', os.path.sep).rstrip('\n')
 
 
 def test_rule(rule, robocop_instance, capsys):


### PR DESCRIPTION
Closes #226 

Due to this change all special characters (or rather, any non letter character) will be stripped from keyword name before check. If some special character is not desired in keyword name it should be detected by different rule.

Closes #214 

Fixed issue with workaround that strips any path like parts from keyword name. SeleniumLib.Open Browser will become Open Browser (but also My.Keyword will become just Keyword). The only other way of fixing 214 would be implementing scope recognition (loading up available libraries) - this is planned for the further future. 

I'm open to discuss how to best handle both issues.