### PR TITLE
Improve handling arguments with variable imports

### DIFF
--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -16,37 +16,38 @@ class DuplicationsChecker(VisitorChecker):
     rules = {
         "0801": (
             "duplicated-test-case",
-            'Multiple test cases with name "%s" in suite',
+            'Multiple test cases with name "%s" (first occurrence in line %d)',
             RuleSeverity.ERROR
         ),
         "0802": (
             "duplicated-keyword",
-            'Multiple keywords with name "%s" in file',
+            'Multiple keywords with name "%s" (first occurrence in line %d)',
             RuleSeverity.ERROR
         ),
         "0803": (
             "duplicated-variable",
-            'Multiple variables with name "%s" in Variables section. Note that Robot Framework is case-insensitive',
+            'Multiple variables with name "%s" in Variables section (first occurrence in line %d). '
+            'Note that Robot Framework is case-insensitive',
             RuleSeverity.ERROR
         ),
         "0804": (
             "duplicated-resource",
-            'Multiple resource imports with path "%s" in suite',
+            'Multiple resource imports with path "%s" (first occurrence in line %d)',
             RuleSeverity.WARNING
         ),
         "0805": (
             "duplicated-library",
-            'Multiple library imports with name "%s" and identical arguments in suite',
+            'Multiple library imports with name "%s" and identical arguments (first occurrence in line %d)',
             RuleSeverity.WARNING
         ),
         "0806": (
             "duplicated-metadata",
-            'Duplicated metadata "%s" in suite',
+            'Duplicated metadata "%s" (first occurrence in line %d)',
             RuleSeverity.WARNING
         ),
         "0807": (
             "duplicated-variables-import",
-            'Duplicated variables import with path "%s" in suite',
+            'Duplicated variables import with path "%s" (first occurrence in line %d)',
             RuleSeverity.WARNING
         ),
         "0811": (
@@ -90,10 +91,8 @@ class DuplicationsChecker(VisitorChecker):
 
     def check_duplicates(self, container, rule):
         for nodes in container.values():
-            if len(nodes) == 1:
-                continue
-            for duplicate in nodes:
-                self.report(rule, duplicate.name, node=duplicate)
+            for duplicate in nodes[1:]:
+                self.report(rule, duplicate.name, nodes[0].lineno, node=duplicate)
 
     def visit_TestCase(self, node):  # noqa
         testcase_name = normalize_robot_name(node.name)

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -123,7 +123,7 @@ class DuplicationsChecker(VisitorChecker):
     def visit_VariablesImport(self, node): # noqa
         if not node.name:
             return
-        # only python files can have arguments - covered in # TODO: add rule id
+        # only python files can have arguments - covered in E0404 variables-import-with-args
         if not node.name.endswith('.py') and node.get_token(Token.ARGUMENT):
             return
         name_with_args = node.name + ''.join(token.value for token in node.data_tokens[2:])

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -121,8 +121,13 @@ class DuplicationsChecker(VisitorChecker):
             self.metadata[node.name + node.value].append(node)
 
     def visit_VariablesImport(self, node): # noqa
-        if node.name:
-            self.variable_imports[node.name].append(node)
+        if not node.name:
+            return
+        # only python files can have arguments - covered in # TODO: add rule id
+        if not node.name.endswith('.py') and node.get_token(Token.ARGUMENT):
+            return
+        name_with_args = node.name + ''.join(token.value for token in node.data_tokens[2:])
+        self.variable_imports[name_with_args].append(node)
 
 
 class SectionHeadersChecker(VisitorChecker):

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -3,6 +3,8 @@ Errors checkers
 """
 import re
 
+from robot.api import Token
+
 from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
 from robocop.utils import IS_RF4
@@ -90,3 +92,18 @@ class MissingKeywordName(VisitorChecker):
                 lineno=node.lineno,
                 col=node.data_tokens[0].col_offset + 1
             )
+
+
+class VariablesImportErrorChecker(VisitorChecker):
+    """ Checker for syntax error in variables import. """
+    rules = {
+        "0404": (
+            "variables-import-with-args",
+            "Robot and YAML variable files do not take arguments",
+            RuleSeverity.ERROR
+        )
+    }
+
+    def visit_VariablesImport(self, node): # noqa
+        if node.name and not node.name.endswith('.py') and node.get_token(Token.ARGUMENT):
+            self.report("variables-import-with-args", node=node)

--- a/tests/atest/rules/duplications/duplicated-keyword/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-keyword/expected_output.txt
@@ -1,2 +1,1 @@
-${rules_dir}${\}test.robot:15:1 [E] 0802 Multiple keywords with name "Duplicated Keyword" in file
-${rules_dir}${\}test.robot:25:1 [E] 0802 Multiple keywords with name "Duplicated Keyword" in file
+${rules_dir}${\}test.robot:25:1 [E] 0802 Multiple keywords with name "Duplicated Keyword" (first occurrence in line 15)

--- a/tests/atest/rules/duplications/duplicated-library/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-library/expected_output.txt
@@ -1,2 +1,1 @@
-${rules_dir}${\}test.robot:3:1 [W] 0805 Multiple library imports with name "MyLib" and identical arguments in suite
-${rules_dir}${\}test.robot:7:1 [W] 0805 Multiple library imports with name "MyLib" and identical arguments in suite
+${rules_dir}${\}test.robot:7:1 [W] 0805 Multiple library imports with name "MyLib" and identical arguments (first occurrence in line 3)

--- a/tests/atest/rules/duplications/duplicated-metadata/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-metadata/expected_output.txt
@@ -1,2 +1,1 @@
-${rules_dir}${\}__init__.robot:2:1 [W] 0806 Duplicated metadata "some text" in suite
-${rules_dir}${\}__init__.robot:4:1 [W] 0806 Duplicated metadata "some text" in suite
+${rules_dir}${\}__init__.robot:4:1 [W] 0806 Duplicated metadata "some text" (first occurrence in line 2)

--- a/tests/atest/rules/duplications/duplicated-resource/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-resource/expected_output.txt
@@ -1,2 +1,1 @@
-${rules_dir}${\}test.robot:3:1 [W] 0804 Multiple resource imports with path "resource.robot" in suite
-${rules_dir}${\}test.robot:5:1 [W] 0804 Multiple resource imports with path "resource.robot" in suite
+${rules_dir}${\}test.robot:5:1 [W] 0804 Multiple resource imports with path "resource.robot" (first occurrence in line 3)

--- a/tests/atest/rules/duplications/duplicated-test-case/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-test-case/expected_output.txt
@@ -1,7 +1,4 @@
-${rules_dir}${\}test.robot:6:1 [E] 0801 Multiple test cases with name "Test" in suite
-${rules_dir}${\}test.robot:13:1 [E] 0801 Multiple test cases with name "Test" in suite
-${rules_dir}${\}test1.robot:6:1 [E] 0801 Multiple test cases with name "Test" in suite
-${rules_dir}${\}test1.robot:13:1 [E] 0801 Multiple test cases with name "test" in suite
-${rules_dir}${\}test2.robot:6:1 [E] 0801 Multiple test cases with name "Test 1" in suite
-${rules_dir}${\}test2.robot:13:1 [E] 0801 Multiple test cases with name "test1" in suite
-${rules_dir}${\}test2.robot:16:1 [E] 0801 Multiple test cases with name "Te s t_1" in suite
+${rules_dir}${\}test.robot:13:1 [E] 0801 Multiple test cases with name "Test" (first occurrence in line 6)
+${rules_dir}${\}test1.robot:13:1 [E] 0801 Multiple test cases with name "test" (first occurrence in line 6)
+${rules_dir}${\}test2.robot:13:1 [E] 0801 Multiple test cases with name "test1" (first occurrence in line 6)
+${rules_dir}${\}test2.robot:16:1 [E] 0801 Multiple test cases with name "Te s t_1" (first occurrence in line 6)

--- a/tests/atest/rules/duplications/duplicated-variable/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-variable/expected_output.txt
@@ -1,2 +1,1 @@
-${rules_dir}${\}test.robot:6:1 [E] 0803 Multiple variables with name "${v_ar}" in Variables section. Note that Robot Framework is case-insensitive
-${rules_dir}${\}test.robot:8:1 [E] 0803 Multiple variables with name "${V AR}" in Variables section. Note that Robot Framework is case-insensitive
+${rules_dir}${\}test.robot:8:1 [E] 0803 Multiple variables with name "${V AR}" in Variables section (first occurrence in line 6). Note that Robot Framework is case-insensitive

--- a/tests/atest/rules/duplications/duplicated-variables-import/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-variables-import/expected_output.txt
@@ -1,8 +1,5 @@
-${rules_dir}${\}test.robot:3:1 [W] 0807 Duplicated variables import with path "variables.py" in suite
-${rules_dir}${\}test.robot:5:1 [W] 0807 Duplicated variables import with path "variables.py" in suite
-${rules_dir}${\}test.robot:9:1 [W] 0807 Duplicated variables import with path "other1.py" in suite
-${rules_dir}${\}test.robot:10:1 [W] 0807 Duplicated variables import with path "other1.py" in suite
-${rules_dir}${\}test.robot:12:1 [W] 0807 Duplicated variables import with path "vars2.yaml" in suite
-${rules_dir}${\}test.robot:13:1 [W] 0807 Duplicated variables import with path "vars2.yaml" in suite
-${rules_dir}${\}test.robot:14:1 [W] 0807 Duplicated variables import with path "variables.robot" in suite
-${rules_dir}${\}test.robot:15:1 [W] 0807 Duplicated variables import with path "variables.robot" in suite
+${rules_dir}${\}test.robot:5:1 [W] 0807 Duplicated variables import with path "variables.py" (first occurrence in line 3)
+${rules_dir}${\}test.robot:10:1 [W] 0807 Duplicated variables import with path "other1.py" (first occurrence in line 9)
+${rules_dir}${\}test.robot:13:1 [W] 0807 Duplicated variables import with path "vars2.yaml" (first occurrence in line 12)
+${rules_dir}${\}test.robot:15:1 [W] 0807 Duplicated variables import with path "variables.robot" (first occurrence in line 14)
+${rules_dir}${\}test.robot:16:1 [W] 0807 Duplicated variables import with path "variables.robot" (first occurrence in line 14)

--- a/tests/atest/rules/duplications/duplicated-variables-import/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-variables-import/expected_output.txt
@@ -1,2 +1,8 @@
 ${rules_dir}${\}test.robot:3:1 [W] 0807 Duplicated variables import with path "variables.py" in suite
 ${rules_dir}${\}test.robot:5:1 [W] 0807 Duplicated variables import with path "variables.py" in suite
+${rules_dir}${\}test.robot:9:1 [W] 0807 Duplicated variables import with path "other1.py" in suite
+${rules_dir}${\}test.robot:10:1 [W] 0807 Duplicated variables import with path "other1.py" in suite
+${rules_dir}${\}test.robot:12:1 [W] 0807 Duplicated variables import with path "vars2.yaml" in suite
+${rules_dir}${\}test.robot:13:1 [W] 0807 Duplicated variables import with path "vars2.yaml" in suite
+${rules_dir}${\}test.robot:14:1 [W] 0807 Duplicated variables import with path "variables.robot" in suite
+${rules_dir}${\}test.robot:15:1 [W] 0807 Duplicated variables import with path "variables.robot" in suite

--- a/tests/atest/rules/duplications/duplicated-variables-import/test.robot
+++ b/tests/atest/rules/duplications/duplicated-variables-import/test.robot
@@ -4,6 +4,17 @@ Variables  variables.py
 Variables  other.robot
 Variables  variables.py
 
+Variables  other.py    arg1
+Variables  other.py    arg2
+Variables  other1.py    arg1
+Variables  other1.py    arg1
+Variables  vars.yaml    arg1
+Variables  vars2.yaml
+Variables  vars2.yaml
+Variables  variables.robot
+Variables  variables.robot
+Variables  variables.robot    arg
+
 
 *** Test Cases ***
 Test

--- a/tests/atest/rules/duplications/duplicated-variables-import/test.robot
+++ b/tests/atest/rules/duplications/duplicated-variables-import/test.robot
@@ -13,6 +13,7 @@ Variables  vars2.yaml
 Variables  vars2.yaml
 Variables  variables.robot
 Variables  variables.robot
+Variables  variables.robot
 Variables  variables.robot    arg
 
 

--- a/tests/atest/rules/errors/variables-import-with-args/expected_output.txt
+++ b/tests/atest/rules/errors/variables-import-with-args/expected_output.txt
@@ -1,0 +1,2 @@
+${rules_dir}${\}test.robot:11:1 [E] 0404 Robot and YAML variable files do not take arguments
+${rules_dir}${\}test.robot:16:1 [E] 0404 Robot and YAML variable files do not take arguments

--- a/tests/atest/rules/errors/variables-import-with-args/test.robot
+++ b/tests/atest/rules/errors/variables-import-with-args/test.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Documentation  doc
+Variables  variables.py
+Variables  other.robot
+Variables  variables.py
+
+Variables  other.py    arg1
+Variables  other.py    arg2
+Variables  other1.py    arg1
+Variables  other1.py    arg1
+Variables  vars.yaml    arg1
+Variables  vars2.yaml
+Variables  vars2.yaml
+Variables  variables.robot
+Variables  variables.robot
+Variables  variables.robot    arg
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail


### PR DESCRIPTION
Closes #434 - now arguments for python variable files are parsed and it's possible to reuse the same variables import but with different arguments
Closes #435 - added variables-import-with-args rule that checks if we provide args to robot or yaml variable file

Closes #482 