### PR TITLE
Use jinja templating in rule messages

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylama pylama_pylint pytest robotframework packaging==21.* pathspec==0.9.*
+        pip install pylama pylama_pylint pytest robotframework packaging==21.* pathspec==0.9.* jinja2~=3.0
     - name: Code quality with pylama
       run: python tests/pylama_parse.py

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install robotframework${{ matrix.rf-version }}
-        pip install toml pytest pytest-benchmark coverage[toml] pyyaml packaging==21.* pathspec==0.9.*
+        pip install toml pytest pytest-benchmark coverage[toml] pyyaml packaging==21.* pathspec==0.9.* jinja2~=3.0
     - name: Run unit tests with coverage
       run:
         coverage run -m pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ def get_checker_docs():
                 "name": rule.name,
                 "id": rule.rule_id,
                 "severity": rule.severity.value,
-                "desc": rule.message_for_docs,
+                "desc": rule.msg,
                 "ext_docs": rule.docs,
                 "version": rule.supported_version,
                 "params": [

--- a/docs/external_rules.rst
+++ b/docs/external_rules.rst
@@ -87,9 +87,9 @@ When defining rule messages you can use `jinja` templates. The most basic usage 
         )
     }
 
-Variables needs to be passed as kwargs to report() method::
+Variables need to be passed by name to report() method::
 
-    self.report("my-rule", variable="some string", "number"=10, node=node)
+    self.report("my-rule", variable="some string", number=10, node=node)
 
 
 Import from external module

--- a/docs/external_rules.rst
+++ b/docs/external_rules.rst
@@ -35,10 +35,12 @@ This is an example of the file with custom checker that asserts that no test hav
             if 'Dummy' in node.name:
                 self.report("dummy-in-name", node=node, col=node.name.find('Dummy'))
 
+Rule parameters
+---------------
 Rules can have configurable values. You need to specify them using RuleParam class and pass it as not named arg to Rule::
 
     from robocop.checkers import VisitorChecker
-    from robocop.rules import Rule, RuleParam
+    from robocop.rules import Rule, RuleParam, RuleSeverity
 
 
     rules = {
@@ -46,8 +48,8 @@ Rules can have configurable values. You need to specify them using RuleParam cla
             RuleParam(name="param_name", converter=str, default="Dummy", desc="Optional desc"),
             rule_id="9999",
             name="dummy-in-name",
-            msg="There is '%s' in test case name",
-            severity="W"
+            msg="There is '{{ variable }}' in test case name",
+            severity=RuleSeverity.WARNING,
         )
     }
 
@@ -59,7 +61,7 @@ Rules can have configurable values. You need to specify them using RuleParam cla
             if self.private_name in node.name:
                 self.report(
                     "dummy-in-name",
-                    self.param("dummy-in-name", "param_name"),
+                    variable=self.param("dummy-in-name", "param_name"),
                     node=node,
                     col=node.name.find(self.param("dummy-in-name", "param_name")))
 
@@ -70,6 +72,25 @@ Configurable parameter can be referred by its :code:`name` in command line optio
 Value of the configurable parameter can be retrieved using :code:`param` method::
 
     self.param("name-of-the-rule", "name-of-param")
+
+Templated rule messages
+------------------------
+When defining rule messages you can use `jinja` templates. The most basic usage is supplying variables to rule message::
+
+    rules = {
+        "9001": Rule(
+            rule_id="9001",
+            name="my-rule",
+            msg="You can supply variables like {{ variable }} or {{ number }}. "
+                "Basic {% if number==10 %}jinja {% endif %}syntax supported",
+            severity=RuleSeverity.ERROR
+        )
+    }
+
+Variables needs to be passed as kwargs to report() method::
+
+    self.report("my-rule", variable="some string", "number"=10, node=node)
+
 
 Import from external module
 ----------------------------
@@ -88,11 +109,11 @@ inside ``__init__.py``::
 inside ``some_rules.py``::
 
     from robocop.checkers import VisitorChecker
-    from robocop.rules import Rule
+    from robocop.rules import Rule, RuleSeverity
 
 
     rules = {
-        "9903": Rule(rule_id="9903", name="external-rule", msg="This is an external rule", severity="I")
+        "9903": Rule(rule_id="9903", name="external-rule", msg="This is an external rule", severity=RuleSeverity.INFO)
     }
 
 
