### PR TITLE
Add statement-outside-loop rule

### DIFF
--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -7,7 +7,7 @@ from robot.api import Token
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import ROBOT_VERSION, normalize_robot_name, normalize_robot_var_name
+from robocop.utils import ROBOT_VERSION, normalize_robot_name, normalize_robot_var_name, get_errors
 
 
 def configure_sections_order(value):
@@ -308,9 +308,7 @@ class DuplicationsChecker(VisitorChecker):
         self.generic_visit(node)
 
     def visit_Variable(self, node):  # noqa
-        if not node.name or (
-            ROBOT_VERSION.major != 3 and node.errors or ROBOT_VERSION.major == 3 and node.error
-        ):  # TODO refactor
+        if not node.name or get_errors(node):
             return
         var_name = normalize_robot_name(self.replace_chars(node.name, "${}@&"))
         self.variables[var_name].append(node)

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -4,7 +4,6 @@ Errors checkers
 import re
 
 from robot.api import Token
-from robot.parsing.model.statements import EmptyLine
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleSeverity
@@ -258,6 +257,7 @@ class ParsingErrorChecker(VisitorChecker):
         "resource": "Resource",
         "variables": "Variables",
     }
+    ignore_errors = ("can only be used inside a loop",)
 
     def visit_If(self, node):  # noqa
         self.parse_errors(node)
@@ -286,6 +286,8 @@ class ParsingErrorChecker(VisitorChecker):
 
     def handle_error(self, node, error, error_index=0):  # noqa
         if not error:
+            return
+        if any(should_ignore in error for should_ignore in self.ignore_errors):
             return
         if "Invalid argument syntax" in error:
             self.handle_invalid_syntax(node, error)

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -295,7 +295,7 @@ class ParsingErrorChecker(VisitorChecker):
             self.handle_invalid_setting(node, error)
         elif "Invalid variable name" in error:
             self.handle_invalid_variable(node, error)
-        elif "IF has" in error or "ELSE IF branch" in error:
+        elif "IF" in error or "ELSE IF" in error:
             self.handle_invalid_block(node, error, "invalid-if")
         elif "FOR loop has" in error:
             self.handle_invalid_block(node, error, "invalid-for-loop")

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -252,7 +252,7 @@ rules = {
         severity=RuleSeverity.ERROR,
         version=">=5.0",
         docs="""
-        Following loop keywords and statements should only be used inside loop (``WHILE`` or ``FOR``):
+        Following keywords and statements should only be used inside loop (``WHILE`` or ``FOR``):
             - ``Exit For Loop``,
             - ``Exit For Loop If``,
             - ``Continue For Loop``,

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -22,6 +22,8 @@ from robocop.utils import (
     normalize_robot_name,
     parse_assignment_sign_type,
     keyword_col,
+    token_col,
+    get_errors,
 )
 
 rules = {
@@ -243,6 +245,23 @@ rules = {
 
         """,
     ),
+    "0915": Rule(
+        rule_id="0915",
+        name="statement-outside-loop",
+        msg="{{ name }} {{ statement_type }} used outside a loop",
+        severity=RuleSeverity.ERROR,
+        version=">=5.0",
+        docs="""
+        Following loop keywords and statements should only be used inside loop (``WHILE`` or ``FOR``):
+            - ``Exit For Loop``,
+            - ``Exit For Loop If``,
+            - ``Continue For Loop``,
+            - ``Continue For Loop If ``
+            - ``CONTINUE``,
+            - ``BREAK``
+        
+        """
+    ),
 }
 
 
@@ -369,7 +388,7 @@ class ConsistentAssignmentSignChecker(VisitorChecker):
         if self.variables_expected_sign_type is None:
             return
         for child in node.body:
