### PR TITLE
Properly handle exceptions

### DIFF
--- a/robocop/run.py
+++ b/robocop/run.py
@@ -272,9 +272,9 @@ def run_robocop():
         print(f"Error: {err}")
         sys.exit(1)
     except Exception as err:
-        warning = (
-            "\nFatal exception occurred. You can create issue at "
+        message = (
+            "\nFatal exception occurred. You can create an issue at "
             "https://github.com/MarketSquare/robotframework-robocop/issues . Thanks!"
         )
-        err.args = (err.args[0] + warning,) + err.args[1:]
+        err.args = (err.args[0] + message,) + err.args[1:]
         raise err

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -288,5 +288,16 @@ class Robocop:
 
 
 def run_robocop():
-    linter = Robocop(from_cli=True)
-    linter.run()
+    try:
+        linter = Robocop(from_cli=True)
+        linter.run()
+    except robocop.exceptions.RobocopFatalError as err:
+        print(f"Error: {err}")
+        sys.exit(1)
+    except Exception as err:
+        print(f"Error: {err}")
+        print(
+            "Fatal exception occurred. You can create issue at "
+            "https://github.com/MarketSquare/robotframework-robocop/issues . Thanks!"
+        )
+        sys.exit(1)

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -295,9 +295,9 @@ def run_robocop():
         print(f"Error: {err}")
         sys.exit(1)
     except Exception as err:
-        print(f"Error: {err}")
-        print(
-            "Fatal exception occurred. You can create issue at "
+        warning = (
+            "\nFatal exception occurred. You can create issue at "
             "https://github.com/MarketSquare/robotframework-robocop/issues . Thanks!"
         )
-        sys.exit(1)
+        err.args = (err.args[0] + warning,) + err.args[1:]
+        raise err


### PR DESCRIPTION
Closes #521 

Upon my investigation I've noticed that our error handling is far from perfect. Recognized errors (like not existing rule used in configuration) is printed together with stack trace. Unknown error just fail the code - without any suggestion for user (like reporting in our issue tracker).

To solve those issues I've decided to catch all exceptions and re-raise unknown ones with additional warning message.

Known issue now:
```
robocop --configure stuff2:stuff:value
Error: Provided rule or report 'stuff2' does not exist.
```
instead of 
```
robocop --configure stuff2:stuff:value
(...several lines of code...)
self.configure_checkers_or_reports()
  File "c:\users\barte\desktop\repo\robotframework-robocop\robocop\run.py", line 285, in configure_checkers_or_reports
    raise robocop.exceptions.ConfigGeneralError(
robocop.exceptions.ConfigGeneralError: Provided rule or report 'stuff2' does not exist.
```

Stack trace is printed when there is unexpected issue (for easier debugging):
```
  File "robotframework-robocop\robocop\run.py", line 273, in configure_checkers_or_reports
    s = "s" + 1
TypeError: can only concatenate str (not "int") to str
Fatal exception occurred. You can create issue at https://github.com/MarketSquare/robotframework-robocop/issues . Thanks!
```