### PR TITLE
Refactor documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ def get_checker_docs():
                 "name": rule.name,
                 "id": rule.rule_id,
                 "severity": rule.severity.value,
-                "desc": rule.desc,
+                "desc": rule.message_for_docs,
                 "ext_docs": rule.docs,
                 "version": rule.supported_version,
                 "params": [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,8 +73,8 @@ def get_checker_docs():
                 "id": rule.rule_id,
                 "severity": rule.severity.value,
                 "desc": rule.desc,
-                "ext_docs": rule.ext_docs,
-                "version": rule.version,
+                "ext_docs": rule.docs,
+                "version": rule.supported_version,
                 "params": [
                     {"name": param.name, "default": param.value, "type": param.converter.__name__, "desc": param.desc}
                     for param in rule.config.values()

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -27,21 +27,41 @@ Rules
 {{ checker_group[0] }}
 -------------
 {% for rule_doc in checker_group[1] %}
-* {{ rule_doc[1] }}
+{{ rule_doc.name }}
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  .. list-table:: Configurable parameters
-     :widths: 25 25 25 25
-     :header-rows: 1
+.. list-table::
+  :width: 100%
+  :widths: 33 33 33
+  :header-rows: 1
 
-     * - name
-       - type
-       - default
-       - info
-{% for rule_param in rule_doc[2] %}
-     * - {{ rule_param[0] }}
-       - {{ rule_param[1] }}
-       - {{ rule_param[2] }}
-       - {{ rule_param[3] }}
+  * - Severity
+    - Rule id
+    - Robot Framework version
+  * - {{ rule_doc.severity }}
+    - {{ rule_doc.id }}
+    - {{ rule_doc.version }}
+
+{{ rule_doc.desc }}.
+
+{%- if rule_doc.ext_docs %}
+{{ rule_doc.ext_docs }}
+{% endif %}
+
+.. list-table:: Configurable parameters
+  :width: 100%
+  :widths: 25 25 25 25
+  :header-rows: 1
+
+  * - Name
+    - Default value
+    - Type
+    - Description
+{% for rule_param in rule_doc.params %}
+  * - {{ rule_param.name }}
+    - {{ rule_param.default }}
+    - {{ rule_param.type }}
+    - {{ rule_param.desc }}
 {% endfor %}
 
 

--- a/docs/static/theme.css
+++ b/docs/static/theme.css
@@ -1,0 +1,12 @@
+.rst-content table.docutils caption, .rst-content table.field-list caption, .wy-table caption {
+    font: 85%/1 arial,sans-serif;
+    font-weight: bold;
+    text-align: left;
+}
+.tight-table td {
+    white-space: normal !important;
+}
+h3 {
+    padding: .4rem 1rem .1rem;
+    border-bottom: 1px solid #dbd7d7;
+} 

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -10,12 +10,30 @@ from robocop.rules import Rule, RuleSeverity
 from robocop.utils import ROBOT_VERSION
 
 rules = {
-    "0701": Rule(rule_id="0701", name="todo-in-comment", msg="Found %s in comment", severity=RuleSeverity.WARNING),
+    "0701": Rule(
+        rule_id="0701",
+        name="todo-in-comment",
+        msg="Found %s in comment",
+        severity=RuleSeverity.WARNING,
+        docs="""
+        TODO or FIXME statement found in the comment. Example::
+        
+            # TODO: Refactor this code
+            # fixme 
+        
+        """,
+    ),
     "0702": Rule(
         rule_id="0702",
         name="missing-space-after-comment",
         msg="Missing blank space after comment character",
         severity=RuleSeverity.WARNING,
+        docs="""
+        Example::
+        
+            #bad
+            # good
+        """,
     ),
     "0703": Rule(
         rule_id="0703",
@@ -24,6 +42,18 @@ rules = {
         "For block comments you can use '*** Comments ***' section",
         severity=RuleSeverity.ERROR,
         version="<4.0",
+        docs="""
+        In Robot Framework 3.2.2 comments that started from second character in the cell were not recognized as 
+        comments.
+        
+        Example::
+        
+        
+            # good
+             # bad
+              # third cell so it's good
+        
+        """,
     ),
     "0704": Rule(rule_id="0704", name="ignored-data", msg="Ignored data found in file", severity=RuleSeverity.WARNING),
     "0705": Rule(

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -16,12 +16,13 @@ rules = {
         msg="Found %s in comment",
         severity=RuleSeverity.WARNING,
         docs="""
-        TODO or FIXME statement found in the comment. Example::
+        Example::
         
             # TODO: Refactor this code
             # fixme 
         
         """,
+        docs_args=("TODO or FIXME statement found",),
     ),
     "0702": Rule(
         rule_id="0702",

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -30,6 +30,8 @@ rules = {
         msg="Missing blank space after comment character",
         severity=RuleSeverity.WARNING,
         docs="""
+        Make sure to have one blank space after '#' comment character
+
         Example::
         
             #bad

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -22,7 +22,7 @@ rules = {
             # fixme 
         
         """,
-        docs_args=("TODO or FIXME statement found",),
+        docs_args=("TODO or FIXME statement",),
     ),
     "0702": Rule(
         rule_id="0702",

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -37,6 +37,18 @@ rules = {
         name="duplicated-test-case",
         msg='Multiple test cases with name "%s" (first occurrence in line %d)',
         severity=RuleSeverity.ERROR,
+        docs="""
+        It is not allowed to reuse the same name of the test case within the same suite in the Robot Framework. 
+        Name matching is case insensitive and ignores spaces and `_` characters.
+        Duplicated test cases example::
+        
+            *** Test Cases ***
+            Test with name
+                No Operation
+            
+            test_with Name  # it is duplicate of 'Test with name'
+                No Operation
+        """,
     ),
     "0802": Rule(
         rule_id="0802",
@@ -75,23 +87,30 @@ rules = {
         msg='Duplicated variables import with path "%s" (first occurrence in line %d)',
         severity=RuleSeverity.WARNING,
     ),
-    "0811": Rule(
-        rule_id="0811",
-        name="duplicated-argument-name",
-        msg="Argument name '%s' is already used",
-        severity=RuleSeverity.ERROR,
-    ),
-    "0812": Rule(
-        rule_id="0812",
-        name="duplicated-assigned-var-name",
-        msg="Assigned variable name '%s' is already used",
-        severity=RuleSeverity.INFO,
-    ),
     "0808": Rule(
         rule_id="0808",
         name="section-already-defined",
         msg="'%s' section header already defined in file",
         severity=RuleSeverity.WARNING,
+        docs="""
+        Duplicated section in the file. Robot Framework will parse multiple duplicated sections but it is better
+        practice to not duplicate sections.
+        
+        Example::
+        
+            *** Test Cases ***
+            My Test
+                Keyword
+            
+            *** Keywords ***
+            Keyword
+                No Operation
+            
+            *** Test Cases ***  # duplicate
+            Other Test
+                Keyword
+
+        """,
     ),
     "0809": Rule(
         RuleParam(
@@ -104,12 +123,52 @@ rules = {
         name="section-out-of-order",
         msg="'%s' section header is defined in wrong order: %s",
         severity=RuleSeverity.WARNING,
+        docs="""
+        Sections should be defined in order set by `sections_order` 
+        parameter (default: `settings,variables,testcases,keywords`).
+        
+        To change the default order use following option::
+        
+            robocop --configure section-out-of-order:sections_order:comma,separated,list,of,sections
+        
+        Where sections should be case insensitive name from the list: comments,settings,variables,testcases,keywords. 
+        Order of not configured sections is ignored.
+        
+        Example::
+        
+            *** Settings ***
+            
+            *** Keywords ***
+            
+            *** Test Cases ***  # it will report issue because Test Cases should be defined before Keywords
+
+        """,
     ),
     "0810": Rule(
         rule_id="0810",
         name="both-tests-and-tasks",
         msg="Both Task(s) and Test Case(s) section headers defined in file",
         severity=RuleSeverity.ERROR,
+        docs="""
+        The file contains both Test Case and Task sections. Use only one of them. ::
+        
+            *** Test Cases ***
+            
+            *** Tasks ***
+
+        """,
+    ),
+    "0811": Rule(
+        rule_id="0811",
+        name="duplicated-argument-name",
+        msg="Argument name '%s' is already used",
+        severity=RuleSeverity.ERROR,
+    ),
+    "0812": Rule(
+        rule_id="0812",
+        name="duplicated-assigned-var-name",
+        msg="Assigned variable name '%s' is already used",
+        severity=RuleSeverity.INFO,
     ),
 }
 

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -38,15 +38,15 @@ rules = {
         msg='Multiple test cases with name "%s" (first occurrence in line %d)',
         severity=RuleSeverity.ERROR,
         docs="""
-        It is not allowed to reuse the same name of the test case within the same suite in the Robot Framework. 
-        Name matching is case insensitive and ignores spaces and `_` characters.
+        It is not allowed to reuse the same name of the test case within the same suite in Robot Framework. 
+        Name matching is case-insensitive and ignores spaces and underscore characters.
         Duplicated test cases example::
         
             *** Test Cases ***
             Test with name
                 No Operation
             
-            test_with Name  # it is duplicate of 'Test with name'
+            test_with Name  # it is a duplicate of 'Test with name'
                 No Operation
         """,
     ),
@@ -93,8 +93,7 @@ rules = {
         msg="'%s' section header already defined in file",
         severity=RuleSeverity.WARNING,
         docs="""
-        Duplicated section in the file. Robot Framework will parse multiple duplicated sections but it is better
-        practice to not duplicate sections.
+        Duplicated section in the file. Robot Framework will handle repeated sections but it is recommended to not duplicate them.
         
         Example::
         
@@ -131,7 +130,7 @@ rules = {
         
             robocop --configure section-out-of-order:sections_order:comma,separated,list,of,sections
         
-        Where sections should be case insensitive name from the list: comments,settings,variables,testcases,keywords. 
+        where section should be case-insensitive name from the list: comments, settings, variables, testcases, keywords. 
         Order of not configured sections is ignored.
         
         Example::

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -17,6 +17,10 @@ rules = {
         name="too-long-keyword",
         msg="Keyword is too long (%d/%d)",
         severity=RuleSeverity.WARNING,
+        docs_args=(
+            "keyword length",
+            "allowed length",
+        ),
     ),
     "0502": Rule(
         RuleParam(name="min_calls", default=1, converter=int, desc="number of keyword calls required in a keyword"),

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -25,6 +25,26 @@ rules = {
         msg="[Return] is not defined at the end of keyword. "
         "Note that [Return] does not return from keyword but only set returned variables",
         severity=RuleSeverity.WARNING,
+        docs="""
+        To improve readability use `[Return]` setting at the end of the keyword. If you want to return immediately from 
+        the keyword use `Return From Keyword` keyword instead (`[Return]` does not return until all steps in the 
+        keyword are complected).
+        
+        Bad::
+        
+            Keyword
+                Step
+                [Return]    ${variable}
+                ${variable}    Other Step
+        
+        Good::
+        
+            Keyword
+                Step
+                ${variable}    Other Step
+                [Return]    ${variable}
+
+        """,
     ),
     "0902": Rule(
         rule_id="0902",
@@ -39,6 +59,16 @@ rules = {
         msg="Nested for loops are not supported. You can use keyword with for loop instead",
         severity=RuleSeverity.ERROR,
         version="<4.0",
+        docs="""
+        Older versions of Robot Framework did not support nested for loops::
+        
+            FOR    ${var}    IN RANGE    10
+                FOR   ${other_var}   IN    a  b
+                    # Nesting not supported in Robot Framework <4.0
+                END
+            END
+
+        """,
     ),
     "0908": Rule(
         rule_id="0908",

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -28,7 +28,7 @@ rules = {
         docs="""
         To improve readability use `[Return]` setting at the end of the keyword. If you want to return immediately from 
         the keyword use `Return From Keyword` keyword instead (`[Return]` does not return until all steps in the 
-        keyword are complected).
+        keyword are completed).
         
         Bad::
         
@@ -64,7 +64,7 @@ rules = {
         
             FOR    ${var}    IN RANGE    10
                 FOR   ${other_var}   IN    a  b
-                    # Nesting not supported in Robot Framework <4.0
+                    # Nesting supported from Robot Framework 4.0+
                 END
             END
 

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -64,7 +64,7 @@ rules = {
             keyword_with_underscores
             
             # good
-            Keyword With Underscores
+            Keyword Without Underscores
 
         """,
     ),

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -57,6 +57,16 @@ rules = {
         name="underscore-in-keyword-name",
         msg="Underscores in keyword name can be replaced with spaces",
         severity=RuleSeverity.WARNING,
+        docs="""
+        Example::
+        
+            # bad
+            keyword_with_underscores
+            
+            # good
+            Keyword With Underscores
+
+        """,
     ),
     "0306": Rule(
         rule_id="0306",

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -22,6 +22,7 @@ Available formats:
   * ``desc``:       description of the rule
 """
 from enum import Enum
+from textwrap import dedent
 from functools import total_ordering
 from typing import Any, Callable, Union, Pattern, Dict
 
@@ -134,7 +135,14 @@ class Rule:
     """
 
     def __init__(
-        self, *params: RuleParam, rule_id: str, name: str, msg: str, severity: RuleSeverity, version: str = None
+        self,
+        *params: RuleParam,
+        rule_id: str,
+        name: str,
+        msg: str,
+        severity: RuleSeverity,
+        version: str = None,
+        docs: str = "",
     ):
         """
         :param params: RuleParam() instances
@@ -147,6 +155,7 @@ class Rule:
         self.rule_id = rule_id
         self.name = name
         self.desc = msg
+        self.docs = dedent(docs)
         self.config = {
             "severity": RuleParam(
                 "severity", severity, RuleSeverity.parser, "Rule severity (E = Error, W = Warning, I = Info)"

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -47,11 +47,10 @@ class RuleSeverity(Enum):
 
         -t/--threshold <severity value>
 
-    Example::
+    To only report rules with severity W and above::
 
-        --threshold E
+        --threshold W
 
-    will only report rules with severity E and above.
     """
 
     INFO = "I"

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -164,6 +164,7 @@ class Rule:
         for param in params:
             self.config[param.name] = param
         self.enabled = True
+        self.supported_version = version if version else "All"
         self.enabled_in_version = self.supported_in_rf_version(version)
 
     @property

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -204,8 +204,9 @@ class Robocop:
             f"\nAltogether {sum(severity_counter.values())} rule(s) with following severity:\n"
             f"    {severity_counter['E']} error rule(s),\n"
             f"    {severity_counter['W']} warning rule(s),\n"
-            f"    {severity_counter['I']} info rule(s)."
+            f"    {severity_counter['I']} info rule(s).\n"
         )
+        print("Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.")
         sys.exit()
 
     def load_reports(self):

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -1,11 +1,11 @@
 import ast
-from typing import Pattern, List, Tuple, Dict
 import difflib
 import importlib.util
 import re
 from collections import Counter, defaultdict
 from importlib import import_module
 from pathlib import Path
+from typing import Pattern, List, Tuple, Dict
 
 from robot.api import Token
 from robot.parsing.model.statements import EmptyLine
@@ -15,9 +15,10 @@ try:
 except ImportError:
     from robot.parsing.model.statements import Variable
 
-from packaging import version
 from robot.version import VERSION as RF_VERSION
+from packaging import version
 
+from robocop.version import __version__
 from robocop.exceptions import InvalidExternalCheckerError
 
 ROBOT_VERSION = version.parse(RF_VERSION)
@@ -113,6 +114,9 @@ def issues_to_lsp_diagnostic(issues) -> List[Dict]:
             "code": issue.rule_id,
             "source": "robocop",
             "message": issue.desc,
+            "codeDescription": {
+                "href": f"https://robocop.readthedocs.io/en/{__version__}/rules.html#{issue.name}"
+            }
         }
         for issue in issues
     ]
@@ -150,7 +154,7 @@ class AssignmentTypeDetector(ast.NodeVisitor):
 
     @staticmethod
     def get_assignment_sign(token_value):
-        return token_value[token_value.find("}") + 1 :]
+        return token_value[token_value.find("}") + 1:]
 
 
 def parse_assignment_sign_type(value: str) -> str:

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -114,9 +114,7 @@ def issues_to_lsp_diagnostic(issues) -> List[Dict]:
             "code": issue.rule_id,
             "source": "robocop",
             "message": issue.desc,
-            "codeDescription": {
-                "href": f"https://robocop.readthedocs.io/en/{__version__}/rules.html#{issue.name}"
-            }
+            "codeDescription": {"href": f"https://robocop.readthedocs.io/en/{__version__}/rules.html#{issue.name}"},
         }
         for issue in issues
     ]
@@ -154,7 +152,7 @@ class AssignmentTypeDetector(ast.NodeVisitor):
 
     @staticmethod
     def get_assignment_sign(token_value):
-        return token_value[token_value.find("}") + 1:]
+        return token_value[token_value.find("}") + 1 :]
 
 
 def parse_assignment_sign_type(value: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     keywords=KEYWORDS,
     packages=["robocop"],
     include_package_data=True,
-    install_requires=["robotframework>=3.2.2", "toml>=0.10.2"],
+    install_requires=["robotframework>=3.2.2", "toml>=0.10.2", "packaging==21.*"],
     extras_requires={
         "dev": ["pytest", "pytest-benchmark", "pyyaml", "tox", "black", "packaging==21.*"],
         "doc": ["sphinx", "sphinx_rtd_theme"],

--- a/tests/utest/test_api.py
+++ b/tests/utest/test_api.py
@@ -7,6 +7,7 @@ import robocop
 from robocop.exceptions import InvalidArgumentError
 from robocop.rules import Message, Rule, RuleParam, RuleSeverity
 from robocop.utils import issues_to_lsp_diagnostic
+from robocop.version import __version__
 
 
 @pytest.fixture
@@ -116,6 +117,9 @@ class TestAPI:
                 "code": "0101",
                 "source": "robocop",
                 "message": "Some description",
+                "codeDescription": {
+                    "href": f"https://robocop.readthedocs.io/en/{__version__}/rules.html#some-message",
+                },
             },
             {
                 "range": {
@@ -126,6 +130,9 @@ class TestAPI:
                 "code": "0101",
                 "source": "robocop",
                 "message": "Some description",
+                "codeDescription": {
+                    "href": f"https://robocop.readthedocs.io/en/{__version__}/rules.html#some-message",
+                },
             },
         ]
         diagnostic = issues_to_lsp_diagnostic(issues)

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -99,7 +99,8 @@ class TestListingRules:
             "Altogether 1 rule(s) with following severity:\n"
             "    0 error rule(s),\n"
             "    1 warning rule(s),\n"
-            "    0 info rule(s).\n"
+            "    0 info rule(s).\n\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.\n"
         )
 
     def test_list_disabled_rule(self, robocop_pre_load, msg_0101, capsys):
@@ -114,6 +115,7 @@ class TestListingRules:
             "    0 error rule(s),\n"
             "    1 warning rule(s),\n"
             "    0 info rule(s).\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.\n"
         )
 
     def test_list_reports(self, robocop_pre_load, msg_0101, capsys):
@@ -172,7 +174,8 @@ class TestListingRules:
             "Altogether 1 rule(s) with following severity:\n"
             "    0 error rule(s),\n"
             "    1 warning rule(s),\n"
-            "    0 info rule(s).\n"
+            "    0 info rule(s).\n\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.\n"
         )
 
     def test_list_configurables_filtered(self, robocop_pre_load, msg_0101_config, msg_0102_0204_config, capsys):

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -114,7 +114,7 @@ class TestListingRules:
             "Altogether 1 rule(s) with following severity:\n"
             "    0 error rule(s),\n"
             "    1 warning rule(s),\n"
-            "    0 info rule(s).\n"
+            "    0 info rule(s).\n\n"
             "Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.\n"
         )
 


### PR DESCRIPTION
* Add `docs` argument to `Rule` class allowing to define extended documentation for the rule. Closes #468 
Code example:
```
    "0702": Rule(
        rule_id="0702",
        name="missing-space-after-comment",
        msg="Missing blank space after comment character",
        severity=RuleSeverity.WARNING,
        docs="""
        Example::
        
            #bad
            # good
        """,
    ),
```
Resulting in:
![image](https://user-images.githubusercontent.com/8532066/139208341-84164a2e-63aa-41d7-90c2-47722beace37.png)

* Various visual enhancements and more useful documentation (effects visible above)
* Rule documentation is now linkable - and link is included in codeDescription field of LSP message.
* Placeholders in rule names can now be replaced when printing (in cli or documentation) with `docs_args` optional argument:
Rule def:
```
    "0501": Rule(
        RuleParam(name="max_len", default=40, converter=int, desc="number of lines allowed in a keyword"),
        rule_id="0501",
        name="too-long-keyword",
        msg="Keyword is too long (%d/%d)",
        severity=RuleSeverity.WARNING,
        docs_args=(
            "keyword length",
            "allowed length",
        ),
    ),
```
Rule in docs:
![image](https://user-images.githubusercontent.com/8532066/139208987-861b663b-daf6-4b46-8575-8826edb17a32.png)

Rule from ``--list``:
![image](https://user-images.githubusercontent.com/8532066/139209063-80745f46-18c9-40fa-bb63-3dc1ba417b0e.png)
* Add 'Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation' statement at the end of ``--list`

Note that I only implemented feaures allowing us to do above + added few examples. I will create separate issue with list of all issuses so we could go over them and add docs/docs_args whenever necessary.