-            if not isinstance(child, Variable) or getattr(child, "errors", None) or getattr(child, "error", None):
+            if not isinstance(child, Variable) or get_errors(child):
                 continue
             var_token = child.get_token(Token.VARIABLE)
             self.check_assign_type(
@@ -438,12 +457,8 @@ class EmptyVariableChecker(VisitorChecker):
     reports = ("empty-variable",)
 
     def visit_Variable(self, node):  # noqa
-        if ROBOT_VERSION.major == 3:  # TODO refactor
-            if node.error:
-                return
-        else:
-            if node.errors:
-                return
+        if get_errors(node):
+            return
         if not node.value:  # catch variable declaration without any value
             self.report("empty-variable", node=node)
         for token in node.get_tokens(Token.ARGUMENT):
@@ -486,11 +501,7 @@ class IfChecker(VisitorChecker):
     def visit_Keyword(self, node):  # noqa
         self.check_adjacent_ifs(node)
 
-    def visit_For(self, node):  # noqa
-        self.check_adjacent_ifs(node)
-
-    def visit_If(self, node):  # noqa
-        self.check_adjacent_ifs(node)
+    visit_For = visit_If = visit_Keyword  # TODO  While, Try Except?
 
     def check_adjacent_ifs(self, node):
         previous_if = None
@@ -513,6 +524,55 @@ class IfChecker(VisitorChecker):
                 return False
             if_node = if_node.orelse
             other_if_node = other_if_node.orelse
-        if if_node is None and other_if_node is None:
-            return True
-        return False
+        return if_node is None and other_if_node is None
+
+
+class LoopStatementsChecker(VisitorChecker):
+    """Checker for loop keywords and statements such as CONTINUE or Exit For Loop"""
+
+    reports = ("statement-outside-loop",)
+    for_keyword = {"continueforloop", "continueforloopif", "exitforloop", "exitforloopif"}
+
+    def __init__(self):
+        self.loops = 0
+        super().__init__()
+
+    def visit_File(self, node):  # noqa
+        self.loops = 0
+        self.generic_visit(node)
+
+    def visit_For(self, node):  # noqa
+        self.loops += 1
+        self.generic_visit(node)
+        self.loops -= 1
+
+    visit_While = visit_For
+
+    def visit_KeywordCall(self, node):  # noqa
+        if node.errors or self.loops:
+            return
+        if normalize_robot_name(node.keyword, remove_prefix="builtin.") in self.for_keyword:
+            self.report(
+                "statement-outside-loop",
+                name=f"'{node.keyword}'",
+                statement_type="keyword",
+                node=node,
+                col=keyword_col(node),
+            )
+
+    def visit_Continue(self, node):  # noqa
+        self.check_statement_in_loop(node, Token.CONTINUE)
+
+    def visit_Break(self, node):  # noqa
+        self.check_statement_in_loop(node, Token.BREAK)
+
+    def check_statement_in_loop(self, node, token_type):
+        if self.loops or node.errors and f"{token_type} can only be used inside a loop." not in node.errors:
+            return
+        self.report(
+            "statement-outside-loop",
+            name=token_type,
+            statement_type="statement",
+            node=node,
+            col=token_col(node, token_type),
+        )

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -561,10 +561,10 @@ class LoopStatementsChecker(VisitorChecker):
             )
 
     def visit_Continue(self, node):  # noqa
-        self.check_statement_in_loop(node, Token.CONTINUE)
+        self.check_statement_in_loop(node, "CONTINUE")
 
     def visit_Break(self, node):  # noqa
