### PR TITLE
Display available reports

### DIFF
--- a/robocop/config.py
+++ b/robocop/config.py
@@ -69,42 +69,44 @@ class Config:
         self.filetypes = {'.robot', '.resource', '.tsv'}
         self.list = ''
         self.list_configurables = ''
+        self.list_reports = False
         self.output = None
         self.recursive = True
         self.parser = self._create_parser()
 
     HELP_MSGS = {
-        'help_paths':       'List of paths (files or directories) to be parsed by Robocop',
-        'help_include':     'Run Robocop only with specified rules. You can define rule by its name or id.\n'
-                            'Glob patterns are supported',
-        'help_exclude':     'Ignore specified rules. You can define rule by its name or id.\n'
-                            'Glob patterns are supported',
-        'help_ext_rules':   'List of paths with custom rules',
-        'help_reports':     'Generate reports after scan. You can enable reports by listing them in comma\n'
-                            'separated list:\n'
-                            '--reports rules_by_id,rules_by_error_type,scan_timer\n'
-                            'To enable all reports use all:\n'
-                            '--report all',
-        'help_format':      'Format of output message. '
-                            'You can use placeholders to change the way an issue is reported.\n'
-                            'Default: {source}:{line}:{col} [{severity}] {rule_id} {desc}',
-        'help_configure':   'Configure checker with parameter value. Usage:\n'
-                            '-c message_name_or_id:param_name:param_value\nExample:\n'
-                            '-c line-too-long:line_length:150\n'
-                            '--configure 0101:severity:E',
-        'help_list':        'List all available rules. You can use optional pattern argument',
-        'help_list_confs':  'List all available rules with configurable parameters. '
-                            'You can use optional pattern argument',
-        'help_output':      'Path to output file',
-        'help_filetypes':   'Comma separated list of file extensions to be scanned by Robocop',
-        'help_threshold':    f'Disable rules below given threshold. Available message levels: '
-                             f'{" < ".join(sev.value for sev in RuleSeverity)}',
-        'help_recursive':   'Use this flag to stop scanning directories recursively',
-        'help_argfile':     'Path to file with arguments',
-        'help_ignore':      'Ignore file(s) and path(s) provided. Glob patterns are supported',
-        'help_info':        'Print this help message and exit',
-        'help_version':     'Display Robocop version',
-        'directives':       '1. Serve the public trust\n2. Protect the innocent\n3. Uphold the law\n4. [ACCESS DENIED]'
+        'help_paths':        'List of paths (files or directories) to be parsed by Robocop',
+        'help_include':      'Run Robocop only with specified rules. You can define rule by its name or id.\n'
+                             'Glob patterns are supported',
+        'help_exclude':      'Ignore specified rules. You can define rule by its name or id.\n'
+                             'Glob patterns are supported',
+        'help_ext_rules':    'List of paths with custom rules',
+        'help_reports':      'Generate reports after scan. You can enable reports by listing them in comma\n'
+                             'separated list:\n'
+                             '--reports rules_by_id,rules_by_error_type,scan_timer\n'
+                             'To enable all reports use all:\n'
+                             '--report all',
+        'help_format':       'Format of output message. '
+                             'You can use placeholders to change the way an issue is reported.\n'
+                             'Default: {source}:{line}:{col} [{severity}] {rule_id} {desc}',
+        'help_configure':    'Configure checker with parameter value. Usage:\n'
+                             '-c message_name_or_id:param_name:param_value\nExample:\n'
+                             '-c line-too-long:line_length:150\n'
+                             '--configure 0101:severity:E',
+        'help_list':         'List all available rules. You can use optional pattern argument',
+        'help_list_confs':   'List all available rules with configurable parameters. '
+                             'You can use optional pattern argument',
+        'help_list_reports': 'List all available reports',
+        'help_output':       'Path to output file',
+        'help_filetypes':    'Comma separated list of file extensions to be scanned by Robocop',
+        'help_threshold':     f'Disable rules below given threshold. Available message levels: '
+                              f'{" < ".join(sev.value for sev in RuleSeverity)}',
+        'help_recursive':    'Use this flag to stop scanning directories recursively',
+        'help_argfile':      'Path to file with arguments',
+        'help_ignore':       'Ignore file(s) and path(s) provided. Glob patterns are supported',
+        'help_info':         'Print this help message and exit',
+        'help_version':      'Display Robocop version',
+        'directives':        '1. Serve the public trust\n2. Protect the innocent\n3. Uphold the law\n4. [ACCESS DENIED]'
     }
 
     def _translate_patterns(self, pattern_list):
@@ -178,8 +180,11 @@ class Config:
                               metavar='CONFIGURABLE', help=self.HELP_MSGS['help_configure'])
         optional.add_argument('-l', '--list', action=SetListOption, nargs='?', const='', default=self.list,
                               metavar='PATTERN', help=self.HELP_MSGS['help_list'])
