### PR TITLE
Add new rule for checking too many blank lines at EOF

### DIFF
--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -28,6 +28,11 @@ class InvalidSpacingChecker(RawFileChecker):
             "missing-trailing-blank-line",
             "Missing trailing blank line at the end of file",
             RuleSeverity.WARNING
+        ),
+        "1010": (
+            "too-many-trailing-blank-lines",
+            "Too many blank lines at the end of file",
+            RuleSeverity.WARNING
         )
     }
 
@@ -38,8 +43,12 @@ class InvalidSpacingChecker(RawFileChecker):
     def parse_file(self):
         self.lines = []
         super().parse_file()
-        if self.lines and not self.lines[-1].endswith('\n'):
-            self.report("missing-trailing-blank-line", lineno=len(self.lines), col=0)
+        if self.lines:
+            last_line = self.lines[-1]
+            if not last_line.endswith('\n'):
+                self.report("missing-trailing-blank-line", lineno=len(self.lines), col=0)
+            if last_line == '\n':
+                self.report("too-many-trailing-blank-lines", lineno=len(self.lines) + 1, col=0)
 
     def check_line(self, line, lineno):
         self.lines.append(line)

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -45,10 +45,20 @@ class InvalidSpacingChecker(RawFileChecker):
         super().parse_file()
         if self.lines:
             last_line = self.lines[-1]
-            if not last_line.endswith('\n'):
-                self.report("missing-trailing-blank-line", lineno=len(self.lines), col=0)
             if last_line == '\n':
                 self.report("too-many-trailing-blank-lines", lineno=len(self.lines) + 1, col=0)
+                return
+            empty_lines = 0
+            for line in self.lines[::-1]:
+                if not line.strip():
+                    empty_lines += 1
+                else:
+                    break
+                if empty_lines > 1:
+                    self.report("too-many-trailing-blank-lines", lineno=len(self.lines), col=0)
+                    return
+            if not empty_lines:
+                self.report("missing-trailing-blank-line", lineno=len(self.lines), col=0)
 
     def check_line(self, line, lineno):
         self.lines.append(line)

--- a/tests/atest/rules/too-many-trailing-blank-lines/expected_output.txt
+++ b/tests/atest/rules/too-many-trailing-blank-lines/expected_output.txt
@@ -1,1 +1,2 @@
 ${rules_dir}${\}test.robot:23:0 [W] 1010 Too many blank lines at the end of file
+${rules_dir}${\}test2.robot:22:0 [W] 1010 Too many blank lines at the end of file

--- a/tests/atest/rules/too-many-trailing-blank-lines/expected_output.txt
+++ b/tests/atest/rules/too-many-trailing-blank-lines/expected_output.txt
@@ -1,0 +1,1 @@
+${rules_dir}${\}test.robot:23:0 [W] 1010 Too many blank lines at the end of file

--- a/tests/atest/rules/too-many-trailing-blank-lines/test.robot
+++ b/tests/atest/rules/too-many-trailing-blank-lines/test.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+

--- a/tests/atest/rules/too-many-trailing-blank-lines/test2.robot
+++ b/tests/atest/rules/too-many-trailing-blank-lines/test2.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+    
+    

--- a/tests/atest/rules/trailing-whitespace/expected_output.txt
+++ b/tests/atest/rules/trailing-whitespace/expected_output.txt
@@ -1,1 +1,2 @@
 ${rules_dir}${\}test.robot:5:19 [W] 1001 Trailing whitespace at the end of line
+${rules_dir}${\}test.robot:16:34 [W] 1001 Trailing whitespace at the end of line

--- a/tests/atest/rules/trailing-whitespace/test.robot
+++ b/tests/atest/rules/trailing-whitespace/test.robot
@@ -13,7 +13,7 @@ Test
 
 *** Keywords ***
 Keyword
-    [Documentation]  this is doc
+    [Documentation]  this is doc  
     No Operation
     Pass
     No Operation


### PR DESCRIPTION
Closes #250 

- Added new rules for checking too many blank lines at the end of the file
- Added one more case to trailing whitespace atest