### PR TITLE
Add support for comment between sections, improve test coverage

### DIFF
--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -6,7 +6,7 @@ from collections import Counter
 from robot.api import Token
 from robot.parsing.model.visitor import ModelVisitor
 from robot.parsing.model.blocks import TestCase, Keyword
-from robot.parsing.model.statements import EmptyLine
+from robot.parsing.model.statements import EmptyLine, Comment
 
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import RuleSeverity
@@ -216,6 +216,8 @@ class EmptyLinesChecker(VisitorChecker):
                             break
                 if isinstance(child, EmptyLine):
                     empty_lines += 1
+                elif isinstance(child, Comment):
+                    continue
                 else:
                     break
             if empty_lines != self.empty_lines_between_sections:

--- a/tests/atest/rules/spacing/empty-lines-between-sections/expected_output.txt
+++ b/tests/atest/rules/spacing/empty-lines-between-sections/expected_output.txt
@@ -1,2 +1,4 @@
-${rules_dir}${\}test.robot:6:0 [W] 1003 Invalid number of empty lines between sections (4/2)
-${rules_dir}${\}test.robot:14:0 [W] 1003 Invalid number of empty lines between sections (1/2)
+${rules_dir}${\}test.robot:5:0 [W] 1003 Invalid number of empty lines between sections (3/2)
+${rules_dir}${\}test.robot:9:0 [W] 1003 Invalid number of empty lines between sections (1/2)
+${rules_dir}${\}test.robot:17:0 [W] 1003 Invalid number of empty lines between sections (1/2)
+${rules_dir}${\}test.robot:24:0 [W] 1003 Invalid number of empty lines between sections (0/2)

--- a/tests/atest/rules/spacing/empty-lines-between-sections/golden.robot
+++ b/tests/atest/rules/spacing/empty-lines-between-sections/golden.robot
@@ -1,3 +1,8 @@
+*** Variables ***
+${MY_VAR}    1
+
+
+# some comment
 *** Keywords ***
 Keyword
     [Documentation]  this is doc
@@ -14,3 +19,7 @@ Test
     Pass
     Keyword
     One More
+
+
+
+# some comment

--- a/tests/atest/rules/spacing/empty-lines-between-sections/test.robot
+++ b/tests/atest/rules/spacing/empty-lines-between-sections/test.robot
@@ -3,7 +3,10 @@ Documentation  doc
 
 
 
+*** Variables ***
+${MY_VAR}    1
 
+# some comment
 *** Test Cases ***
 Test
     [Documentation]  doc
@@ -19,3 +22,5 @@ Keyword
     Pass
     No Operation
     Fail
+*** Comments ***
+Blah Blah Blah


### PR DESCRIPTION
I found out that in this case:
```
*** Variables ***
${MY_VAR}    1

# some comment
*** Test Cases ***
```
the rule `empty-lines-between-sections` was reporting where the comment is. I fixed it now so that it is not counted as an empty line but it also doesn't break the rule.