### PR TITLE
Detect all not capitalized test case and keyword settings

### DIFF
--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -224,6 +224,21 @@ class SettingsNamingChecker(VisitorChecker):
     def visit_Documentation(self, node):  # noqa
         self.check_setting_name(node.data_tokens[0].value, node)
 
+    def visit_Tags(self, node):  # noqa
+        self.check_setting_name(node.data_tokens[0].value, node)
+
+    def visit_Timeout(self, node):  # noqa
+        self.check_setting_name(node.data_tokens[0].value, node)
+
+    def visit_Template(self, node):  # noqa
+        self.check_setting_name(node.data_tokens[0].value, node)
+
+    def visit_Arguments(self, node):  # noqa
+        self.check_setting_name(node.data_tokens[0].value, node)
+
+    def visit_Return(self, node):  # noqa
+        self.check_setting_name(node.data_tokens[0].value, node)
+
     def check_setting_name(self, name, node):
         if not (name.istitle() or name.isupper()):
             self.report("setting-name-not-capitalized", node=node)

--- a/tests/atest/rules/setting-name-not-capitalized/expected_output.txt
+++ b/tests/atest/rules/setting-name-not-capitalized/expected_output.txt
@@ -7,5 +7,15 @@ ${rules_dir}${\}test.robot:8:0 [W] 0306 Setting name should be capitalized or up
 ${rules_dir}${\}test.robot:9:0 [W] 0306 Setting name should be capitalized or upper case
 ${rules_dir}${\}test.robot:10:0 [W] 0306 Setting name should be capitalized or upper case
 ${rules_dir}${\}test.robot:11:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:16:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:17:0 [W] 0306 Setting name should be capitalized or upper case
 ${rules_dir}${\}test.robot:18:0 [W] 0306 Setting name should be capitalized or upper case
-${rules_dir}${\}test.robot:22:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:19:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:20:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:24:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:51:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:52:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:53:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:54:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:59:0 [W] 0306 Setting name should be capitalized or upper case
+${rules_dir}${\}test.robot:60:0 [W] 0306 Setting name should be capitalized or upper case

--- a/tests/atest/rules/setting-name-not-capitalized/test.robot
+++ b/tests/atest/rules/setting-name-not-capitalized/test.robot
@@ -12,20 +12,73 @@ default tags    defaulttag
 
 
 *** Test Cases ***
-Test
-    [Documentation]  doc
-    [Tags]  sometag
+Test Lowercase Settings
+    [documentation]  doc
+    [tags]  sometag
     [setup]  Keyword
+    [template]  template
+    [timeout]  timeout
     Pass
     Keyword
     One More
     [teardown]  Keyword
 
+Test Titlecase Settings
+    [Documentation]  doc
+    [Tags]  sometag
+    [Setup]  Keyword
+    [Template]  template
+    [Timeout]  timeout
+    Pass
+    Keyword
+    One More
+    [Teardown]  Keyword
+
+Test Uppercase Settings
+    [DOCUMENTATION]  doc
+    [TAGS]  sometag
+    [SETUP]  Keyword
+    [TEMPLATE]  template
+    [TIMEOUT]  timeout
+    Pass
+    Keyword
+    One More
+    [TEARDOWN]  Keyword
+
 
 *** Keywords ***
-Keyword
-    [Documentation]  this is doc
+Keyword Lowercase Settings
+    [documentation]  this is doc
+    [tags]  sometag
+    [arguments]  arg1  arg2
+    [timeout]  timeout
     No Operation
     Pass
     No Operation
     Fail
+    [teardown]  Teardown
+    [return]  value
+
+Keyword Titlecase Settings
+    [Documentation]  this is doc
+    [Tags]  sometag
+    [Arguments]  arg1  arg2
+    [Timeout]  timeout
+    No Operation
+    Pass
+    No Operation
+    Fail
+    [Teardown]  Teardown
+    [Return]  value
+
+Keyword Uppercase Settings
+    [DOCUMENTATION]  this is doc
+    [TAGS]  sometag
+    [ARGUMENTS]  arg1  arg2
+    [TIMEOUT]  timeout
+    No Operation
+    Pass
+    No Operation
+    Fail
+    [TEARDOWN]  Teardown
+    [RETURN]  value


### PR DESCRIPTION
Some of the keyword and test case settings were not supported for detecting "setting-name-not-capitalized" rule.