### PR TITLE
Add support for RF4.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
         python-version: [ 3.6, 3.7, 3.8]
-        rf-version: ['<4.0.0', '==4.0b3']
+        rf-version: ['3.2.*', '4.0b3']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install robotframework${{ matrix.rf-version }}
+        pip install robotframework$=={{ matrix.rf-version }}
         pip install pylama pylama_pylint
         pip install pytest
         pip install coverage

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
         python-version: [ 3.6, 3.7, 3.8]
+        rf-version: ['<4.0.0', '4.0b3']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install robotframework>=3.2.1
+        pip install robotframework${{ matrix.rf-version }}
         pip install pylama pylama_pylint
         pip install pytest
         pip install coverage
@@ -40,5 +41,5 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1.0.11
       with:
-        name: ${{ matrix.python-version }}-${{ matrix.os }}
+        name: ${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.rf-version }}
       if: always()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install robotframework$=={{ matrix.rf-version }}
+        pip install robotframework==${{ matrix.rf-version }}
         pip install pylama pylama_pylint
         pip install pytest
         pip install coverage

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
         python-version: [ 3.6, 3.7, 3.8]
-        rf-version: ['<4.0.0', '4.0b3']
+        rf-version: ['<4.0.0', '==4.0b3']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/robocop/checkers/__init__.py
+++ b/robocop/checkers/__init__.py
@@ -32,6 +32,10 @@ import inspect
 from robocop.rules import Rule
 from robocop.exceptions import DuplicatedRuleError
 from robocop.utils import modules_in_current_dir, modules_from_paths
+try:
+    from robot.api.parsing import ModelVisitor
+except ImportError:
+    from robot.parsing.model.visitor import ModelVisitor
 
 
 class BaseChecker:
@@ -65,7 +69,7 @@ class BaseChecker:
         raise NotImplementedError
 
 
-class VisitorChecker(BaseChecker, ast.NodeVisitor):  # noqa
+class VisitorChecker(BaseChecker, ModelVisitor):  # noqa
     type = 'visitor_checker'
 
     def scan_file(self, *args):

--- a/robocop/checkers/__init__.py
+++ b/robocop/checkers/__init__.py
@@ -27,7 +27,6 @@ Every rule has a `unique id` made of 4 digits where first 2 are `group id` while
 `Unique id` as well as `rule name` can be used to refer to the rule (e.g. in include/exclude statements,
 configurations etc.) You can optionally configure rule severity or other parameters.
 """
-import ast
 import inspect
 from robocop.rules import Rule
 from robocop.exceptions import DuplicatedRuleError

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -3,6 +3,7 @@ Comments checkers
 """
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import RuleSeverity
+from robocop.utils import IS_RF4
 
 
 class CommentChecker(VisitorChecker):
@@ -18,7 +19,7 @@ class CommentChecker(VisitorChecker):
             "Missing blank space after comment character",
             RuleSeverity.WARNING
         ),
