### PR TITLE
Move custom tests to yaml and skip embedded variables in 0302 rule

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,9 +44,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install robotframework==${{ matrix.rf-version }}
-        pip install toml
-        pip install pytest
-        pip install coverage
+        pip install toml pytest coverage pyyaml
     - name: Run unit tests with coverage
       run:
         coverage run -m pytest

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -20,7 +20,7 @@ class InvalidCharactersInNameChecker(VisitorChecker):
     rules = {
         "0301": (
             "invalid-char-in-name",
-            "Invalid character %s in %s name",
+            "Invalid character '%s' in %s name",
             RuleSeverity.WARNING,
             (
                 'invalid_chars',
@@ -30,6 +30,7 @@ class InvalidCharactersInNameChecker(VisitorChecker):
             )
         )
     }
+    var_pattern = re.compile(r'[$@%&]{[^}]+}')
 
     def __init__(self):
         self.invalid_chars = {'.', '?'}
@@ -49,12 +50,28 @@ class InvalidCharactersInNameChecker(VisitorChecker):
             self.check_if_char_in_name(node, suite_name, 'SUITE')
         super().visit_File(node)
 
-    def check_if_char_in_node_name(self, node, name_of_node):
-        for index, char in enumerate(node.name):
-            if char in self.invalid_chars:
-                self.report("invalid-char-in-name", char, self.node_names_map[name_of_node],
+    def check_if_char_in_node_name(self, node, name_of_node, is_keyword=False):
+        if is_keyword:
+            matches = [(m.span()) for m in self.var_pattern.finditer(node.name)]
+        else:
+            matches = []
+        index = 0
+        while index <= len(node.name):
+            index += self._skip_captured_group(index, matches)  # allows to skip ${vars} without breaking indexes
+            if index >= len(node.name):
+                return
+            if node.name[index] in self.invalid_chars:
+                self.report("invalid-char-in-name", node.name[index], self.node_names_map[name_of_node],
                             node=node,
                             col=node.col_offset + index + 1)
+            index += 1
+
+    @staticmethod
+    def _skip_captured_group(index, matches):
+        for start, stop in matches:
+            if not start < index >= stop:
+                return stop - start
+        return 0
 
     def check_if_char_in_name(self, node, name, node_type):
         for char in self.invalid_chars:
@@ -66,7 +83,7 @@ class InvalidCharactersInNameChecker(VisitorChecker):
         self.check_if_char_in_node_name(node, 'TESTCASE_NAME')
 
     def visit_KeywordName(self, node):  # noqa
-        self.check_if_char_in_node_name(node, 'KEYWORD_NAME')
+        self.check_if_char_in_node_name(node, 'KEYWORD_NAME', is_keyword=True)
 
 
 class KeywordNamingChecker(VisitorChecker):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     include_package_data = True,
     install_requires = ['robotframework>=3.2.2', 'toml>=0.10.2'],
     extras_requires = {
-        'dev': ['pytest'],
+        'dev': ['pytest', 'pyyaml'],
         'doc': ['sphinx', 'sphinx_rtd_theme']
     },
     entry_points = {'console_scripts': ['robocop=robocop:run_robocop']}

--- a/tests/atest/conftest.py
+++ b/tests/atest/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import yaml
+from pathlib import Path
 from robocop.checkers import get_rules_for_atest
 from robocop.run import Robocop
 
@@ -37,45 +39,9 @@ def pytest_generate_tests(metafunc):
         else:
             pytest.exit(f"Rule: '{selected_rule}' was not found", 1)
         return
-    # TODO: load other tests from file (like yaml)
-    auto_discovered_rules.append((
-        'inconsistent-assignment',
-        ['-c', 'inconsistent-assignment:assignment_sign_type:space_and_equal_sign'],
-        'misc/inconsistent-assignment-const'
-    ))
-    auto_discovered_rules.append((
-        'inconsistent-assignment-in-variables',
-        ['-c', 'inconsistent-assignment-in-variables:assignment_sign_type:space_and_equal_sign'],
-        'misc/inconsistent-assignment-in-variables-const'
-    ))
-    auto_discovered_rules.append((
-        'inconsistent-assignment',
-        ['-c', 'inconsistent-assignment:assignment_sign_type:autodetect'],
-        'misc/inconsistent-assignment-autodetect'
-    ))
-    auto_discovered_rules.append((
-        'inconsistent-assignment-in-variables',
-        ['-c', 'inconsistent-assignment-in-variables:assignment_sign_type:autodetect'],
-        'misc/inconsistent-assignment-in-variables-autodetect'
-    ))
-    auto_discovered_rules.append((
-        'wrong-case-in-keyword-name',
-        ['-c', 'wrong-case-in-keyword-name:convention:first_word_capitalized'],
-        'naming/wrong-case-in-keyword-name-first-word'
-    ))
-    auto_discovered_rules.append((
-        'section-out-of-order',
-        ['-c', 'section-out-of-order:sections_order:settings,keywords,testcases,variables'],
-        'duplications/section-out-of-order_custom_order'
-    ))
-    auto_discovered_rules.append((
-        'section-out-of-order',
-        ['-c', 'section-out-of-order:sections_order:settings,variables,testcases,keywords'],
-        'duplications/section-out-of-order_default_order'
-    ))
-    auto_discovered_rules.append((
-        'section-out-of-order',
-        ['-c', 'section-out-of-order:sections_order:settings,variables,testcases,tasks,keywords'],
-        'duplications/section-out-of-order_default_order'
-    ))
+    with open(Path(__file__).parent / 'custom_tests.yaml') as f:
+        tests = yaml.safe_load(f)
+    for rule, configs in tests['tests'].items():
+        for config in configs:
+            auto_discovered_rules.append((rule, ['-c', config['config']], config['src_dir']))
     metafunc.parametrize('rule, args, test_data', auto_discovered_rules)

--- a/tests/atest/custom_tests.yaml
+++ b/tests/atest/custom_tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  inconsistent-assignment:
+    - config: inconsistent-assignment:assignment_sign_type:space_and_equal_sign
+      src_dir: misc/inconsistent-assignment-const
+    - config: inconsistent-assignment:assignment_sign_type:autodetect
+      src_dir: misc/inconsistent-assignment-autodetect
+  inconsistent-assignment-in-variables:
+    - config: inconsistent-assignment-in-variables:assignment_sign_type:space_and_equal_sign
+      src_dir: misc/inconsistent-assignment-in-variables-const
+    - config: inconsistent-assignment-in-variables:assignment_sign_type:autodetect
+      src_dir: misc/inconsistent-assignment-in-variables-autodetect
+  wrong-case-in-keyword-name:
+    - config: wrong-case-in-keyword-name:convention:first_word_capitalized
+      src_dir: naming/wrong-case-in-keyword-name-first-word
+  section-out-of-order:
+    - config: section-out-of-order:sections_order:settings,keywords,testcases,variables
+      src_dir: duplications/section-out-of-order_custom_order
+    - config: section-out-of-order:sections_order:settings,variables,testcases,keywords
+      src_dir: duplications/section-out-of-order_default_order
+    - config: section-out-of-order:sections_order:settings,variables,testcases,tasks,keywords
+      src_dir: duplications/section-out-of-order_default_order
+  invalid-char-in-name:
+    - config: invalid-char-in-name:invalid_chars:$:{}
+      src_dir: naming/invalid-char-in-name-configured

--- a/tests/atest/rules/naming/invalid-char-in-name-configured/expected_output.txt
+++ b/tests/atest/rules/naming/invalid-char-in-name-configured/expected_output.txt
@@ -1,4 +1,7 @@
-${rules_dir}${\}test.robot:9:26 [W] 0301 Invalid character '$' in keyword name
-${rules_dir}${\}test.robot:9:36 [W] 0301 Invalid character '{' in keyword name
-${rules_dir}${\}test.robot:9:37 [W] 0301 Invalid character '}' in keyword name
-${rules_dir}${\}test.robot:12:14 [W] 0301 Invalid character ':' in keyword name
+${rules_dir}${\}test.robot:2:32 [W] 0301 Invalid character '$' in test case name
+${rules_dir}${\}test.robot:2:33 [W] 0301 Invalid character '{' in test case name
+${rules_dir}${\}test.robot:2:37 [W] 0301 Invalid character '}' in test case name
+${rules_dir}${\}test.robot:13:26 [W] 0301 Invalid character '$' in keyword name
+${rules_dir}${\}test.robot:13:36 [W] 0301 Invalid character '{' in keyword name
+${rules_dir}${\}test.robot:13:37 [W] 0301 Invalid character '}' in keyword name
+${rules_dir}${\}test.robot:16:14 [W] 0301 Invalid character ':' in keyword name

--- a/tests/atest/rules/naming/invalid-char-in-name-configured/expected_output.txt
+++ b/tests/atest/rules/naming/invalid-char-in-name-configured/expected_output.txt
@@ -1,0 +1,4 @@
+${rules_dir}${\}test.robot:9:26 [W] 0301 Invalid character '$' in keyword name
+${rules_dir}${\}test.robot:9:36 [W] 0301 Invalid character '{' in keyword name
+${rules_dir}${\}test.robot:9:37 [W] 0301 Invalid character '}' in keyword name
+${rules_dir}${\}test.robot:12:14 [W] 0301 Invalid character ':' in keyword name

--- a/tests/atest/rules/naming/invalid-char-in-name-configured/test.robot
+++ b/tests/atest/rules/naming/invalid-char-in-name-configured/test.robot
@@ -1,3 +1,7 @@
+*** Test Cases ***
+Test with not allowed variable ${var}
+    Steps
+
 *** Keywords ***
 Keyword?
     [Documentation]  this is doc

--- a/tests/atest/rules/naming/invalid-char-in-name-configured/test.robot
+++ b/tests/atest/rules/naming/invalid-char-in-name-configured/test.robot
@@ -1,0 +1,13 @@
+*** Keywords ***
+Keyword?
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With ${em.bedded}$ Argument{}
+    No Operation
+
+Keyword With :
+    No Operation

--- a/tests/atest/rules/naming/invalid-char-in-name/expected_output.txt
+++ b/tests/atest/rules/naming/invalid-char-in-name/expected_output.txt
@@ -1,3 +1,3 @@
-${rules_dir}${\}suite.withdot${\}__init__.robot:0:0 [W] 0301 Invalid character . in suite name
-${rules_dir}${\}test.robot:6:5 [W] 0301 Invalid character . in test case name
-${rules_dir}${\}test.robot:15:8 [W] 0301 Invalid character ? in keyword name
+${rules_dir}${\}suite.withdot${\}__init__.robot:0:0 [W] 0301 Invalid character '.' in suite name
+${rules_dir}${\}test.robot:6:5 [W] 0301 Invalid character '.' in test case name
+${rules_dir}${\}test.robot:15:8 [W] 0301 Invalid character '?' in keyword name

--- a/tests/atest/rules/naming/invalid-char-in-name/test.robot
+++ b/tests/atest/rules/naming/invalid-char-in-name/test.robot
@@ -18,3 +18,6 @@ Keyword?
     Pass
     No Operation
     Fail
+
+Keyword With ${em.bedded} Argument
+    No Operation


### PR DESCRIPTION
Closes #421

I've also decided to define our custom acceptance tests for rules in external yaml file - it allow more concise syntax. 