### PR TITLE
Remove variants of robot vars from keyword name before check

### DIFF
--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -10,7 +10,7 @@ from robot.parsing.model.statements import KeywordCall, Arguments
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
-from robocop.utils import normalize_robot_name, normalize_robot_var_name, IS_RF4, keyword_col
+from robocop.utils import normalize_robot_name, normalize_robot_var_name, IS_RF4, keyword_col, remove_robot_vars
 
 
 class InvalidCharactersInNameChecker(VisitorChecker):
@@ -144,7 +144,6 @@ class KeywordNamingChecker(VisitorChecker):
 
     def __init__(self):
         self.letter_pattern = re.compile(r'\W|_', re.UNICODE)
-        self.var_pattern = re.compile(r'[$@%&]{.+}')
         self.convention = 'each_word_capitalized'
         super().__init__()
 
@@ -205,8 +204,8 @@ class KeywordNamingChecker(VisitorChecker):
                     )
         elif self.check_if_keyword_is_reserved(keyword_name, node):
             return
+        keyword_name = remove_robot_vars(keyword_name)
         keyword_name = keyword_name.split('.')[-1]  # remove any imports ie ExternalLib.SubLib.Log -> Log
-        keyword_name = self.var_pattern.sub('', keyword_name)  # remove any embedded variables from name
         keyword_name = keyword_name.replace("'", '')  # replace ' apostrophes
         if '_' in keyword_name:
             self.report("underscore-in-keyword-name", node=node)

--- a/robocop/utils/__init__.py
+++ b/robocop/utils/__init__.py
@@ -19,5 +19,6 @@ from robocop.utils.misc import (
     token_col,
     RecommendationFinder,
     is_suite_templated,
-    last_non_empty_line
+    last_non_empty_line,
+    remove_robot_vars
 )

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -248,7 +248,8 @@ def remove_robot_vars(name):
     replaced = ''
     index = 0
     while index < len(name):
-        if not started and name[index] in var_start and index + 1 < len(name) and name[index+1] == '{':
+        if not started and name[index] in var_start and index + 1 < len(name) and name[index+1] == '{' and not \
+                (index and name[index-1] == '\\'):
             started = True
             open_bracket = '{'
             close_bracket = '}'

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -248,6 +248,7 @@ def remove_robot_vars(name):
     replaced = ''
     index = 0
     while index < len(name):
+        # it looks for $ (or other var starter) and then check if next char is { and previous is not escape \
         if not started and name[index] in var_start and index + 1 < len(name) and name[index+1] == '{' and not \
                 (index and name[index-1] == '\\'):
             started = True

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -240,39 +240,36 @@ def last_non_empty_line(node):
     return node.lineno
 
 
+def next_char_is(string, i, char):
+    if not i < len(string) - 1:
+        return False
+    return string[i + 1] == char
+
+
 def remove_robot_vars(name):
     var_start = set('$@%&')
-    started, after_var = False, False
     brackets = 0
     open_bracket, close_bracket = '', ''
     replaced = ''
     index = 0
     while index < len(name):
-        # it looks for $ (or other var starter) and then check if next char is { and previous is not escape \
-        if not started and name[index] in var_start and index + 1 < len(name) and name[index+1] == '{' and not \
-                (index and name[index-1] == '\\'):
-            started = True
-            open_bracket = '{'
-            close_bracket = '}'
-            brackets += 1
-            index += 2
-            continue
-        if started:
+        if brackets:
             if name[index] == open_bracket:
                 brackets += 1
             elif name[index] == close_bracket:
                 brackets -= 1
             if not brackets:
-                started = False
-                after_var = True
-        elif after_var:
-            if name[index] == '[':
-                brackets += 1
-                started = True
-                open_bracket, close_bracket = '[', ']'
-            else:
-                replaced += name[index]
-            after_var = False
+                # check if next chars are not ['key']
+                if next_char_is(name, index, '['):
+                    brackets += 1
+                    index += 1
+                    open_bracket, close_bracket = '[', ']'
+        # it looks for $ (or other var starter) and then check if next char is { and previous is not escape \
+        elif name[index] in var_start and next_char_is(name, index, '{') and not (index and name[index - 1] == '\\'):
+            open_bracket = '{'
+            close_bracket = '}'
+            brackets += 1
+            index += 1
         else:
             replaced += name[index]
         index += 1

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -8,6 +8,7 @@ import re
 
 from robot.api import Token
 from robot.parsing.model.statements import EmptyLine
+
 try:
     from robot.api.parsing import Variable
 except ImportError:
@@ -16,7 +17,6 @@ from robot.version import VERSION
 
 from robocop.rules import RuleSeverity
 from robocop.exceptions import InvalidExternalCheckerError
-
 
 IS_RF4 = VERSION.startswith('4')
 DISABLED_IN_4 = frozenset(('nested-for-loop', 'invalid-comment'))