-        "0703": (
+        "0703": (  # Deprecated in RF 4.0
             "invalid-comment",
             "Invalid comment. '#' needs to be first character in the cell. "
             "For block comments you can use '*** Comments ***' section",
@@ -47,6 +48,8 @@ class CommentChecker(VisitorChecker):
                 self.check_comment_content(token)
 
     def check_invalid_comments(self, name, node):
+        if IS_RF4:
+            return
         if name and name.lstrip().startswith('#'):
             self.report("invalid-comment", node=node, col=node.col_offset)
 

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -139,57 +139,39 @@ class DuplicatedOrOutOfOrderSectionChecker(VisitorChecker):
     }
 
     def __init__(self, *args):
-        self.settings_defined = False
-        self.variables_defined = False
-        self.test_cases_defined = False
-        self.tasks_defined = False
-        self.keywords_defined = False
+        self.sections_order = {
+            'SETTING HEADER': 0,
+            'VARIABLE HEADER': 1,
+            'TESTCASE HEADER': 2,
+            'TASK HEADER': 3,
+            'KEYWORD HEADER': 4
+        }
+        self.sections_by_order = []
+        self.sections_by_existence = set()
         super().__init__(*args)
 
     def visit_File(self, node):
-        self.settings_defined = False
-        self.variables_defined = False
-        self.test_cases_defined = False
-        self.tasks_defined = False
-        self.keywords_defined = False
+        self.sections_by_order = []
+        self.sections_by_existence = set()
         super().visit_File(node)
 
-    def visit_SettingSectionHeader(self, node):  # noqa
-        if self.settings_defined:
-            self.report("section-already-defined", node.data_tokens[0].value, node=node)
-        else:
-            self.settings_defined = True
-        if self.variables_defined or self.test_cases_defined or self.tasks_defined or self.keywords_defined:
-            self.report("section-out-of-order", node.data_tokens[0].value, node=node)
-
-    def visit_VariableSectionHeader(self, node):  # noqa
-        if self.variables_defined:
-            self.report("section-already-defined", node.data_tokens[0].value, node=node)
-        else:
-            self.variables_defined = True
-        if self.test_cases_defined or self.tasks_defined or self.keywords_defined:
-            self.report("section-out-of-order", node.data_tokens[0].value, node=node)
-
-    def visit_TestCaseSectionHeader(self, node):  # noqa
-        if 'task' in node.name.lower():
-            if self.test_cases_defined:
-                self.report("both-tests-and-tasks", node=node)
-            if self.tasks_defined:
-                self.report("section-already-defined", node.data_tokens[0].value, node=node)
+    def visit_SectionHeader(self, node):  # noqa
+        section_name = node.type.replace('_', ' ')  # In RF 4.0 '_' -> ' '
+        if section_name not in self.sections_order:
+            return
+        if section_name == 'TESTCASE HEADER':
+            if 'task' in node.name.lower():
+                section_name = 'TASK HEADER'
+                if 'TESTCASE HEADER' in self.sections_by_existence:
+                    self.report("both-tests-and-tasks", node=node)
             else:
-                self.tasks_defined = True
-        else:
-            if self.tasks_defined:
-                self.report("both-tests-and-tasks", node=node)
-            if self.test_cases_defined:
-                self.report("section-already-defined", node.data_tokens[0].value, node=node)
-            else:
-                self.test_cases_defined = True
-        if self.keywords_defined:
-            self.report("section-out-of-order", node.data_tokens[0].value, node=node)
-
-    def visit_KeywordSectionHeader(self, node):  # noqa
-        if self.keywords_defined:
+                if 'TASK HEADER' in self.sections_by_existence:
+                    self.report("both-tests-and-tasks", node=node)
+        order_id = self.sections_order[section_name]
+        if section_name in self.sections_by_existence:
             self.report("section-already-defined", node.data_tokens[0].value, node=node)
-        else:
-            self.keywords_defined = True
+        if any(previous_id > order_id for previous_id in self.sections_by_order):
+            self.report("section-out-of-order", node.data_tokens[0].value, node=node)
+        self.sections_by_order.append(order_id)
+        self.sections_by_existence.add(section_name)
+

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -6,6 +6,8 @@ from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
 from robocop.utils import normalize_robot_name
 
+from robot.api import Token
+
 
 class DuplicationsChecker(VisitorChecker):
     """ Checker for duplicated names. """
@@ -140,11 +142,11 @@ class DuplicatedOrOutOfOrderSectionChecker(VisitorChecker):
 
     def __init__(self, *args):
         self.sections_order = {
-            'SETTING HEADER': 0,
-            'VARIABLE HEADER': 1,
-            'TESTCASE HEADER': 2,
+            Token.SETTING_HEADER: 0,
+            Token.VARIABLE_HEADER: 1,
+            Token.TESTCASE_HEADER: 2,
             'TASK HEADER': 2,
-            'KEYWORD HEADER': 4
+            Token.KEYWORD_HEADER: 4
         }
         self.sections_by_order = []
         self.sections_by_existence = set()
@@ -159,10 +161,10 @@ class DuplicatedOrOutOfOrderSectionChecker(VisitorChecker):
         section_name = node.type.replace('_', ' ')  # In RF 4.0 '_' -> ' '
         if section_name not in self.sections_order:
             return
-        if section_name == 'TESTCASE HEADER':
+        if section_name == Token.TESTCASE_HEADER:
             if 'task' in node.name.lower():
                 section_name = 'TASK HEADER'
-                if 'TESTCASE HEADER' in self.sections_by_existence:
+                if Token.TESTCASE_HEADER in self.sections_by_existence:
                     self.report("both-tests-and-tasks", node=node)
             else:
                 if 'TASK HEADER' in self.sections_by_existence:
@@ -174,4 +176,3 @@ class DuplicatedOrOutOfOrderSectionChecker(VisitorChecker):
             self.report("section-out-of-order", node.data_tokens[0].value, node=node)
         self.sections_by_order.append(order_id)
         self.sections_by_existence.add(section_name)
-

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -158,7 +158,7 @@ class DuplicatedOrOutOfOrderSectionChecker(VisitorChecker):
         super().visit_File(node)
 
     def visit_SectionHeader(self, node):  # noqa
-        section_name = node.type.replace('_', ' ')  # In RF 4.0 '_' -> ' '
+        section_name = node.type
         if section_name not in self.sections_order:
             return
         if section_name == Token.TESTCASE_HEADER:

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -143,7 +143,7 @@ class DuplicatedOrOutOfOrderSectionChecker(VisitorChecker):
             'SETTING HEADER': 0,
             'VARIABLE HEADER': 1,
             'TESTCASE HEADER': 2,
-            'TASK HEADER': 3,
+            'TASK HEADER': 2,
             'KEYWORD HEADER': 4
         }
         self.sections_by_order = []

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -2,8 +2,12 @@
 Errors checkers
 """
 import re
+
+from robot.version import VERSION as ROBOT_VERSION
+
 from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
+from robocop.utils import IS_RF4
 
 
 class ParsingErrorChecker(VisitorChecker):
@@ -17,7 +21,11 @@ class ParsingErrorChecker(VisitorChecker):
     }
 
     def visit_Error(self, node):  # noqa
-        self.report("parsing-error", node.error, node=node)
+        if IS_RF4:
+            for error in node.errors:
+                self.report("parsing-error", error, node=node)
+        else:
+            self.report("parsing-error", node.error, node=node)
 
 
 class TwoSpacesAfterSettingsChecker(VisitorChecker):

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -210,6 +210,9 @@ class NumberOfReturnedArgsChecker(VisitorChecker):
     def visit_ForLoop(self, node):  # noqa
         self.generic_visit(node)
 
+    def visit_For(self, node):  # noqa
+        self.generic_visit(node)
+
     def visit_Return(self, node):  # noqa
         self.check_node_returns(len(node.values), node)
 

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -70,7 +70,10 @@ class EqualSignChecker(VisitorChecker):
 
 
 class NestedForLoopsChecker(VisitorChecker):
-    """ Checker for not supported nested FOR loops. """
+    """ Checker for not supported nested FOR loops.
+
+    Deprecated in RF 4.0
+    """
     rules = {
         "0907": (
             "nested-for-loop",

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -80,6 +80,7 @@ class NestedForLoopsChecker(VisitorChecker):
     }
 
     def visit_ForLoop(self, node):  # noqa
+        # For RF 4.0 node is "For" but we purposely don't visit it because nested for loop is allowed in 4.0
         for child in node.body:
             if child.type == 'FOR':
                 self.report("nested-for-loop", node=child)

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -183,20 +183,10 @@ class SettingsNamingChecker(VisitorChecker):
         self.section_name_pattern = re.compile(r'\*\*\*\s.+\s\*\*\*')
         super().__init__(*args)
 
-    def visit_SettingSectionHeader(self, node):  # noqa
-        self.check_section_name(node.data_tokens[0].value, node)
-
-    def visit_VariableSectionHeader(self, node):  # noqa
-        self.check_section_name(node.data_tokens[0].value, node)
-
-    def visit_TestCaseSectionHeader(self, node):  # noqa
-        self.check_section_name(node.data_tokens[0].value, node)
-
-    def visit_KeywordSectionHeader(self, node):  # noqa
-        self.check_section_name(node.data_tokens[0].value, node)
-
-    def visit_CommentSectionHeader(self, node):  # noqa
-        self.check_section_name(node.data_tokens[0].value, node)
+    def visit_SectionHeader(self, node):  # noqa
+        name = node.data_tokens[0].value
+        if not self.section_name_pattern.match(name) or not (name.istitle() or name.isupper()):
+            self.report("section-name-invalid", node=node)
 
     def visit_SuiteSetup(self, node):  # noqa
         self.check_setting_name(node.data_tokens[0].value, node)
@@ -237,7 +227,3 @@ class SettingsNamingChecker(VisitorChecker):
     def check_setting_name(self, name, node):
         if not (name.istitle() or name.isupper()):
             self.report("setting-name-not-capitalized", node=node)
-
-    def check_section_name(self, name, node):  # noqa
-        if not self.section_name_pattern.match(name) or not (name.istitle() or name.isupper()):
-            self.report("section-name-invalid", node=node)

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -2,10 +2,16 @@
 Spacing checkers
 """
 from collections import Counter
