### PR TITLE
Detect redundant equal sign in variable section

### DIFF
--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -72,10 +72,12 @@ class EqualSignChecker(VisitorChecker):
 
     def visit_VariableSection(self, node):  # noqa
         for child in node.body:
-            for token in child.data_tokens:
-                if token.type == Token.VARIABLE and token.value[-1] == '=':
-                    self.report("redundant-equal-sign", lineno=token.lineno,
-                                col=token.end_col_offset + token.col_offset)
+            if not child.data_tokens:
+                continue
+            token = child.data_tokens[0]
+            if token.type == Token.VARIABLE and token.value[-1] == '=':
+                self.report("redundant-equal-sign", lineno=token.lineno,
+                            col=token.end_col_offset + token.col_offset)
 
 
 class NestedForLoopsChecker(VisitorChecker):

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -55,11 +55,11 @@ class ReturnChecker(VisitorChecker):
 
 
 class EqualSignChecker(VisitorChecker):
-    """ Checker for redundant equal signs when assigning return values. """
+    """ Checker for redundant equal signs when assigning values to variables. """
     rules = {
         "0906": (
             "redundant-equal-sign",
-            "Redundant equal sign in return value assignment",
+            "Redundant equal sign in variable assignment",
             RuleSeverity.WARNING
         )
     }
@@ -69,6 +69,13 @@ class EqualSignChecker(VisitorChecker):
             if node.assign[-1][-1] == '=':  # last character of last assigned variable
                 equal_position = [x for x in node.data_tokens if x.type == 'ASSIGN'][-1].end_col_offset
                 self.report("redundant-equal-sign", lineno=node.lineno, col=equal_position)
+
+    def visit_VariableSection(self, node):  # noqa
+        for child in node.body:
+            for token in child.data_tokens:
+                if token.type == Token.VARIABLE and token.value[-1] == '=':
+                    self.report("redundant-equal-sign", lineno=token.lineno,
+                                col=token.end_col_offset + token.col_offset)
 
 
 class NestedForLoopsChecker(VisitorChecker):

--- a/tests/atest/rules/redundant-equal-sign/expected_output.txt
+++ b/tests/atest/rules/redundant-equal-sign/expected_output.txt
@@ -1,2 +1,4 @@
-${rules_dir}${\}test.robot:10:11 [W] 0906 Redundant equal sign in return value assignment
-${rules_dir}${\}test.robot:19:13 [W] 0906 Redundant equal sign in return value assignment
+${rules_dir}${\}test.robot:6:18 [W] 0906 Redundant equal sign in variable assignment
+${rules_dir}${\}test.robot:7:21 [W] 0906 Redundant equal sign in variable assignment
+${rules_dir}${\}test.robot:16:11 [W] 0906 Redundant equal sign in variable assignment
+${rules_dir}${\}test.robot:25:13 [W] 0906 Redundant equal sign in variable assignment

--- a/tests/atest/rules/redundant-equal-sign/test.robot
+++ b/tests/atest/rules/redundant-equal-sign/test.robot
@@ -2,6 +2,12 @@
 Documentation  doc
 
 
+*** Variables ***
+${SUITE_VARIABLE}=  Value
+${ANOTHER_VARIABLE} =  Value
+${VAR_WITHOUT_EQUAL_SIGN}  Value
+
+
 *** Test Cases ***
 Test
     [Documentation]  doc


### PR DESCRIPTION
I changed the description of the rule so it fits now 2 scenarios (equal sign for return value assignment and for variables section). If you think that it should be done with 2 separate rules, let me know, but I think it's the same issue.