### PR TITLE
Fix Robocop failing to parse Keywords using Run Keyword names

### DIFF
--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -16,7 +16,7 @@ from robot.libraries import STDLIBS
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import ROBOT_VERSION, AssignmentTypeDetector, normalize_robot_name, parse_assignment_sign_type
+from robocop.utils import ROBOT_VERSION, AssignmentTypeDetector, normalize_robot_name, parse_assignment_sign_type, keyword_col
 
 rules = {
     "0901": Rule(
@@ -186,12 +186,8 @@ class IfBlockCanBeUsed(VisitorChecker):
     def visit_KeywordCall(self, node):  # noqa
         if not node.keyword:
             return
-        if normalize_robot_name(node.keyword) in self.run_keyword_variants:
-            col = 0
-            for token in node.data_tokens:
-                if token.type == Token.KEYWORD:
-                    col = token.col_offset + 1
-                    break
+        if normalize_robot_name(node.keyword, remove_prefix='builtin.') in self.run_keyword_variants:
+            col = keyword_col(node)
             self.report("if-can-be-used", node.keyword, node=node, col=col)
 
 

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -298,7 +298,7 @@ class KeywordNamingChecker(VisitorChecker):
             return False
         reserved_type = reserved[keyword_name.lower()]
         suffix = self.prepare_reserved_word_rule_message(keyword_name, reserved_type)
-        self.report("keyword-name-is-reserved-word", keyword_name=keyword_name, error_msg=ssuffix, node=node, col=keyword_col(node))
+        self.report("keyword-name-is-reserved-word", keyword_name=keyword_name, error_msg=suffix, node=node, col=keyword_col(node))
         return True
 
     @staticmethod

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -259,7 +259,7 @@ class KeywordNamingChecker(VisitorChecker):
             return
         if keyword_name == r"/":  # old for loop, / are interpreted as keywords
             return
-        if normalize_robot_name(keyword_name) == "runkeywordif":
+        if isinstance(node, KeywordCall) and normalize_robot_name(keyword_name, remove_prefix="builtin.") == "runkeywordif":
             for token in node.data_tokens:
                 if (token.value.lower() in self.else_if) and not token.value.isupper():
                     self.report(
@@ -267,6 +267,7 @@ class KeywordNamingChecker(VisitorChecker):
                         token.value,
                         self.prepare_reserved_word_rule_message(token.value, "Run Keyword If"),
                         node=node,
+                        col=token.col_offset+1,
                     )
         elif self.check_if_keyword_is_reserved(keyword_name, node):
             return
@@ -297,7 +298,7 @@ class KeywordNamingChecker(VisitorChecker):
             return False
         reserved_type = reserved[keyword_name.lower()]
         suffix = self.prepare_reserved_word_rule_message(keyword_name, reserved_type)
-        self.report("keyword-name-is-reserved-word", keyword_name, suffix, node=node)
+        self.report("keyword-name-is-reserved-word", keyword_name, suffix, node=node, col=keyword_col(node))
         return True
 
     @staticmethod
@@ -454,7 +455,7 @@ class VariableNamingChecker(VisitorChecker):
 
         if not node.keyword:
             return
-        if normalize_robot_name(node.keyword) in self.set_variable_variants:
+        if normalize_robot_name(node.keyword, remove_prefix='builtin.') in self.set_variable_variants:
             if len(node.data_tokens) < 2:
                 return
             token = node.data_tokens[1]

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -5,7 +5,7 @@ import re
 from collections import Counter, defaultdict
 from importlib import import_module
 from pathlib import Path
-from typing import Pattern, List, Tuple, Dict
+from typing import Pattern, List, Tuple, Dict, Optional
 
 from robot.api import Token
 from robot.parsing.model.statements import EmptyLine
@@ -69,9 +69,11 @@ def modules_from_path(path, module_name=None, relative="."):
                 yield from modules_from_path(file, module_name, relative)
 
 
-def normalize_robot_name(name: str) -> str:
-    return name.replace(" ", "").replace("_", "").lower() if name else ""
-
+def normalize_robot_name(name: str, remove_prefix: Optional[str] = None) -> str:
+    name = name.replace(" ", "").replace("_", "").lower() if name else ""
+    if remove_prefix:
+        return name[name.startswith(remove_prefix) and len(remove_prefix):]
+    return name
 
 def normalize_robot_var_name(name: str) -> str:
     return normalize_robot_name(name)[2:-1] if name else ""

--- a/tests/atest/rules/misc/if-can-be-used/expected_output.txt
+++ b/tests/atest/rules/misc/if-can-be-used/expected_output.txt
@@ -1,3 +1,4 @@
 ${rules_dir}${\}test.robot:8:5 [I] 0908 'Run Keyword If' can be replaced with IF block since Robot Framework 4.0
 ${rules_dir}${\}test.robot:19:15 [I] 0908 'Run Keyword If' can be replaced with IF block since Robot Framework 4.0
 ${rules_dir}${\}test.robot:20:5 [I] 0908 'Run Keyword Unless' can be replaced with IF block since Robot Framework 4.0
+${rules_dir}${\}test.robot:21:5 [I] 0908 'BuiltIn.Run Keyword If' can be replaced with IF block since Robot Framework 4.0

--- a/tests/atest/rules/misc/if-can-be-used/test.robot
+++ b/tests/atest/rules/misc/if-can-be-used/test.robot
@@ -18,3 +18,4 @@ Keyword
     # comment with runkeywordif
     ${var}    Run Keyword If    ${condition}    Keyword
     Run Keyword Unless    ${condition}    Keyword2
+    BuiltIn.Run Keyword If  ${stuff}  Keyword

--- a/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output.txt
+++ b/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output.txt
@@ -1,7 +1,8 @@
-${rules_dir}${\}if_blocks.robot:8:1 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}if_blocks.robot:13:1 [E] 0303 'END' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}if_blocks.robot:20:1 [E] 0303 'END' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}if_blocks.robot:24:1 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:20:1 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:21:1 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:23:1 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}if_blocks.robot:8:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}if_blocks.robot:13:5 [E] 0303 'END' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}if_blocks.robot:20:5 [E] 0303 'END' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}if_blocks.robot:24:9 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:20:5 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:21:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:23:10 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:28:67 [E] 0303 'else if' is a reserved keyword. It must be in uppercase (ELSE IF) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.