@@ -100,7 +100,7 @@ def issues_to_lsp_diagnostic(issues):
             'start': {
                 'line': max(0, issue.line - 1),
                 'character': issue.col
-                },
+            },
             'end': {
                 'line': max(0, issue.end_line - 1),
                 'character': issue.end_col
@@ -115,6 +115,7 @@ def issues_to_lsp_diagnostic(issues):
 
 class AssignmentTypeDetector(ast.NodeVisitor):
     """ Visitor for counting number and type of assignments """
+
     def __init__(self):
         self.keyword_sign_counter = Counter()
         self.keyword_most_common = None
@@ -144,7 +145,7 @@ class AssignmentTypeDetector(ast.NodeVisitor):
 
     @staticmethod
     def get_assignment_sign(token_value):
-        return token_value[token_value.find('}')+1:]
+        return token_value[token_value.find('}') + 1:]
 
 
 def parse_assignment_sign_type(value):
@@ -258,14 +259,17 @@ def remove_robot_vars(name):
                 brackets += 1
             elif name[index] == close_bracket:
                 brackets -= 1
-            if not brackets:
-                # check if next chars are not ['key']
-                if next_char_is(name, index, '['):
-                    brackets += 1
-                    index += 1
-                    open_bracket, close_bracket = '[', ']'
+            # check if next chars are not ['key']
+            if not brackets and next_char_is(name, index, '['):
+                brackets += 1
+                index += 1
+                open_bracket, close_bracket = '[', ']'
         # it looks for $ (or other var starter) and then check if next char is { and previous is not escape \
-        elif name[index] in var_start and next_char_is(name, index, '{') and not (index and name[index - 1] == '\\'):
+        elif (
+                name[index] in var_start and
+                next_char_is(name, index, '{') and
+                not (index and name[index - 1] == '\\')
+        ):
             open_bracket = '{'
             close_bracket = '}'
             brackets += 1

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -238,3 +238,40 @@ def last_non_empty_line(node):
         if not isinstance(child, EmptyLine):
             return child.lineno
     return node.lineno
+
+
+def remove_robot_vars(name):
+    var_start = set('$@%&')
+    started, after_var = False, False
+    brackets = 0
+    open_bracket, close_bracket = '', ''
+    replaced = ''
+    index = 0
+    while index < len(name):
+        if not started and name[index] in var_start and index + 1 < len(name) and name[index+1] == '{':
+            started = True
+            open_bracket = '{'
+            close_bracket = '}'
+            brackets += 1
+            index += 2
+            continue
+        if started:
+            if name[index] == open_bracket:
+                brackets += 1
+            elif name[index] == close_bracket:
+                brackets -= 1
+            if not brackets:
+                started = False
+                after_var = True
+        elif after_var:
+            if name[index] == '[':
+                brackets += 1
+                started = True
+                open_bracket, close_bracket = '[', ']'
+            else:
+                replaced += name[index]
+            after_var = False
+        else:
+            replaced += name[index]
+        index += 1
+    return replaced

--- a/tests/atest/rules/naming/wrong-case-in-keyword-name/test.robot
+++ b/tests/atest/rules/naming/wrong-case-in-keyword-name/test.robot
@@ -58,3 +58,9 @@ Keyword With Unicode And Non Latin
     Eäi Saa Peittää
     日本語
     _
+
+More Embedded Variables
+    Keyword With Embedded ${var} Variable
+    Keyword With Embedded ${var.attr} Variable
+    Keyword With Embedded ${var}['key'] Variable
+    Keyword With Embedded ${var}['${var}'] Variable

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -124,7 +124,8 @@ class TestRecommendationFinder:
         ('a@{variable}b', 'ab'),
         ('${variable${nested}suffix}', ''),
         ('&{dict["key"]}', ''),
-        ('this is ${variable not closed properly', 'this is ')
+        ('this is ${variable not closed properly', 'this is '),
+        (r'this is \${ escaped', r'this is \${ escaped'),
     ])
     def test_remove_robot_vars(self, string, replaced):
         actual = remove_robot_vars(string)

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -5,7 +5,8 @@ from robot.api import get_model
 from robocop.utils import (
     AssignmentTypeDetector,
     parse_assignment_sign_type,
-    RecommendationFinder
+    RecommendationFinder,
+    remove_robot_vars
 )
 
 
@@ -111,3 +112,20 @@ class TestRecommendationFinder:
     def test_find_similar(self, name, candidates, similar):
         rec = RecommendationFinder().find_similar(name, candidates)
         assert similar == rec
+
+    @pytest.mark.parametrize('string, replaced', [
+        ('Keyword With Embedded ${var} Variable', 'Keyword With Embedded  Variable'),
+        ('Keyword With Embedded ${var.attr} Variable', 'Keyword With Embedded  Variable'),
+        ("Keyword With Embedded ${var}['key'] Variable", 'Keyword With Embedded  Variable'),
+        ('Keyword With Embedded ${var}[${var}] Variable', 'Keyword With Embedded  Variable'),
+        ('${variable}', ''),
+        ('a${variable}', 'a'),
+        ('%{variable}b', 'b'),
+        ('a@{variable}b', 'ab'),
+        ('${variable${nested}suffix}', ''),
+        ('&{dict["key"]}', ''),
+        ('this is ${variable not closed properly', 'this is ')
+    ])
+    def test_remove_robot_vars(self, string, replaced):
+        actual = remove_robot_vars(string)
+        assert actual == replaced


### PR DESCRIPTION
It will deal with this syntax:
```
${var}['key']['key2']
```
But it will also fix minor issues with embedded variables (for example it was not working correctly for ${var.attr}). 

I've decided to replace regex pattern with python method for replacing robot variables - it was more clear than monstrous regex that would be required to cover nested robot variables and dictionary subscriptions.

Closes #433