@@ -118,7 +139,7 @@ external rules using modules and `__init__.py` it should be also imported (or de
 You can enable (or disable) your rule for particular Robot Framework version. Add `version` parameter to Rule definition::
 
     rules = {
-        "9903": Rule(rule_id="9903", name="external-rule", msg="This is external rule", severity="I", version=">=5.0")
+        "9903": Rule(rule_id="9903", name="external-rule", msg="This is external rule", severity=RuleSeverity.INFO, version=">=5.0")
     }
 
 In this case rule "external-rule" will be disabled for all Robot Framework versions except 5.0 and newer.

--- a/docs/external_rules.rst
+++ b/docs/external_rules.rst
@@ -87,7 +87,7 @@ When defining rule messages you can use `jinja` templates. The most basic usage 
         )
     }
 
-Variables need to be passed by name to report() method::
+Variables need to be passed to report() method by their name::
 
     self.report("my-rule", variable="some string", number=10, node=node)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 sphinx-rtd-theme
 robotframework>=4.0
 toml>=0.10.2
+packaging==21.*
+pathspec==0.9.*

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ robotframework>=4.0
 toml>=0.10.2
 packaging==21.*
 pathspec==0.9.*
+jinja2~=3.0

--- a/robocop/checkers/__init__.py
+++ b/robocop/checkers/__init__.py
@@ -63,18 +63,17 @@ class BaseChecker:
     def report(
         self,
         rule,
-        *args,
         node=None,
         lineno=None,
         col=None,
         end_lineno=None,
         end_col=None,
         ext_disablers=None,
+        **kwargs,
     ):
         if rule not in self.rules:
             raise ValueError(f"Missing definition for message with name {rule}")
         message = self.rules[rule].prepare_message(
-            *args,
             source=self.source,
             node=node,
             lineno=lineno,
@@ -82,6 +81,7 @@ class BaseChecker:
             end_lineno=end_lineno,
             end_col=end_col,
             ext_disablers=ext_disablers,
+            **kwargs,
         )
         if message.enabled:
             self.issues.append(message)

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -22,7 +22,6 @@ rules = {
             # fixme 
         
         """,
-        docs_args=("TODO or FIXME statement",),
     ),
     "0702": Rule(
         rule_id="0702",

--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -13,7 +13,7 @@ rules = {
     "0701": Rule(
         rule_id="0701",
         name="todo-in-comment",
-        msg="Found %s in comment",
+        msg="Found {{ todo_or_fixme }} in comment",
         severity=RuleSeverity.WARNING,
         docs="""
         Example::
@@ -196,14 +196,14 @@ class CommentChecker(VisitorChecker):
         if "todo" in token.value.lower():
             self.report(
                 "todo-in-comment",
-                "TODO",
+                todo_or_fixme="TODO",
                 lineno=token.lineno,
                 col=token.col_offset + 1 + token.value.lower().find("todo"),
             )
         if "fixme" in token.value.lower():
             self.report(
                 "todo-in-comment",
-                "FIXME",
+                todo_or_fixme="FIXME",
                 lineno=token.lineno,
                 col=token.col_offset + 1 + token.value.lower().find("fixme"),
             )

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -35,7 +35,7 @@ rules = {
     "0801": Rule(
         rule_id="0801",
         name="duplicated-test-case",
-        msg='Multiple test cases with name "%s" (first occurrence in line %d)',
+        msg='Multiple test cases with name "{{ name }}" (first occurrence in line {{ first_occurrence_line }})',
         severity=RuleSeverity.ERROR,
         docs="""
         It is not allowed to reuse the same name of the test case within the same suite in Robot Framework. 
@@ -53,47 +53,50 @@ rules = {
     "0802": Rule(
         rule_id="0802",
         name="duplicated-keyword",
-        msg='Multiple keywords with name "%s" (first occurrence in line %d)',
+        msg='Multiple keywords with name "{{ name }}" (first occurrence in line {{ first_occurrence_line }})',
         severity=RuleSeverity.ERROR,
     ),
     "0803": Rule(
         rule_id="0803",
         name="duplicated-variable",
-        msg='Multiple variables with name "%s" in Variables section (first occurrence in line %d). '
+        msg='Multiple variables with name "{{ name }}" in Variables section (first occurrence in line '
+        "{{ first_occurrence_line }}). "
         "Note that Robot Framework is case-insensitive",
         severity=RuleSeverity.ERROR,
     ),
     "0804": Rule(
         rule_id="0804",
         name="duplicated-resource",
-        msg='Multiple resource imports with path "%s" (first occurrence in line %d)',
+        msg='Multiple resource imports with path "{{ name }}" (first occurrence in line {{ first_occurrence_line }})',
         severity=RuleSeverity.WARNING,
     ),
     "0805": Rule(
         rule_id="0805",
         name="duplicated-library",
-        msg='Multiple library imports with name "%s" and identical arguments (first occurrence in line %d)',
+        msg='Multiple library imports with name "{{ name }}" and identical arguments (first occurrence in line '
+        "{{ first_occurrence_line }})",
         severity=RuleSeverity.WARNING,
     ),
     "0806": Rule(
         rule_id="0806",
         name="duplicated-metadata",
-        msg='Duplicated metadata "%s" (first occurrence in line %d)',
+        msg='Duplicated metadata "{{ name }}" (first occurrence in line {{ first_occurrence_line }})',
         severity=RuleSeverity.WARNING,
     ),
     "0807": Rule(
         rule_id="0807",
         name="duplicated-variables-import",
-        msg='Duplicated variables import with path "%s" (first occurrence in line %d)',
+        msg='Duplicated variables import with path "{{ name }}" (first occurrence in line {{ first_occurrence_line }})',
         severity=RuleSeverity.WARNING,
     ),
     "0808": Rule(
         rule_id="0808",
         name="section-already-defined",
-        msg="'%s' section header already defined in file",
+        msg="'{{ section_name }}' section header already defined in file",
         severity=RuleSeverity.WARNING,
         docs="""
-        Duplicated section in the file. Robot Framework will handle repeated sections but it is recommended to not duplicate them.
+        Duplicated section in the file. Robot Framework will handle repeated sections but it is recommended to not 
+        duplicate them.
         
         Example::
         
@@ -120,7 +123,7 @@ rules = {
         ),
         rule_id="0809",
         name="section-out-of-order",
-        msg="'%s' section header is defined in wrong order: %s",
+        msg="'{{ section_name }}' section header is defined in wrong order: {{ recommended_order }}",
         severity=RuleSeverity.WARNING,
         docs="""
         Sections should be defined in order set by `sections_order` 
@@ -160,13 +163,13 @@ rules = {
     "0811": Rule(
         rule_id="0811",
         name="duplicated-argument-name",
-        msg="Argument name '%s' is already used",
+        msg="Argument name '{{ argument_name }}' is already used",
         severity=RuleSeverity.ERROR,
     ),
     "0812": Rule(
         rule_id="0812",
         name="duplicated-assigned-var-name",
-        msg="Assigned variable name '%s' is already used",
+        msg="Assigned variable name '{{ variable_name }}' is already used",
         severity=RuleSeverity.INFO,
     ),
 }
@@ -217,7 +220,7 @@ class DuplicationsChecker(VisitorChecker):
     def check_duplicates(self, container, rule):
         for nodes in container.values():
             for duplicate in nodes[1:]:
-                self.report(rule, duplicate.name, nodes[0].lineno, node=duplicate)
+                self.report(rule, name=duplicate.name, first_occurrence_line=nodes[0].lineno, node=duplicate)
 
     def visit_TestCase(self, node):  # noqa
         testcase_name = normalize_robot_name(node.name)
@@ -237,7 +240,7 @@ class DuplicationsChecker(VisitorChecker):
             if name in seen:
                 self.report(
                     "duplicated-assigned-var-name",
-                    var.value,
+                    variable_name=var.value,
                     node=node,
                     lineno=var.lineno,
                     col=var.col_offset + 1,
@@ -291,7 +294,7 @@ class DuplicationsChecker(VisitorChecker):
             if name in args:
                 self.report(
                     "duplicated-argument-name",
-                    orig,
+                    argument_name=orig,
                     node=node,
                     lineno=arg.lineno,
                     col=arg.col_offset + 1,
@@ -350,12 +353,12 @@ class SectionHeadersChecker(VisitorChecker):
                     self.report("both-tests-and-tasks", node=node)
         order_id = self.param("section-out-of-order", "sections_order")[section_name]
         if section_name in self.sections_by_existence:
-            self.report("section-already-defined", node.data_tokens[0].value, node=node)
+            self.report("section-already-defined", section_name=node.data_tokens[0].value, node=node)
         if any(previous_id > order_id for previous_id in self.sections_by_order):
             self.report(
                 "section-out-of-order",
-                node.data_tokens[0].value,
-                self.section_order_to_str(self.param("section-out-of-order", "sections_order")),
+                section_name=node.data_tokens[0].value,
+                recommended_order=self.section_order_to_str(self.param("section-out-of-order", "sections_order")),
                 node=node,
             )
         self.sections_by_order.append(order_id)

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -61,7 +61,7 @@ rules = {
         severity=RuleSeverity.WARNING,
     ),
     "0508": Rule(
-        RuleParam(name="line_length", default=120, converter=int, desc="number of lines allowed in a file"),  # FIXME
+        RuleParam(name="line_length", default=120, converter=int, desc="number of characters allowed in line"),
         RuleParam(
             name="ignore_pattern",
             default=re.compile(r"https?://\S+"),

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -17,10 +17,6 @@ rules = {
         name="too-long-keyword",
         msg="Keyword is too long ({{ keyword_length }}/{{ allowed_length}})",
         severity=RuleSeverity.WARNING,
-        docs_args=(
-            "keyword length",
-            "allowed length",
-        ),
     ),
     "0502": Rule(
         RuleParam(name="min_calls", default=1, converter=int, desc="number of keyword calls required in a keyword"),

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -73,7 +73,7 @@ rules = {
     "0908": Rule(
         rule_id="0908",
         name="if-can-be-used",
-        msg="'%s' can be replaced with IF block since Robot Framework 4.0",
+        msg="'{{ run_keyword }}' can be replaced with IF block since Robot Framework 4.0",
         severity=RuleSeverity.INFO,
         version=">=4.0",
     ),
@@ -87,7 +87,8 @@ rules = {
         ),
         rule_id="0909",
         name="inconsistent-assignment",
-        msg="The assignment sign is not consistent within the file. Expected '%s' but got '%s' instead",
+        msg="The assignment sign is not consistent within the file. Expected '{{ expected_sign }}' "
+        "but got '{{ actual_sign }}' instead",
         severity=RuleSeverity.WARNING,
     ),
     "0910": Rule(
@@ -100,13 +101,14 @@ rules = {
         ),
         rule_id="0910",
         name="inconsistent-assignment-in-variables",
-        msg="The assignment sign is not consistent inside the variables section. Expected '%s' but got '%s' instead",
+        msg="The assignment sign is not consistent inside the variables section. Expected '{{ expected_sign }}' "
+        "but got '{{ actual_sign }}' instead",
         severity=RuleSeverity.WARNING,
     ),
     "0911": Rule(
         rule_id="0911",
         name="wrong-import-order",
-        msg="BuiltIn library import '%s' should be placed before '%s'",
+        msg="BuiltIn library import '{{ builtin_import }}' should be placed before '{{ custom_import }}'",
         severity=RuleSeverity.WARNING,
     ),
     "0912": Rule(
@@ -118,7 +120,7 @@ rules = {
     "0913": Rule(
         rule_id="0913",
         name="can-be-resource-file",
-        msg="No tests in '%s' file, consider renaming to '%s.resource'",
+        msg="No tests in '{{ file_name }}' file, consider renaming to '{{ file_name_stem }}.resource'",
         severity=RuleSeverity.INFO,
     ),
 }
@@ -192,7 +194,7 @@ class IfBlockCanBeUsed(VisitorChecker):
                 if token.type == Token.KEYWORD:
                     col = token.col_offset + 1
                     break
-            self.report("if-can-be-used", node.keyword, node=node, col=col)
+            self.report("if-can-be-used", run_keyword=node.keyword, node=node, col=col)
 
 
 class ConsistentAssignmentSignChecker(VisitorChecker):
@@ -266,8 +268,8 @@ class ConsistentAssignmentSignChecker(VisitorChecker):
         if sign != expected:
             self.report(
                 issue_name,
-                expected,
-                sign,
+                expected_sign=expected,
+                actual_sign=sign,
                 lineno=token.lineno,
                 col=token.end_col_offset + 1,
             )
@@ -303,8 +305,8 @@ class SettingsOrderChecker(VisitorChecker):
                 if library.name in STDLIBS:
                     self.report(
                         "wrong-import-order",
-                        library.name,
-                        first_non_builtin,
+                        builtin_import=library.name,
+                        custom_import=first_non_builtin,
                         node=library,
                     )
 
@@ -354,4 +356,4 @@ class ResourceFileChecker(VisitorChecker):
                 and node.sections
                 and not any([isinstance(section, TestCaseSection) for section in node.sections])
             ):
-                self.report("can-be-resource-file", Path(source).name, file_name, node=node)
+                self.report("can-be-resource-file", file_name=Path(source).name, file_name_stem=file_name, node=node)

--- a/robocop/checkers/tags.py
+++ b/robocop/checkers/tags.py
@@ -27,7 +27,8 @@ rules = {
     "0605": Rule(
         rule_id="0605",
         name="could-be-forced-tags",
-        msg='All tests in suite share those tags: "%s". You can define them in Force Tags in suite settings instead',
+        msg='All tests in suite share those tags: "{{ tags }}". '
+        "You can define them in Force Tags in suite settings instead",
         severity=RuleSeverity.INFO,
     ),
     "0606": Rule(
@@ -43,7 +44,10 @@ rules = {
         severity=RuleSeverity.INFO,
     ),
     "0608": Rule(
-        rule_id="0608", name="empty-tags", msg="[Tags] setting without values%s", severity=RuleSeverity.WARNING
+        rule_id="0608",
+        name="empty-tags",
+        msg="[Tags] setting without values{{ optional_warning }}",
+        severity=RuleSeverity.WARNING,
     ),
 }
 
@@ -152,7 +156,7 @@ class TagScopeChecker(VisitorChecker):
         if common_tags:
             self.report(
                 "could-be-forced-tags",
-                ", ".join(common_tags),
+                tags=", ".join(common_tags),
                 node=node if self.force_tags_node is None else self.force_tags_node,
             )
 
@@ -176,7 +180,7 @@ class TagScopeChecker(VisitorChecker):
     def visit_Tags(self, node):  # noqa
         if not node.values:
             suffix = "" if self.in_keywords else ". Consider using NONE if you want to overwrite the Default Tags"
-            self.report("empty-tags", suffix, node=node, col=node.end_col_offset)
+            self.report("empty-tags", optional_warning=suffix, node=node, col=node.end_col_offset)
         self.tags.append([tag.value for tag in node.data_tokens[1:]])
         for tag in node.data_tokens[1:]:
             if tag.value in self.force_tags:

--- a/robocop/checkers/tags.py
+++ b/robocop/checkers/tags.py
@@ -27,8 +27,8 @@ rules = {
     "0605": Rule(
         rule_id="0605",
         name="could-be-forced-tags",
-        msg='All tests in suite share those tags: "{{ tags }}". '
-        "You can define them in Force Tags in suite settings instead",
+        msg='All tests in suite share these tags: "{{ tags }}". '
+        "You can define them in 'Force Tags' in suite settings instead",
         severity=RuleSeverity.INFO,
     ),
     "0606": Rule(

--- a/robocop/exceptions.py
+++ b/robocop/exceptions.py
@@ -6,12 +6,6 @@ class ConfigGeneralError(RobocopFatalError):
     pass
 
 
-class InvalidRuleUsageError(RobocopFatalError):
-    def __init__(self, rule_id, type_error):
-        msg = f"Fatal error: Rule '{rule_id}' failed to prepare message description with error: {type_error}"
-        super().__init__(msg)
-
-
 class InvalidExternalCheckerError(RobocopFatalError):
     def __init__(self, path):
         msg = f'Fatal error: Failed to load external rules from file "{path}". Verify if the file exists'

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -182,7 +182,7 @@ class Rule:
 
     @staticmethod
     def get_template(msg: str) -> Optional[Template]:
-        if "{{" in msg:
+        if "{" in msg:
             return Template(msg)
         return None
 

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -143,7 +143,6 @@ class Rule:
         severity: RuleSeverity,
         version: str = None,
         docs: str = "",
-        docs_args: Optional[Tuple[str, ...]] = None,
     ):
         """
         :param params: RuleParam() instances
@@ -153,7 +152,6 @@ class Rule:
         :param severity: severity of the rule (ie: RuleSeverity.INFO)
         :param version: supported Robot Framework version (ie: >=4.0)
         :param docs: Full documentation of the rule (rst supported)
-        :param docs_args: Arguments used to replace %d,%s placeholders in rule message. Useful to have human readable
         description of the rule
         """
         self.rule_id = rule_id
@@ -161,7 +159,6 @@ class Rule:
         self.msg = msg
         self.msg_template = self.get_template(msg)
         self.docs = dedent(docs)
-        self.docs_args = docs_args
         self.config = {
             "severity": RuleParam(
                 "severity", severity, RuleSeverity.parser, "Rule severity (E = Error, W = Warning, I = Info)"
@@ -177,13 +174,6 @@ class Rule:
     def severity(self):
         return self.config["severity"].value
 
-    @property
-    def message_for_docs(self):
-        if self.docs_args:
-            msg = self.msg.replace("%d", "%s")
-            return msg % self.docs_args
-        return self.msg
-
     @staticmethod
     def supported_in_rf_version(version: str) -> bool:
         if not version:
@@ -197,17 +187,13 @@ class Rule:
         return None
 
     def get_message(self, **kwargs):
-        # try:  # TODO
-        #     self.desc %= args
-        # except TypeError as err:
-        #     raise robocop.exceptions.InvalidRuleUsageError(rule.rule_id, err)
         if self.msg_template:
             return self.msg_template.render(**kwargs)
         return self.msg
 
     def __str__(self):
         return (
-            f"Rule - {self.rule_id} [{self.config['severity'].value}]: {self.name}: {self.message_for_docs} "
+            f"Rule - {self.rule_id} [{self.config['severity'].value}]: {self.name}: {self.msg} "
             f"({self.get_enabled_status_desc()})"
         )
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     keywords=KEYWORDS,
     packages=["robocop"],
     include_package_data=True,
-    install_requires=["robotframework>=3.2.2", "toml>=0.10.2", "packaging==21.*", "pathspec==0.9.*"],
+    install_requires=["robotframework>=3.2.2", "toml>=0.10.2", "packaging==21.*", "pathspec==0.9.*", "jinja2~=3.0"],
     extras_requires={
         "dev": ["pytest", "pytest-benchmark", "pyyaml", "tox", "black"],
         "doc": ["sphinx", "sphinx_rtd_theme"],

--- a/tests/atest/rules/tags/could-be-forced-tags/expected_output.txt
+++ b/tests/atest/rules/tags/could-be-forced-tags/expected_output.txt
@@ -1,1 +1,1 @@
-${rules_dir}${\}test.robot:1:1 [I] 0605 All tests in suite share those tags: "sometag". You can define them in Force Tags in suite settings instead
+${rules_dir}${\}test.robot:1:1 [I] 0605 All tests in suite share these tags: "sometag". You can define them in 'Force Tags' in suite settings instead

--- a/tests/test_data/ext_rule_module/RobocopRules/__init__.py
+++ b/tests/test_data/ext_rule_module/RobocopRules/__init__.py
@@ -1,4 +1,11 @@
 from .some_rules import CustomRuleChecker
 from robocop.rules import Rule, RuleSeverity
 
-rules = {"9903": Rule(rule_id="9903", name="external-rule", msg="This is external rule", severity=RuleSeverity.INFO)}
+rules = {
+    "9903": Rule(
+        rule_id="9903",
+        name="external-rule",
+        msg="This is external rule with {{ parameter }} in msg",
+        severity=RuleSeverity.INFO,
+    )
+}

--- a/tests/utest/test_api.py
+++ b/tests/utest/test_api.py
@@ -90,6 +90,7 @@ class TestAPI:
         issues = [
             Message(
                 rule=rule,
+                msg=rule.get_message(),
                 source=r"C:\directory\file.robot",
                 node=None,
                 lineno=10,
@@ -99,6 +100,7 @@ class TestAPI:
             ),
             Message(
                 rule=rule,
+                msg=rule.get_message(),
                 source=r"C:\directory\file.robot",
                 node=None,
                 lineno=1,

--- a/tests/utest/test_disablers.py
+++ b/tests/utest/test_disablers.py
@@ -19,6 +19,7 @@ def message():
     )
     return Message(
         rule=rule,
+        msg=rule.get_message(),
         source=None,
         node=None,
         lineno=None,

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -80,7 +80,9 @@ def msg_0102_0204():
 @pytest.fixture
 def msg_disabled_for_4():
     return {
-        "9999": Rule(rule_id="9999", name="disabled-in-four", msg="This is desc", severity=RuleSeverity.WARNING, version="<4.0")
+        "9999": Rule(
+            rule_id="9999", name="disabled-in-four", msg="This is desc", severity=RuleSeverity.WARNING, version="<4.0"
+        )
     }
 
 
@@ -124,7 +126,7 @@ class TestListingRules:
         out, _ = capsys.readouterr()
         assert (
             out == "Rule - 0101 [W]: some-message: Some description (disabled)\n"
-                   f"Rule - 9999 [W]: disabled-in-four: This is desc ({enabled_for})\n\n"
+            f"Rule - 9999 [W]: disabled-in-four: This is desc ({enabled_for})\n\n"
             "Altogether 2 rule(s) with following severity:\n"
             "    0 error rule(s),\n"
             "    2 warning rule(s),\n"

--- a/tests/utest/test_reports.py
+++ b/tests/utest/test_reports.py
@@ -20,6 +20,7 @@ class TestReports:
         report = JsonReport()
         issue = Message(
             rule=message,
+            msg=message.get_message(),
             source="some/path/file.robot",
             node=None,
             lineno=50,
@@ -57,6 +58,7 @@ class TestReports:
         if files_with_issues:
             issue = Message(
                 rule=message,
+                msg=message.get_message(),
                 source="some/path/file.robot",
                 node=None,
                 lineno=50,

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = rf3, rf4
 skip_missing_interpreters = true
 [pytest]
-addopts = --benchmark-skip
+addopts = --benchmark-skip --lf
 [testenv]
 commands = pytest tests
 [testenv:rf3]

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,8 @@ deps =
     sphinx-rtd-theme
     robotframework>=4.0
     toml>=0.10.2
+    packaging==21.*
+    pathspec==0.9.*
 commands =
     sphinx-build -b html docs docs/_build/
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     toml
     robotframework==3.2.2
     pathspec
+    jinja2~=3.0
 [testenv:rf4]
 deps =
     pytest
@@ -21,6 +22,7 @@ deps =
     toml
     robotframework==4.1.1
     pathspec
+    jinja2~=3.0
 [testenv:coverage]
 deps =
     pytest
@@ -29,6 +31,7 @@ deps =
     toml
     robotframework
     coverage
+    jinja2~=3.0
 commands =
     coverage run -m pytest
     coverage html
@@ -40,6 +43,7 @@ deps =
     toml>=0.10.2
     packaging==21.*
     pathspec==0.9.*
+    jinja2~=3.0
 commands =
     sphinx-build -b html docs docs/_build/
 


### PR DESCRIPTION
Closes #534 

Accidentally while implementing it it became a lot more powerful than before: you can use full jinja2 syntax (if/for blocks, filtering etc) inside rule messages. But most important benefit for us is improved readiblity over raw '%s' formatters or newly introduced `docs_args` which were not straightforward to use.

When displayed in docs/`--list` output it will look like this:
![image](https://user-images.githubusercontent.com/8532066/140307892-0e6bfc34-544b-47b3-8b49-6baa213ba587.png)