-        optional.add_argument('--list-configurables', action=SetListOption, nargs='?', const='', default=self.list_configurables,
-                              metavar='PATTERN', help=self.HELP_MSGS['help_list_confs'])
+        optional.add_argument('--list-configurables', action=SetListOption, nargs='?', const='',
+                              default=self.list_configurables, metavar='PATTERN',
+                              help=self.HELP_MSGS['help_list_confs'])
+        optional.add_argument('--list-reports', action='store_true', default=self.list_reports,
+                              help=self.HELP_MSGS['help_list_reports'])
         optional.add_argument('-o', '--output', type=argparse.FileType('w'), default=self.output,
                               metavar='PATH', help=self.HELP_MSGS['help_output'])
         optional.add_argument('--filetypes', action=ParseFileTypes, default=self.filetypes,

--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -39,6 +39,7 @@ class RulesByIdReport(Report):
     """
     def __init__(self):
         self.name = 'rules_by_id'
+        self.description = 'Groups detected issues by rule id and prints it ordered by most common'
         self.message_counter = defaultdict(int)
 
     def add_message(self, message, **kwargs):  # noqa
@@ -61,7 +62,7 @@ class RulesBySeverityReport(Report):
     """
     Report name: ``rules_by_error_type``
 
-    Report that group linter rules messages by severity and print total of issues per every severity level.
+    Report that groups linter rules messages by severity and prints total of issues per every severity level.
 
     Example::
 
@@ -69,6 +70,7 @@ class RulesBySeverityReport(Report):
     """
     def __init__(self):
         self.name = 'rules_by_error_type'
+        self.description = 'Prints total number of issues grouped by severity'
         self.severity_counter = defaultdict(int)
 
     def add_message(self, message, **kwargs):  # pylint: disable=unused-argument
@@ -93,6 +95,7 @@ class ReturnStatusReport(Report):
     """
     def __init__(self):
         self.name = 'return_status'
+        self.description = 'Checks if number of specific issues exceed quality gate limits'
         self.return_status = 0
         self.counter = RulesBySeverityReport()
         self.quality_gate = {
@@ -132,6 +135,7 @@ class TimeTakenReport(Report):
     """
     def __init__(self):
         self.name = 'scan_timer'
+        self.description = 'Returns Robocop execution time'
         self.start_time = timer()
 
     def add_message(self, *args, **kwargs):

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -141,6 +141,7 @@ class Robocop:
 
     def load_reports(self):
         classes = inspect.getmembers(reports, inspect.isclass)
+        available_reports = 'Available reports:\n'
         for report_class in classes:
             if not issubclass(report_class[1], reports.Report):
                 continue
@@ -149,6 +150,11 @@ class Robocop:
                 continue
             if 'all' in self.config.reports or report.name in self.config.reports:
                 self.reports.append(report)
+            available_reports += f'{report.name} - {report.description}\n'
+        if self.config.list_reports:
+            available_reports += 'all - Turns on all available reports'
+            print(available_reports)
+            sys.exit()
 
     def register_checker(self, checker):
         if not self.any_rule_enabled(checker):

--- a/tests/utest/test_argument_validation.py
+++ b/tests/utest/test_argument_validation.py
@@ -26,6 +26,7 @@ class TestArgumentValidation(unittest.TestCase):
         self.assertEqual(self.config.format, "{source}:{line}:{col} [{severity}] {rule_id} {desc}")
         self.assertListEqual(self.config.paths, [])
         self.assertIsNone(self.config.output)
+        self.assertFalse(self.config.list_reports)
 
     def test_default_args_after_parse(self):
         args = self.config.parse_opts([''])
@@ -171,3 +172,7 @@ class TestArgumentValidation(unittest.TestCase):
     def test_paths_two_values(self):
         args = self.config.parse_opts(['tests.robot', 'test2.robot'])
         self.assertListEqual(args.paths, ['tests.robot', 'test2.robot'])
+
+    def test_list_reports(self):
+        args = self.config.parse_opts(['--list-reports'])
+        self.assertTrue(args.list_reports)

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -65,6 +65,15 @@ class TestListingRules:
         out, _ = capsys.readouterr()
         assert out == 'Rule - 0101 [W]: some-message: Some description (disabled)\n'
 
+    def test_list_reports(self, robocop_pre_load, msg_0101, capsys):
+        robocop_pre_load.config.list_reports = True
+        init_empty_checker(robocop_pre_load, msg_0101)
+        with pytest.raises(SystemExit):
+            robocop_pre_load.load_reports()
+        out, _ = capsys.readouterr()
+        first_line = out.split('\n')[0]
+        assert first_line == 'Available reports:'
+
     def test_multiple_checkers(self, robocop_pre_load, msg_0101, msg_0102_0204, capsys):
         robocop_pre_load.config.list = robocop.config.translate_pattern('*')
         init_empty_checker(robocop_pre_load, msg_0102_0204, exclude=True)


### PR DESCRIPTION
It displays the message that looks like this:
```
$ robocop --list-reports
Available reports:
return_status - Checks if number of specific issues exceed quality gate limits
rules_by_id - Groups detected issues by rule id and prints it ordered by most common
rules_by_error_type - Prints total number of issues grouped by severity
scan_timer - Returns Robocop execution time
all - Turns on all available reports
```