### PR TITLE
Add toml to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx-rtd-theme
 robotframework>=4.0
+toml>=0.10.2


### PR DESCRIPTION
Our documentation failed to build because of missing dependency.