+
 from robot.api import Token
 from robot.parsing.model.visitor import ModelVisitor
-from robot.parsing.model.blocks import TestCase, Keyword, ForLoop
+from robot.parsing.model.blocks import TestCase, Keyword
+try:
+    from robot.parsing.model.blocks import ForLoop
+except ImportError:
+    from robot.parsing.model.blocks import For as ForLoop
 from robot.parsing.model.statements import EmptyLine, Comment
+
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import RuleSeverity
 
@@ -214,6 +220,10 @@ class UnevenIndentChecker(VisitorChecker):
         self.generic_visit(node)
 
     def visit_ForLoop(self, node):  # noqa
+        column_index = 2 if node.end is None else 0
+        self.check_indents(node, node.header.tokens[1].col_offset + 1, column_index)
+
+    def visit_For(self, node): # noqa
         column_index = 2 if node.end is None else 0
         self.check_indents(node, node.header.tokens[1].col_offset + 1, column_index)
 

--- a/robocop/utils/__init__.py
+++ b/robocop/utils/__init__.py
@@ -3,7 +3,14 @@ Parsing utils
 """
 from robocop.utils.disablers import DisablersFinder
 from robocop.utils.file_types import FileType, FileTypeChecker
-from robocop.utils.utils import modules_from_path, modules_from_paths, modules_in_current_dir, normalize_robot_name
+from robocop.utils.utils import (
+    modules_from_path,
+    modules_from_paths,
+    modules_in_current_dir,
+    normalize_robot_name,
+    IS_RF4,
+    DISABLED_IN_4
+)
 
 
 __all__ = [
@@ -13,5 +20,7 @@ __all__ = [
     'modules_from_path',
     'modules_in_current_dir',
     'modules_from_paths',
-    'normalize_robot_name'
+    'normalize_robot_name',
+    'IS_RF4',
+    'DISABLED_IN_4'
 ]

--- a/robocop/utils/utils.py
+++ b/robocop/utils/utils.py
@@ -1,7 +1,15 @@
 from pathlib import Path
 from importlib import import_module
 import importlib.util
+from packaging import version
+
 from robocop.exceptions import InvalidExternalCheckerError
+
+from robot.version import VERSION
+
+
+IS_RF4 = VERSION.startswith('4')
+DISABLED_IN_4 = frozenset(('nested-for-loop', 'invalid-comment'))
 
 
 def modules_in_current_dir(path, module_name):

--- a/robocop/utils/utils.py
+++ b/robocop/utils/utils.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from importlib import import_module
 import importlib.util
-from packaging import version
 
 from robocop.exceptions import InvalidExternalCheckerError
 

--- a/tests/atest/rules/section-out-of-order/expected_output.txt
+++ b/tests/atest/rules/section-out-of-order/expected_output.txt
@@ -1,2 +1,2 @@
-${rules_dir}${\}test.robot:18:0 [W] 0809 '*** Settings ***' section header is defined in wrong order: Setting(s) > Variable(s) > Test Case(s) / Task(s) > Keyword(s)
-${rules_dir}${\}test.robot:21:0 [W] 0809 '*** Variables ***' section header is defined in wrong order: Setting(s) > Variable(s) > Test Case(s) / Task(s) > Keyword(s)
+${rules_dir}${\}test.robot:19:0 [W] 0809 '*** Settings ***' section header is defined in wrong order: Setting(s) > Variable(s) > Test Case(s) / Task(s) > Keyword(s)
+${rules_dir}${\}test.robot:22:0 [W] 0809 '*** Variables ***' section header is defined in wrong order: Setting(s) > Variable(s) > Test Case(s) / Task(s) > Keyword(s)

--- a/tests/atest/rules/section-out-of-order/test.robot
+++ b/tests/atest/rules/section-out-of-order/test.robot
@@ -1,3 +1,4 @@
+*** Tasks ***
 *** Test Cases ***
 Test
     [Documentation]  doc

--- a/tests/atest/rules/section-out-of-order/test.robot
+++ b/tests/atest/rules/section-out-of-order/test.robot
@@ -7,7 +7,7 @@ Test
     Keyword
     One More
 
-
+*** Comments ***
 *** Keywords ***
 Keyword
     [Documentation]  this is doc

--- a/tests/atest/rules/too-long-keyword/expected_output.txt
+++ b/tests/atest/rules/too-long-keyword/expected_output.txt
@@ -1,1 +1,1 @@
-${rules_dir}${\}test.robot:62:0 [W] 0501 Keyword is too long (47/40)
+${rules_dir}${\}test.robot:61:0 [W] 0501 Keyword is too long (46/40)

--- a/tests/atest/rules/too-long-keyword/test.robot
+++ b/tests/atest/rules/too-long-keyword/test.robot
@@ -59,5 +59,3 @@ Keyword
     ...   ${var}
     ...   ${var}
 
-
- # Special case

--- a/tests/atest/test_rule.py
+++ b/tests/atest/test_rule.py
@@ -35,8 +35,6 @@ def test_rule(rule, robocop_instance, capsys):
         pytest -k test_rule[rule_name] tests/atest
 
     """
