### PR TITLE
Enforce utf-8 encoding

### DIFF
--- a/robocop/checkers/__init__.py
+++ b/robocop/checkers/__init__.py
@@ -113,7 +113,7 @@ class RawFileChecker(BaseChecker):  # noqa
         if self.lines is not None:
             self._parse_lines(self.lines)
         else:
-            with open(self.source) as file:
+            with open(self.source, encoding='utf-8') as file:
                 self._parse_lines(file)
 
     def _parse_lines(self, lines):

--- a/tests/atest/rules/lengths/line-too-long/expected_output.txt
+++ b/tests/atest/rules/lengths/line-too-long/expected_output.txt
@@ -1,3 +1,3 @@
-${rules_dir}${\}test.robot:12:0 [W] 0508 Line is too long (139/120)
-${rules_dir}${\}test.robot:22:0 [W] 0508 Line is too long (159/120)
-${rules_dir}${\}test.robot:25:0 [W] 0508 Line is too long (139/120)
+${rules_dir}${\}test.robot:16:0 [W] 0508 Line is too long (139/120)
+${rules_dir}${\}test.robot:26:0 [W] 0508 Line is too long (159/120)
+${rules_dir}${\}test.robot:29:0 [W] 0508 Line is too long (139/120)

--- a/tests/atest/rules/lengths/line-too-long/test.robot
+++ b/tests/atest/rules/lengths/line-too-long/test.robot
@@ -3,6 +3,10 @@ Documentation  doc
 Library    Collections                                                                                                                                     
 
 
+*** Variables ***
+${MY_VARIABLE}    Liian pitkä rivi, jossa on ääkkösiä. Pituuden tarkistuksen pitäisi laskea merkkejä, eikä tavuja.
+
+
 *** Test Cases ***
 Test
     [Documentation]  doc
@@ -24,3 +28,7 @@ Keyword
     Pass
     Keyword With Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Name And  ${args}
     Fail
+
+Keyword With Unicode
+    This Is ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź ąęłżź
+    日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語 日本語

--- a/tests/utest/test_api.py
+++ b/tests/utest/test_api.py
@@ -169,3 +169,16 @@ class TestAPI:
         issues = robocop_runner.run_check(ast, 'target.robot', source)
         diag_issues = issues_to_lsp_diagnostic(issues)
         assert all(d["message"] != "Missing trailing blank line at the end of file" for d in diag_issues)
+
+    def test_unicode_strings(self):
+        source = '*** Variables ***\n${MY_VARIABLE}    Liian pitkä rivi, jossa on ääkkösiä. ' \
+                 'Pituuden tarkistuksen pitäisi laskea merkkejä, eikä tavuja.\n'
+        ast = get_model(source)
+
+        config = robocop.Config()
+        robocop_runner = robocop.Robocop(config=config)
+        robocop_runner.reload_config()
+
+        issues = robocop_runner.run_check(ast, 'target.robot', source)
+        diag_issues = issues_to_lsp_diagnostic(issues)
+        assert all(d["message"] != "Line is too long" for d in diag_issues)


### PR DESCRIPTION
When reading the files for RawChecker the open() method guess your encoding based on your platform setting. This could lead to problems with special characters - we'll enforce utf-8 encoding from now on. 

Fixes #356 