### PR TITLE
Display supported version if rule is disabled in particular RF version

### DIFF
--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -190,8 +190,14 @@ class Rule:
     def __str__(self):
         return (
             f"Rule - {self.rule_id} [{self.config['severity'].value}]: {self.name}: {self.message_for_docs} "
-            f'({"enabled" if self.enabled else "disabled"})'
+            f'({self.get_enabled_status_desc()})'
         )
+
+    def get_enabled_status_desc(self):
+        s = "enabled" if self.enabled else "disabled"
+        if not self.enabled and self.supported_version != "All":
+            s += f" - enabled for RF version {self.supported_version}"
+        return s
 
     def configure(self, param, value):
         if param not in self.config:

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -196,7 +196,7 @@ class Rule:
     def get_enabled_status_desc(self):
         s = "enabled" if self.enabled else "disabled"
         if not self.enabled and self.supported_version != "All":
-            s += f" - enabled for RF version {self.supported_version}"
+            s += f" - supported only for RF version {self.supported_version}"
         return s
 
     def configure(self, param, value):

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -1,6 +1,7 @@
 import pytest
 
 import robocop.config
+from robocop.utils import ROBOT_VERSION
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
 
@@ -76,6 +77,13 @@ def msg_0102_0204():
     }
 
 
+@pytest.fixture
+def msg_disabled_for_4():
+    return {
+        "9999": Rule(rule_id="9999", name="disabled-in-four", msg="This is desc", severity=RuleSeverity.WARNING, version="<4.0")
+    }
+
+
 def init_empty_checker(robocop_instance_pre_load, rule, exclude=False, **kwargs):
     checker = EmptyChecker()
     checker.rules = rule
@@ -103,17 +111,23 @@ class TestListingRules:
             "Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.\n"
         )
 
-    def test_list_disabled_rule(self, robocop_pre_load, msg_0101, capsys):
+    def test_list_disabled_rule(self, robocop_pre_load, msg_0101, msg_disabled_for_4, capsys):
         robocop_pre_load.config.list = robocop.config.translate_pattern("*")
         init_empty_checker(robocop_pre_load, msg_0101, exclude=True)
+        init_empty_checker(robocop_pre_load, msg_disabled_for_4)
+        if ROBOT_VERSION.major >= 4:
+            enabled_for = "disabled - enabled for RF version <4.0"
+        else:
+            enabled_for = "enabled"
         with pytest.raises(SystemExit):
             robocop_pre_load.list_checkers()
         out, _ = capsys.readouterr()
         assert (
-            out == "Rule - 0101 [W]: some-message: Some description (disabled)\n\n"
-            "Altogether 1 rule(s) with following severity:\n"
+            out == "Rule - 0101 [W]: some-message: Some description (disabled)\n"
+                   f"Rule - 9999 [W]: disabled-in-four: This is desc ({enabled_for})\n\n"
+            "Altogether 2 rule(s) with following severity:\n"
             "    0 error rule(s),\n"
-            "    1 warning rule(s),\n"
+            "    2 warning rule(s),\n"
             "    0 info rule(s).\n\n"
             "Visit https://robocop.readthedocs.io/en/stable/rules.html page for detailed documentation.\n"
         )

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -116,7 +116,7 @@ class TestListingRules:
         init_empty_checker(robocop_pre_load, msg_0101, exclude=True)
         init_empty_checker(robocop_pre_load, msg_disabled_for_4)
         if ROBOT_VERSION.major >= 4:
-            enabled_for = "disabled - enabled for RF version <4.0"
+            enabled_for = "disabled - supported only for RF version <4.0"
         else:
             enabled_for = "enabled"
         with pytest.raises(SystemExit):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pyyaml
     toml
     robotframework==3.2.2
+    pathspec
 [testenv:rf4]
 deps =
     pytest
@@ -19,6 +20,7 @@ deps =
     pyyaml
     toml
     robotframework==4.1.1
+    pathspec
 [testenv:coverage]
 deps =
     pytest


### PR DESCRIPTION
Closes #507 

Currently the logic is:
- If the rule is enabled, always show `(enabled)` next to rule name (when using `--list`)
- If the rule is disabled but not because of the RF version - show `(disabled)`
- If the rule is disabled because it's not supported in used RF version - show `(disabled - enabled for RF version x)` (x = <4.0 etc)

