### PR TITLE
Fix unicode keyword names throwing not capitalized warning

### DIFF
--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -113,7 +113,7 @@ class KeywordNamingChecker(VisitorChecker):
     }
 
     def __init__(self):
-        self.letter_pattern = re.compile('[^a-zA-Z0-9]')
+        self.letter_pattern = re.compile(r'\W|_', re.UNICODE)
         self.var_pattern = re.compile(r'[$@%&]{.+}')
         super().__init__()
 

--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -79,7 +79,7 @@ class RulesBySeverityReport(Report):
     def get_report(self):
         issues_count = sum(self.severity_counter.values())
         if not issues_count:
-            return 'Found 0 issues'
+            return '\nFound 0 issues'
         report = f'\nFound {issues_count} issue(s): '
         report += ', '.join(f"{count} {severity.name}(s)" for severity, count in self.severity_counter.items())
         report += '.'
@@ -180,10 +180,10 @@ class FileStatsReport(Report):
 
     def get_report(self):
         if not self.files_count:
-            return 'No files were processed'
+            return '\nNo files were processed'
         else:
             if not self.files_with_issues:
-                return f'Processed {self.files_count} file(s) but no issues were found'
+                return f'\nProcessed {self.files_count} file(s) but no issues were found'
 
-            return f'Processed {self.files_count} file(s) from which {len(self.files_with_issues)} ' \
+            return f'\nProcessed {self.files_count} file(s) from which {len(self.files_with_issues)} ' \
                    f'file(s) contained issues'

--- a/tests/atest/rules/naming/not-capitalized-keyword-name/expected_output.txt
+++ b/tests/atest/rules/naming/not-capitalized-keyword-name/expected_output.txt
@@ -6,3 +6,4 @@ ${rules_dir}${\}test.robot:14:0 [W] 0302 Keyword name should be capitalized
 ${rules_dir}${\}test.robot:15:0 [W] 0302 Keyword name should be capitalized
 ${rules_dir}${\}test.robot:18:0 [W] 0302 Keyword name should be capitalized
 ${rules_dir}${\}test.robot:22:0 [W] 0302 Keyword name should be capitalized
+${rules_dir}${\}test.robot:47:0 [W] 0302 Keyword name should be capitalized

--- a/tests/atest/rules/naming/not-capitalized-keyword-name/test.robot
+++ b/tests/atest/rules/naming/not-capitalized-keyword-name/test.robot
@@ -44,6 +44,7 @@ Keyword-With_Special $ Chars 10
     Edit Group's Report Logo
     Take2 Is Capitalized
     Quoted "Strings" Are Fine Too
+    Keyword_With_underscores
 
 Keyword With Library Import
     SeleniumLibrary.Input Text    ${txt_welcome}    Hello
@@ -52,3 +53,8 @@ Keyword With Library Import
 Keyword With API Abbreviation Should Pass
     Keyword With Number Ins1de 0r In Fr0nt
     I Will Love U 4 Ever
+
+Keyword With Unicode And Non Latin
+    Eäi Saa Peittää
+    日本語
+    _

--- a/tests/utest/test_reports.py
+++ b/tests/utest/test_reports.py
@@ -30,9 +30,9 @@ class TestReports:
         }
 
     @pytest.mark.parametrize('files, files_with_issues, output', [
-        (0, set(), 'No files were processed'),
-        (10, set(), 'Processed 10 file(s) but no issues were found'),
-        (10, {'a.robot', 'b.robot'}, 'Processed 10 file(s) from which 3 file(s) contained issues')
+        (0, set(), '\nNo files were processed'),
+        (10, set(), '\nProcessed 10 file(s) but no issues were found'),
+        (10, {'a.robot', 'b.robot'}, '\nProcessed 10 file(s) from which 3 file(s) contained issues')
     ])
     def test_file_stats_report(self, files, files_with_issues, output, message):
         report = FileStatsReport()


### PR DESCRIPTION
Fix #314 
Miscellaneous fixes for report printing (added missing new line)