### PR TITLE
LSP integration

### DIFF
--- a/robocop/config.py
+++ b/robocop/config.py
@@ -54,8 +54,9 @@ class SetListOption(argparse.Action):
 
 
 class Config:
-    def __init__(self):
+    def __init__(self, root=None):
         self.exec_dir = os.path.abspath('.')
+        self.root = root
         self.include = set()
         self.exclude = set()
         self.ignore = set()
@@ -219,12 +220,11 @@ class Config:
         config_path = project_root / '.robocop'
         if not config_path.is_file():
             return None
-        print(f"Loaded default configuration file from '{config_path}'")
+        # print(f"Loaded default configuration file from '{config_path}'") TODO: Enable in verbose mode
         return self.load_args_from_file(config_path)
 
-    @staticmethod
-    def find_project_root():
-        root = Path.cwd()
+    def find_project_root(self):
+        root = self.root or Path.cwd()
         for parent in (root, *root.parents):
             if (parent / '.git').exists():
                 return parent

--- a/robocop/utils/__init__.py
+++ b/robocop/utils/__init__.py
@@ -11,7 +11,8 @@ from robocop.utils.utils import (
     IS_RF4,
     DISABLED_IN_4,
     ENABLED_IN_4,
-    keyword_col
+    keyword_col,
+    issues_to_lsp_diagnostic
 )
 
 
@@ -26,5 +27,6 @@ __all__ = [
     'IS_RF4',
     'DISABLED_IN_4',
     'ENABLED_IN_4',
-    'keyword_col'
+    'keyword_col',
+    'issues_to_lsp_diagnostic'
 ]

--- a/robocop/utils/disablers.py
+++ b/robocop/utils/disablers.py
@@ -21,13 +21,16 @@ class DisablersInFile:  # pylint: disable=too-few-public-methods
 
 class DisablersFinder:
     """ Parse all scanned file and find and disablers (in line or blocks) """
-    def __init__(self, source, linter):
+    def __init__(self, linter, filename, source):
         self.linter = linter
         self.file_disabled = False
         self.any_disabler = False
         self.disabler_pattern = re.compile(r'robocop: (?P<disabler>disable|enable)=?(?P<rules>[\w\-,]*)')
         self.rules = defaultdict(DisablersInFile().copy)
-        self._parse_file(source)
+        if filename is not None:
+            self._parse_file(filename)
+        else:
+            self._parse_source(source)
 
     def is_rule_disabled(self, rule_msg):
         """
@@ -46,9 +49,9 @@ class DisablersFinder:
             return True
         return any(block[0] <= line <= block[1] for block in self.rules[rule].blocks)
 
-    def _parse_file(self, source):
+    def _parse_file(self, filename):
         try:
-            with open(source, 'r') as file:
+            with open(filename, 'r') as file:
                 lineno = -1
                 for lineno, line in enumerate(file, start=1):
                     if '#' in line:
@@ -59,10 +62,22 @@ class DisablersFinder:
                 self.file_disabled = self._is_file_disabled(lineno)
                 self.any_disabler = len(self.rules) != 0
         except OSError:
-            raise robocop.exceptions.FileError(source)
+            raise robocop.exceptions.FileError(filename)
         except UnicodeDecodeError:
             print(f"Failed to decode {file}. Default supported encoding by Robot Framework is UTF-8. Skipping file")
             self.file_disabled = True
+
+    def _parse_source(self, source):
+        lineno = -1
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            if '#' in line:
+                if '#' in line:
+                    self._parse_line(line, lineno)
+        if lineno == -1:
+            return
+        self._end_block('all', lineno)
+        self.file_disabled = self._is_file_disabled(lineno)
+        self.any_disabler = len(self.rules) != 0
 
     def _parse_line(self, line, lineno):
         statement, comment = line.split('#', maxsplit=1)

--- a/robocop/utils/utils.py
+++ b/robocop/utils/utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from importlib import import_module
 import importlib.util
 
+from robocop.rules import RuleSeverity
 from robocop.exceptions import InvalidExternalCheckerError
 
 from robot.api import Token
@@ -54,3 +55,30 @@ def keyword_col(node):
     if keyword_token is None:
         return 0
     return keyword_token.col_offset
+
+
+def rule_severity_to_diag_sev(severity):
+    return {
+        RuleSeverity.ERROR: 1,
+        RuleSeverity.WARNING: 2,
+        RuleSeverity.INFO: 3
+    }.get(severity, 4)
+
+
+def issues_to_lsp_diagnostic(issues):
+    return [{
+        'range': {
+            'start': {
+                'line': issue.line,
+                'character': issue.col
+                },
+            'end': {
+                'line': issue.line,
+                'character': issue.col
+            }
+        },
+        'severity': rule_severity_to_diag_sev(issue.severity),
+        'code': issue.rule_id,
+        'source': 'robocop',
+        'message': issue.desc
+    } for issue in issues]


### PR DESCRIPTION
It should be now possible to:
```
# create config class which will autoloads .robocop config file
from robocop.config import Config

config = Config(root='C:\repository\robot_stuff')
```
Run scan on ast model:
```
import robocop

(...)
robocop_runner = robocop.Robocop(config=config)
issues = robocop_runner.run_check(ast_model, filename, source)
```

List of issues can be converted to LSP friendly diagnostic:
```
from robocop.utils import issues_to_lsp_diagnostic

issues = issues_to_lsp_diagnostic(issues)
```
(Note that it's not full support for Diagnostic yet because we don't preserve the full range, only starting line and col. In the future we need to update our rules reporting with that information). 