### PR TITLE
Resolve #382: Invalid number of empty lines in other section order

### DIFF
--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -207,7 +207,7 @@ class EmptyLinesChecker(VisitorChecker):
                 continue
             empty_lines = 0
             for child in reversed(section.body):
-                if isinstance(child, TestCase):
+                if isinstance(child, (Keyword, TestCase)):
                     for statement in reversed(child.body):
                         if isinstance(statement, EmptyLine):
                             empty_lines += 1

--- a/tests/atest/rules/spacing/empty-lines-between-sections/golden.robot
+++ b/tests/atest/rules/spacing/empty-lines-between-sections/golden.robot
@@ -1,0 +1,16 @@
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More


### PR DESCRIPTION
Keywords and test cases have the same structure. I added keywords when checking for blank lines between sections. It solved the problem for me. Please check my contributing.  

this should fix #382 