--- a/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf4.txt
+++ b/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf4.txt
@@ -1,6 +1,7 @@
-${rules_dir}${\}if_blocks.robot:4:1 [E] 0303 'If' is a reserved keyword
-${rules_dir}${\}if_blocks.robot:8:1 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop or if'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}if_blocks.robot:24:1 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop or if'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:20:1 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:21:1 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop or if'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:23:1 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}if_blocks.robot:4:5 [E] 0303 'If' is a reserved keyword
+${rules_dir}${\}if_blocks.robot:8:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop or if'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}if_blocks.robot:24:9 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop or if'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:20:5 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'for loop'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:21:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'for loop or if'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:23:10 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
+${rules_dir}${\}test.robot:28:67 [E] 0303 'else if' is a reserved keyword. It must be in uppercase (ELSE IF) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.

--- a/tests/atest/rules/naming/keyword-name-is-reserved-word/test.robot
+++ b/tests/atest/rules/naming/keyword-name-is-reserved-word/test.robot
@@ -22,3 +22,7 @@ Keyword
     Fail
     Run Keyword If  ${True}  Keyword
     ...  else  Keyword2
+
+Run Keyword If
+    [Arguments]    ${name}    ${condition}    @{args}
+    BuiltIn.Run Keyword If    ${name}    ${condition}    @{args}  else if  Keyword


### PR DESCRIPTION
And other fixes:

- Robocop failed miserable if keyword definition was using `Run Keyword If` name. (Fixes #518)
- Fixed issue where rules that were checking Run Keyword If, Set Variable etc ignored keywords starting with `BuiltIn.` import statement (Fixes #519)
- location of `keyword-name-is-reserved-word` is now more precise (pointing to keyword/token location, not start of the line)