### PR TITLE
Fix running only single atest test

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -189,6 +189,10 @@ second is path separator - \ under Windows and / under Linux.
 If you wish to use additional configuration or use different that default test data directory follow
 instructions from ``pytest_generate_tests`` method.
 
+In case you want to run only single test (not all dynamically generated ones) you can run::
+
+    pytest --rule rule-name tests\atest
+
 E2E tests
 '''''''''
 

--- a/tests/atest/conftest.py
+++ b/tests/atest/conftest.py
@@ -36,8 +36,7 @@ def pytest_generate_tests(metafunc):
             if rule == selected_rule:
                 break
         else:
-            print(f"Rule: '{selected_rule}' was not found")
-            return
+            pytest.exit(f"Rule: '{selected_rule}' was not found", 1)
         metafunc.parametrize('rule, args, test_data', [(selected_rule, args, test_data)])
         return
     # TODO: load other tests from file (like yaml)

--- a/tests/atest/conftest.py
+++ b/tests/atest/conftest.py
@@ -7,7 +7,11 @@ from robocop.run import Robocop
 
 @pytest.fixture
 def robocop_instance():
-    return Robocop(from_cli=True)
+    return Robocop(from_cli=False)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--rule", action="store")
 
 
 def pytest_generate_tests(metafunc):
@@ -25,6 +29,17 @@ def pytest_generate_tests(metafunc):
     if "rule" not in metafunc.fixturenames:
         return
     auto_discovered_rules = [(rule, None, f"{category}/{rule}") for category, rule in get_rules_for_atest()]
+    selected_rule = metafunc.config.getoption('--rule', None)
+    if selected_rule is not None:
+        # Find and use only selected rule
+        for rule, args, test_data in auto_discovered_rules:
+            if rule == selected_rule:
+                break
+        else:
+            print(f"Rule: '{selected_rule}' was not found")
+            return
+        metafunc.parametrize('rule, args, test_data', [(selected_rule, args, test_data)])
+        return
     # TODO: load other tests from file (like yaml)
     auto_discovered_rules.append((
         'inconsistent-assignment',

--- a/tests/atest/test_rule.py
+++ b/tests/atest/test_rule.py
@@ -6,6 +6,7 @@ from robocop.utils import IS_RF4, DISABLED_IN_4, ENABLED_IN_4
 
 
 def configure_robocop_with_rule(args, runner, rule, path):
+    runner.from_cli = True
     config = Config()
     config.parse_opts([
         '--include',


### PR DESCRIPTION
Fix #320 

Add CLI option for running single rule test using pytest:
```
pytest --rule rule_name tests\atest
```