### PR TITLE
split, sort, and normalize specs for install_requires, extras_requires

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 furo
-sphinx_design
+jinja2>=3.0,<4.0
+packaging>=21.0,<22.0
+pathspec>=0.9,<0.10
 robotframework>=4.0
+sphinx_design
 toml>=0.10.2
-packaging==21.*
-pathspec==0.9.*
-jinja2~=3.0

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,25 @@ setup(
     keywords=KEYWORDS,
     packages=["robocop"],
     include_package_data=True,
-    install_requires=["robotframework>=3.2.2", "toml>=0.10.2", "packaging==21.*", "pathspec==0.9.*", "jinja2~=3.0"],
+    install_requires=[
+        "jinja2>=3.0,<4.0",
+        "robotframework>=3.2.2", 
+        "packaging>=21,<22", 
+        "pathspec>=0.9,<0.10", 
+        "toml>=0.10.2",
+    ],
     extras_requires={
-        "dev": ["pytest", "pytest-benchmark", "pyyaml", "tox", "black"],
-        "doc": ["sphinx", "sphinx_rtd_theme"],
+        "dev": [
+            "black",
+            "pytest", 
+            "pytest-benchmark", 
+            "pyyaml", 
+            "tox", 
+        ],
+        "doc": [
+            "sphinx", 
+            "sphinx_rtd_theme",
+        ],
     },
     entry_points={"console_scripts": ["robocop=robocop:run_robocop"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,9 @@ setup(
             "tox", 
         ],
         "doc": [
+            "furo",
             "sphinx", 
-            "sphinx_rtd_theme",
+            "sphinx_design",
         ],
     },
     entry_points={"console_scripts": ["robocop=robocop:run_robocop"]},

--- a/tox.ini
+++ b/tox.ini
@@ -7,63 +7,63 @@ addopts = --benchmark-skip --lf
 commands = pytest tests
 [testenv:rf3]
 deps =
+    jinja2>=3.0,<4.0
+    pathspec
     pytest
     pytest-benchmark
     pyyaml
-    toml
     robotframework==3.2.2
-    pathspec
-    jinja2~=3.0
+    toml
 [testenv:rf4]
 deps =
+    jinja2>=3.0,<4.0
+    pathspec
     pytest
     pytest-benchmark
     pyyaml
-    toml
     robotframework==4.1.1
-    pathspec
-    jinja2~=3.0
+    toml
 [testenv:rf5]
 deps =
+    jinja2>=3.0,<4.0
+    pathspec
     pytest
     pytest-benchmark
     pyyaml
-    toml
     robotframework==5.0rc2
-    pathspec
-    jinja2~=3.0
+    toml
 [testenv:coverage]
 deps =
+    coverage
+    jinja2>=3.0,<4.0
     pytest
     pytest-benchmark
     pyyaml
-    toml
     robotframework
-    coverage
-    jinja2~=3.0
+    toml
 commands =
     coverage run -m pytest
     coverage html
 [testenv:docs]
 deps =
-    sphinx
     furo
-    sphinx_design
+    jinja2>=3.0,<4.0
+    packaging>=21.0,<22.0
+    pathspec>=0.9,<0.10
     robotframework>=4.0
+    sphinx
+    sphinx_design
     toml>=0.10.2
-    packaging==21.*
-    pathspec==0.9.*
-    jinja2~=3.0
 commands =
     sphinx-build -b html docs docs/_build/
 [testenv:benchmark]
 deps =
+    pygal
     pytest
     pytest-benchmark
     pyyaml
-    toml
     robotframework==4.1.1
-    pygal
+    toml
 commands =
     pytest --benchmark-only \
     --benchmark-enable \


### PR DESCRIPTION
Congratulations on `2.0.0`!

I was updating the [downstream on conda-forge](https://github.com/conda-forge/robotframework-robocop-feedstock/pull/9) and found that the dependencies were getting a little hard to read.

This PR:
- splits the dependencies onto separate lines and sorts them so that future diffs are more apparent
- uses a single, old-school definition style for dependency ranges (e.g. `>=X,<Y`) instead of... all of them (except `^` i guess)
  - i've been lead to this by inconsistent implementations of other forms in different package managers, whereas _everybody_ implements the "traditional" `>` operators the same way

Thanks again!