-        self.check_statement_in_loop(node, Token.BREAK)
+        self.check_statement_in_loop(node, "BREAK")
 
     def check_statement_in_loop(self, node, token_type):
         if self.loops or node.errors and f"{token_type} can only be used inside a loop." not in node.errors:

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -11,7 +11,7 @@ from robot.parsing.model.visitor import ModelVisitor
 
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import token_col, get_section_name
+from robocop.utils import token_col, get_section_name, get_errors
 from robocop.utils.misc import ROBOT_VERSION
 
 rules = {
@@ -726,17 +726,9 @@ class LeftAlignedChecker(VisitorChecker):
 
     def visit_SettingSection(self, node):  # noqa
         for child in node.body:
-            # suite_sett_cand = setting_error.replace(' ', '').lower()
-            # for setting in self.suite_settings:
-            #     if suite_sett_cand.startswith(setting):
-            #         if setting_error[0].strip():  # filter out "suite-setting-should-be-left-aligned"
-            if ROBOT_VERSION.major == 3:
-                if child.error and "Non-existing setting" in child.error:
-                    self.parse_error(child, child.error)
-            else:
-                for error in child.errors:
-                    if "Non-existing setting" in error:
-                        self.parse_error(child, error)
+            for error in get_errors(child):
+                if "Non-existing setting" in error:
+                    self.parse_error(child, error)
 
     def parse_error(self, node, error):
         setting_error = re.search("Non-existing setting '(.*)'.", error)

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -24,7 +24,7 @@ Available formats:
 from enum import Enum
 from textwrap import dedent
 from functools import total_ordering
-from typing import Any, Callable, Union, Pattern, Dict, Tuple, Optional
+from typing import Any, Callable, Union, Pattern, Dict, Optional
 from packaging.specifiers import SpecifierSet
 
 from jinja2 import Template
@@ -178,7 +178,7 @@ class Rule:
     def supported_in_rf_version(version: str) -> bool:
         if not version:
             return True
-        return ROBOT_VERSION in SpecifierSet(version)
+        return ROBOT_VERSION in SpecifierSet(version, prereleases=True)
 
     @staticmethod
     def get_template(msg: str) -> Optional[Template]:

--- a/robocop/utils/__init__.py
+++ b/robocop/utils/__init__.py
@@ -22,4 +22,5 @@ from robocop.utils.misc import (
     remove_robot_vars,
     token_col,
     get_section_name,
+    get_errors,
 )

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -324,3 +324,9 @@ def get_section_name(node):
         elif "HEADER" in token.type:
             return token.value
     return ""
+
+
+def get_errors(node):
+    if ROBOT_VERSION.major == 3:
+        return [node.error] if node.error else []
+    return node.errors

--- a/tests/atest/rules/errors/invalid-if/expected_output_rf5.txt
+++ b/tests/atest/rules/errors/invalid-if/expected_output_rf5.txt
@@ -1,0 +1,2 @@
+${rules_dir}${\}test.robot:14:5 [E] 0413 Invalid IF syntax: ELSE IF branch cannot be empty
+${rules_dir}${\}test.robot:14:5 [E] 0413 Invalid IF syntax: ELSE IF cannot have more than one condition

--- a/tests/atest/rules/misc/statement-outside-loop/expected_output.txt
+++ b/tests/atest/rules/misc/statement-outside-loop/expected_output.txt
@@ -1,0 +1,22 @@
+${rules_dir}${\}test.robot:3:5 [E] 0915 'Continue For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:13:5 [E] 0915 'BuiltIn.Exit For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:14:5 [E] 0915 CONTINUE statement used outside a loop
+${rules_dir}${\}test.robot:15:5 [E] 0915 BREAK statement used outside a loop
+${rules_dir}${\}test.robot:16:5 [E] 0915 'Exit For Loop If' keyword used outside a loop
+${rules_dir}${\}test.robot:17:5 [E] 0915 'Continuefor_loopIf' keyword used outside a loop
+${rules_dir}${\}test.robot:20:5 [E] 0915 'Exit For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:21:5 [E] 0915 'Continue For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:22:5 [E] 0915 CONTINUE statement used outside a loop
+${rules_dir}${\}test.robot:23:5 [E] 0915 BREAK statement used outside a loop
+${rules_dir}${\}test.robot:28:5 [E] 0915 'Continue For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:29:5 [E] 0915 CONTINUE statement used outside a loop
+${rules_dir}${\}test.robot:30:5 [E] 0915 BREAK statement used outside a loop
+${rules_dir}${\}test.robot:42:5 [E] 0915 'Exit For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:46:5 [E] 0915 'Exit For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:47:5 [E] 0915 'Continue For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:49:9 [E] 0915 CONTINUE statement used outside a loop
+${rules_dir}${\}test.robot:51:5 [E] 0915 BREAK statement used outside a loop
+${rules_dir}${\}test.robot:52:25 [E] 0915 'Exit For Loop If' keyword used outside a loop
+${rules_dir}${\}test.robot:53:5 [E] 0915 'Continuefor_loopIf' keyword used outside a loop
+${rules_dir}${\}test.robot:67:9 [E] 0915 'Continue For Loop' keyword used outside a loop
+${rules_dir}${\}test.robot:69:9 [E] 0915 BREAK statement used outside a loop

--- a/tests/atest/rules/misc/statement-outside-loop/test.robot
+++ b/tests/atest/rules/misc/statement-outside-loop/test.robot
@@ -1,0 +1,70 @@
+*** Test Cases ***
+Test
+    Continue For Loop
+    FOR    ${var}    IN RANGE    10
+        Keyword 2
+        Exit For Loop
+        Continue For Loop
+        CONTINUE
+        BREAK
+        Exit For Loop If    $condition
+        Continuefor_loopIf    $condition
+    END
+    BuiltIn.Exit For Loop
+    CONTINUE
+    BREAK
+    Exit For Loop If    $condition
+    Continuefor_loopIf    $condition
+
+Test 2
+    Exit For Loop
+    Continue For Loop
+    CONTINUE
+    BREAK
+
+
+*** Keywords ***
+Keyword
+    Continue For Loop
+    CONTINUE
+    BREAK
+    FOR    ${var}    IN RANGE    10
+        Keyword 2
+        FOR    ${var}    IN RANGE    10
+            CONTINUE
+            BREAK
+        END
+        Keyword
+        Exit For Loop
+        BREAK
+    END
+    Keyword
+    Exit For Loop
+
+Keyword 2
+    Keyword
+    Exit For Loop
+    Continue For Loop
+    IF    $condition
+        CONTINUE
+    END
+    BREAK
+    IF    $condition    Exit For Loop If    $condition
+    Continuefor_loopIf    $condition
+
+WHILE loop
+    WHILE    $condition
+        Exit For Loop
+        TRY
+            Continue For Loop
+        EXCEPT
+            BREAK
+        END
+        BREAK    value
+        CONTINUE
+    END
+    TRY
+        Continue For Loop
+    EXCEPT
+        BREAK
+    END

--- a/tests/atest/test_rule.py
+++ b/tests/atest/test_rule.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-from packaging.specifiers import SpecifierSet
 
 from robocop.config import Config
 from robocop.utils import ROBOT_VERSION

--- a/tests/packages/recent/requirements.txt
+++ b/tests/packages/recent/requirements.txt
@@ -1,1 +1,1 @@
-robotframework==4.1.3
+robotframework==5.0b1

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,15 @@ deps =
     robotframework==4.1.1
     pathspec
     jinja2~=3.0
+[testenv:rf5]
+deps =
+    pytest
+    pytest-benchmark
+    pyyaml
+    toml
+    robotframework==5.0b1
+    pathspec
+    jinja2~=3.0
 [testenv:coverage]
 deps =
     pytest
@@ -46,7 +55,6 @@ deps =
     jinja2~=3.0
 commands =
     sphinx-build -b html docs docs/_build/
-
 [testenv:benchmark]
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = rf3, rf4
+envlist = rf3, rf4, rf5
 skip_missing_interpreters = true
 [pytest]
 addopts = --benchmark-skip --lf


### PR DESCRIPTION
Closes #477 

I've decided to only support 5.0 because in 5.0 it's error. Hovewer in <=4.0 using loop keywords (like Exit For Loop) is possible so it would need to be warning instead. It's not possible to have two different severities depending on version hence this decision.

Partly implements #557