### PR TITLE
Improve rule 0509

### DIFF
--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -1,6 +1,7 @@
 """
 Lengths checkers
 """
+from robot.parsing.model.blocks import CommentSection
 from robot.parsing.model.statements import KeywordCall, Comment, EmptyLine, Arguments
 from robocop.checkers import VisitorChecker, RawFileChecker
 from robocop.rules import RuleSeverity
@@ -168,13 +169,8 @@ class EmptySectionChecker(VisitorChecker):
     }
 
     def check_if_empty(self, node):
-        for child in node.body:
-            if isinstance(child, Comment):
-                if 'robocop:' in child.tokens[0].value and len(node.body) == 1:
-                    break
-            elif not isinstance(child, EmptyLine):
-                break
-        else:
+        anything_but = EmptyLine if isinstance(node, CommentSection) else (Comment, EmptyLine)
+        if all(isinstance(child, anything_but) for child in node.body):
             self.report("empty-section", node=node)
 
     def visit_SettingSection(self, node):  # noqa

--- a/tests/atest/rules/empty-section/expected_output.txt
+++ b/tests/atest/rules/empty-section/expected_output.txt
@@ -1,3 +1,3 @@
 ${rules_dir}${\}with_empty_sections.robot:1:0 [W] 0509 Section is empty
 ${rules_dir}${\}with_empty_sections.robot:13:0 [W] 0509 Section is empty
-${rules_dir}${\}with_empty_sections.robot:16:0 [W] 0509 Section is empty
+${rules_dir}${\}with_empty_sections.robot:17:0 [W] 0509 Section is empty

--- a/tests/atest/rules/empty-section/with_empty_sections.robot
+++ b/tests/atest/rules/empty-section/with_empty_sections.robot
@@ -11,6 +11,7 @@ Test
 
 
 *** Keywords ***
+# This section considered as empty.
 
 
 *** Variables ***


### PR DESCRIPTION
- If the section is Comments, just check if there is anything
  except EmptyLines.
- If the section is any other section, it should trigger warning if
  there are only EmptyLines and Comments.

Closes #234