-    if IS_RF4 and rule in DISABLED_IN_4:
-        return
     current_dir = Path(__file__).parent
     test_data = Path(current_dir, 'rules', rule)
     expected_output = Path(test_data, 'expected_output.txt')
@@ -47,7 +45,10 @@ def test_rule(rule, robocop_instance, capsys):
     robocop_instance = configure_robocop_with_rule(robocop_instance, rule, test_data)
     with pytest.raises(SystemExit) as system_exit:
         robocop_instance.run()
-    assert system_exit.value.code > 0  # if any error issue found there should be > 0 exit code
-    out, _ = capsys.readouterr()
-    actual = out.splitlines()
-    assert sorted(actual) == sorted(expected)
+    if IS_RF4 and rule in DISABLED_IN_4:
+        assert system_exit.value.code == 0
+    else:
+        assert system_exit.value.code > 0  # if any error issue found there should be > 0 exit code
+        out, _ = capsys.readouterr()
+        actual = out.splitlines()
+        assert sorted(actual) == sorted(expected)

--- a/tests/atest/test_rule.py
+++ b/tests/atest/test_rule.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 import os
 from robocop.config import Config
+from robocop.utils import IS_RF4, DISABLED_IN_4
 
 
 def configure_robocop_with_rule(runner, rule, path):
