### PR TITLE
Add if-can-be-merged rule

### DIFF
--- a/tests/atest/rules/misc/if-can-be-merged/expected_output.txt
+++ b/tests/atest/rules/misc/if-can-be-merged/expected_output.txt
@@ -4,4 +4,6 @@ ${rules_dir}${\}test.robot:67:9 [I] 0914 IF statement can be merged with previou
 ${rules_dir}${\}test.robot:79:5 [I] 0914 IF statement can be merged with previous IF (defined in line 76)
 ${rules_dir}${\}test.robot:90:5 [I] 0914 IF statement can be merged with previous IF (defined in line 86)
 ${rules_dir}${\}test.robot:99:9 [I] 0914 IF statement can be merged with previous IF (defined in line 96)
-${rules_dir}${\}test.robot:158:5 [I] 0914 IF statement can be merged with previous IF (defined in line 151)
+${rules_dir}${\}test.robot:148:5 [I] 0914 IF statement can be merged with previous IF (defined in line 141)
+${rules_dir}${\}test.robot:162:5 [I] 0914 IF statement can be merged with previous IF (defined in line 157)
+${rules_dir}${\}test.robot:167:5 [I] 0914 IF statement can be merged with previous IF (defined in line 162)

--- a/tests/atest/rules/misc/if-can-be-merged/expected_output.txt
+++ b/tests/atest/rules/misc/if-can-be-merged/expected_output.txt
@@ -1,0 +1,7 @@
+${rules_dir}${\}test.robot:8:5 [I] 0914 IF statement can be merged with previous IF (defined in line 4)
+${rules_dir}${\}test.robot:50:5 [I] 0914 IF statement can be merged with previous IF (defined in line 41)
+${rules_dir}${\}test.robot:67:9 [I] 0914 IF statement can be merged with previous IF (defined in line 64)
+${rules_dir}${\}test.robot:79:5 [I] 0914 IF statement can be merged with previous IF (defined in line 76)
+${rules_dir}${\}test.robot:90:5 [I] 0914 IF statement can be merged with previous IF (defined in line 86)
+${rules_dir}${\}test.robot:99:9 [I] 0914 IF statement can be merged with previous IF (defined in line 96)
+${rules_dir}${\}test.robot:158:5 [I] 0914 IF statement can be merged with previous IF (defined in line 151)

--- a/tests/atest/rules/misc/if-can-be-merged/invalid.robot
+++ b/tests/atest/rules/misc/if-can-be-merged/invalid.robot
@@ -1,0 +1,16 @@
+*** Test Cases ***
+Missing condition
+    IF
+        Keyword
+    END
+    IF
+        Keyword
+    END
+
+Two conditions
+    IF    ${condition}    Keyword
+        Keyword
+    END
+    IF    ${condition}    Keyword
+        Keyword
+    END

--- a/tests/atest/rules/misc/if-can-be-merged/test.robot
+++ b/tests/atest/rules/misc/if-can-be-merged/test.robot
@@ -111,16 +111,6 @@ ElSE IF not adjacent
         Step 2
     END
 
-ElSE IF not adjacent
-    IF  ${condition} == 'True'
-        Step 1
-    ELSE IF  ${stuff}
-        Step 2
-    END
-    IF  ${condition} == 'True'
-        Step 2
-    END
-
 ELSE IF not adjacent similar branches
     IF  ${condition} == 'True'
         Step 1
@@ -161,4 +151,21 @@ ELSE IF adjacent
         Step 2
     ELSE
        Step 4
+    END
+
+Three identical if
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
     END

--- a/tests/atest/rules/misc/if-can-be-merged/test.robot
+++ b/tests/atest/rules/misc/if-can-be-merged/test.robot
@@ -51,7 +51,7 @@ Nested Adjacent If
         Step 2
     END
 
-Singe nested If
+Single nested If
     IF  ${condition} == 'True'
         Step 1
         IF  ${condition} == 'True'

--- a/tests/atest/rules/misc/if-can-be-merged/test.robot
+++ b/tests/atest/rules/misc/if-can-be-merged/test.robot
@@ -1,0 +1,164 @@
+*** Test Cases ***
+Adjacent IF
+    No Operation
+    IF  ${condition} == 'True'
+        Step 1
+    END
+    # comment
+    IF  ${condition} == 'True'
+        Step 2
+    END
+
+Not adjacent
+    IF  ${condition} == 'True'
+        Step 1
+    END
+    No Operation
+    IF  ${condition} == 'True'
+        Step 2
+    END
+
+Different conditions
+    IF  ${condition} == 'True'
+        Step 1
+    END
+    IF  ${condition} == 'False'
+        Step 2
+    END
+
+Mixed conditions
+    IF  ${condition} == 'True'
+        Step 1
+    END
+    IF  ${condition} == 'False'
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 3
+    END
+
+Nested Adjacent If
+    IF  ${condition} == 'True'
+        Step 1
+        IF  ${STUFF}
+            Log  Oh!
+        END
+    END
+
+
+
+    IF  ${condition} == 'True'
+        Step 2
+    END
+
+Singe nested If
+    IF  ${condition} == 'True'
+        Step 1
+        IF  ${condition} == 'True'
+            Log  Oh!
+        END
+    END
+
+Adjacent inside for loop
+    FOR  ${value}  IN RANGE  10
+        IF  ${value}==${5}
+            Log    ${value}
+        END
+        IF  ${value}==${5}
+            Log    ${value}
+        END
+    END
+    IF  ${value}==${5}
+        Log    ${value}
+    END
+
+Adjacent but with comment
+    IF  ${condition} == 'True'
+        Step 1
+    END
+    IF  ${condition} == 'True'  # comment
+        Step 2
+    END
+
+*** Keywords ***
+Adjacent IF
+    No Operation
+    IF  ${condition} == 'True'
+        Step 1
+    END
+    # comment
+    IF  ${condition} == 'True'
+        Step 2
+    END
+
+Adjacent inside IF
+    IF  ${condition} == 'True'
+        IF  ${condition} == 'True'
+            Step 1
+        END
+        IF  ${condition} == 'True'
+            Step 2
+        END
+    END
+
+ElSE IF not adjacent
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 2
+    END
+
+ElSE IF not adjacent
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 2
+    END
+
+ELSE IF not adjacent similar branches
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff2}
+        Step 2
+    END
+
+ELSE IF not adjacent similar branches 2
+    IF  ${condition} == 'True'
+        Step 1  ${argument}
+    ELSE IF  ${stuff}
+        Step 2
+    END
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    ELSE
+       Step 3
+    END
+
+ELSE IF adjacent
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    ELSE
+        Step 3
+    END
+    IF  ${condition} == 'True'
+        Step 1
+    ELSE IF  ${stuff}
+        Step 2
+    ELSE
+       Step 4
+    END

--- a/tests/atest/test_rule.py
+++ b/tests/atest/test_rule.py
@@ -19,6 +19,7 @@ support_matrix = {
     "invalid-for-loop": SpecifierSet(">=4.0"),
     "not-enough-whitespace-after-variable": SpecifierSet(">=4.0"),
     "suite-setting-should-be-left-aligned": SpecifierSet(">=4.0"),
+    "if-can-be-merged": SpecifierSet(">=4.0")
 }
 
 


### PR DESCRIPTION
Closes #441

It's missing code for ignoring if with errors In else if branches (ie missing condition) but it's simple to implement - I will update PR later. 