@@ -29,6 +30,13 @@ def replace_paths(line, rules_dir):
 
 
 def test_rule(rule, robocop_instance, capsys):
+    """ To run one rule instead of all run::
+
+        pytest -k test_rule[rule_name] tests/atest
+
+    """
+    if IS_RF4 and rule in DISABLED_IN_4:
+        return
     current_dir = Path(__file__).parent
     test_data = Path(current_dir, 'rules', rule)
     expected_output = Path(test_data, 'expected_output.txt')
@@ -39,7 +47,7 @@ def test_rule(rule, robocop_instance, capsys):
     robocop_instance = configure_robocop_with_rule(robocop_instance, rule, test_data)
     with pytest.raises(SystemExit) as system_exit:
         robocop_instance.run()
-    assert system_exit.value.code > 0
+    assert system_exit.value.code > 0  # if any error issue found there should be > 0 exit code
     out, _ = capsys.readouterr()
     actual = out.splitlines()
     assert sorted(actual) == sorted(expected)


### PR DESCRIPTION
Relates #254 

Several changes to core and tests were needed to support RF 4.0. 

Deprecated:
  - nested-for-loop (allowed in RF 4.0)
  - invalid-comment (bug that caused comments starting from second cell be interpreted as Keyword Call was fixed)

Extended Github Actions to test on pre 4.0 and 4.0 RF version.
Replaced ast.NodeVisitor by ModelVisitor in VisitorChecker (allows to reduce amount of code needed ito visit all matching nodes in some cases)
Refactored section-our-of-order rule

