### PR TITLE
Fix typos & sort imports

### DIFF
--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -2,7 +2,7 @@ name: Repo visualizer
 
 on:
   push:
-    branches-ignore:
+    branches:
       - master
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Python 3.6+ :snake: and Robot Framework 3.2.2+ :robot:.
 Installation <a name="installation"></a>
 ------------
 
-You can install latest version of Robocop simply by running::
+You can install the latest version of Robocop simply by running::
 
 ```
 pip install -U robotframework-robocop
@@ -333,7 +333,7 @@ FAQ <a name="faq"></a>
   - is highly configurable
   - has very good defaults that work out of the box
   - can be configured in source code
-  - uses latest [Robot Framework Parsing API](https://robot-framework.readthedocs.io/en/stable/)
+  - uses the latest [Robot Framework Parsing API](https://robot-framework.readthedocs.io/en/stable/)
   - is actively developed & fixed
   - is easy to integrate with external tools
   - can redirect output to a file

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,3 +51,4 @@ converter between ``Message`` and LSP diagnostic format::
     from robocop.utils import issues_to_lsp_diagnostic
 
     issues = issues_to_lsp_diagnostic(issues)
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-
 sys.path.append(str(Path(__file__).parent.parent))
 import robocop
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -59,3 +59,4 @@ You can simply run::
 All command line options can be displayed in help message by executing::
 
     robocop -h
+

--- a/robocop/checkers/__init__.py
+++ b/robocop/checkers/__init__.py
@@ -38,8 +38,8 @@ except ImportError:
 
 from robot.utils import FileReader
 
-from robocop.utils import modules_from_paths, modules_in_current_dir
 from robocop.exceptions import RuleNotFoundError, RuleParamNotFoundError, RuleReportsNotFoundError
+from robocop.utils import modules_from_paths, modules_in_current_dir
 
 
 class BaseChecker:

--- a/robocop/checkers/documentation.py
+++ b/robocop/checkers/documentation.py
@@ -5,7 +5,7 @@ from robot.parsing.model.blocks import SettingSection
 from robot.parsing.model.statements import Documentation
 
 from robocop.checkers import VisitorChecker
-from robocop.rules import Rule, RuleSeverity, RuleParam
+from robocop.rules import Rule, RuleParam, RuleSeverity
 from robocop.utils.misc import str2bool
 
 rules = {

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -7,7 +7,7 @@ from robot.api import Token
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import normalize_robot_name, normalize_robot_var_name, get_errors
+from robocop.utils import get_errors, normalize_robot_name, normalize_robot_var_name
 
 
 def configure_sections_order(value):

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -7,7 +7,7 @@ from robot.api import Token
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import ROBOT_VERSION, normalize_robot_name, normalize_robot_var_name, get_errors
+from robocop.utils import normalize_robot_name, normalize_robot_var_name, get_errors
 
 
 def configure_sections_order(value):
@@ -62,7 +62,7 @@ rules = {
         
             *** Keywords ***
             Keyword
-                No Operaton
+                No Operation
             
             keyword
                 No Operation

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -8,7 +8,7 @@ from robot.parsing.model.statements import Arguments, Comment, EmptyLine, Keywor
 
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import last_non_empty_line, normalize_robot_name, pattern_type, get_section_name
+from robocop.utils import get_section_name, last_non_empty_line, normalize_robot_name, pattern_type
 
 rules = {
     "0501": Rule(

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -8,11 +8,11 @@ from robot.parsing.model.blocks import TestCaseSection
 from robot.parsing.model.statements import KeywordCall, Return, Teardown
 
 try:
-    from robot.api.parsing import Variable, Comment, EmptyLine, If
+    from robot.api.parsing import Comment, EmptyLine, If, Variable
 except ImportError:
-    from robot.parsing.model.statements import Variable, Comment, EmptyLine
+    from robot.parsing.model.statements import Comment, EmptyLine, Variable
 try:
-    from robot.api.parsing import ReturnStatement, InlineIfHeader, Break, Continue
+    from robot.api.parsing import Break, Continue, InlineIfHeader, ReturnStatement
 except ImportError:
     ReturnStatement, InlineIfHeader, Break, Continue = None, None, None, None
 from robot.libraries import STDLIBS

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -368,8 +368,9 @@ class IfBlockCanBeUsed(VisitorChecker):
 class ConsistentAssignmentSignChecker(VisitorChecker):
     """Checker for inconsistent assignment signs.
 
-    By default this checker will try to autodetect most common assignment sign (separately for *** Variables *** section
-    and (*** Test Cases ***, *** Keywords ***) sections and report any not consistent type of sign in particular file.
+    By default, this checker will try to autodetect most common assignment sign (separately for *** Variables ***
+    section and *** Test Cases ***, *** Keywords *** sections) and report any inconsistent type of sign in particular
+    file.
 
     To force one type of sign type you, can configure two rules::
 

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 from pathlib import Path
 
 from robot.api import Token
-from robot.parsing.model.statements import Arguments, KeywordCall
 from robot.parsing.model.blocks import Keyword
+from robot.parsing.model.statements import Arguments, KeywordCall
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -11,7 +11,7 @@ from robot.parsing.model.visitor import ModelVisitor
 
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
-from robocop.utils import token_col, get_section_name, get_errors
+from robocop.utils import get_errors, get_section_name, token_col
 
 rules = {
     "1001": Rule(

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -12,7 +12,6 @@ from robot.parsing.model.visitor import ModelVisitor
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
 from robocop.utils import token_col, get_section_name, get_errors
-from robocop.utils.misc import ROBOT_VERSION
 
 rules = {
     "1001": Rule(

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -1,11 +1,11 @@
 import argparse
-from typing import Pattern, Set, Dict
 import fnmatch
 import os
 import re
 import sys
 from itertools import chain
 from pathlib import Path
+from typing import Dict, Pattern, Set
 
 import toml
 from robot.utils import FileReader
@@ -16,8 +16,8 @@ from robocop.exceptions import (
     InvalidArgumentError,
     NestedArgumentFileError,
 )
-from robocop.rules import RuleSeverity
 from robocop.files import DEFAULT_EXCLUDES, find_file_in_project_root, find_project_root
+from robocop.rules import RuleSeverity
 from robocop.utils import RecommendationFinder
 from robocop.version import __version__
 
@@ -48,9 +48,7 @@ class ParseFileTypes(argparse.Action):  # pylint: disable=too-few-public-methods
 
 class SetRuleThreshold(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        setattr(
-            namespace, self.dest, RuleSeverity.parser(values) if values in ("I", "W", "E") else RuleSeverity.INFO
-        )
+        setattr(namespace, self.dest, RuleSeverity.parser(values) if values in ("I", "W", "E") else RuleSeverity.INFO)
 
 
 class SetListOption(argparse.Action):

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -50,7 +50,7 @@ class SetRuleThreshold(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(
             namespace, self.dest, RuleSeverity.parser(values) if values in ("I", "W", "E") else RuleSeverity.INFO
-        )  # TODO Change severity to enum
+        )
 
 
 class SetListOption(argparse.Action):

--- a/robocop/files.py
+++ b/robocop/files.py
@@ -5,7 +5,6 @@ from pathspec import PathSpec
 
 from robocop.exceptions import FileError
 
-
 DEFAULT_EXCLUDES = r"(\.direnv|\.eggs|\.git|\.hg|\.nox|\.tox|\.venv|venv|\.svn)"
 
 

--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -123,7 +123,7 @@ class ReturnStatusReport(Report):
     def add_message(self, message: Message):
         self.counter.add_message(message)
 
-    def get_report(self) -> str:
+    def get_report(self):
         for severity, count in self.counter.severity_counter.items():
             threshold = self.quality_gate.get(severity.value, 0)
             if -1 < threshold < count:

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -24,12 +24,12 @@ Output message of rules can be defined with ``-f`` / ``--format`` argument. Defa
 
 """
 from enum import Enum
-from textwrap import dedent
 from functools import total_ordering
-from typing import Any, Callable, Union, Pattern, Dict, Optional
-from packaging.specifiers import SpecifierSet
+from textwrap import dedent
+from typing import Any, Callable, Dict, Optional, Pattern, Union
 
 from jinja2 import Template
+from packaging.specifiers import SpecifierSet
 
 import robocop.exceptions
 from robocop.utils import ROBOT_VERSION

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -91,7 +91,7 @@ class Robocop:
         """
         Pre-parse files to recognize their types. If the filename is `__init__.*`, the type is `INIT`.
         Files with .resource extension are `RESOURCE` type.
-        If the file is imported somewhere then file type is `RESOURCE`. Otherwise file type is `GENERAL`.
+        If the file is imported somewhere then file type is `RESOURCE`. Otherwise, file type is `GENERAL`.
         These types are important since they are used to define parsing class for robot API.
         """
         file_type_checker = FileTypeChecker(self.config.exec_dir)

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -11,16 +11,10 @@ from robot.errors import DataError
 
 import robocop.exceptions
 from robocop import checkers, reports
-from robocop.rules import Message
-from robocop.files import get_files
 from robocop.config import Config
-from robocop.utils import (
-    DisablersFinder,
-    FileType,
-    FileTypeChecker,
-    RecommendationFinder,
-    is_suite_templated,
-)
+from robocop.files import get_files
+from robocop.rules import Message
+from robocop.utils import DisablersFinder, FileType, FileTypeChecker, RecommendationFinder, is_suite_templated
 
 
 class Robocop:

--- a/robocop/utils/disablers.py
+++ b/robocop/utils/disablers.py
@@ -106,7 +106,7 @@ class DisablersFinder:
 
     def _is_file_disabled(self, last_line):
         """
-        The file is disabled if all rules are disabled in every lines - we need to iterate every block to see
+        The file is disabled if all rules are disabled in every line - we need to iterate every block to see
         if they are linked from first to last line without breaks.
         """
         if "all" not in self.rules:

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -5,7 +5,7 @@ import re
 from collections import Counter, defaultdict
 from importlib import import_module
 from pathlib import Path
-from typing import Pattern, List, Tuple, Dict, Optional
+from typing import Dict, List, Optional, Pattern, Tuple
 
 from robot.api import Token
 from robot.parsing.model.statements import EmptyLine
@@ -15,11 +15,11 @@ try:
 except ImportError:
     from robot.parsing.model.statements import Variable
 
-from robot.version import VERSION as RF_VERSION
 from packaging import version
+from robot.version import VERSION as RF_VERSION
 
-from robocop.version import __version__
 from robocop.exceptions import InvalidExternalCheckerError
+from robocop.version import __version__
 
 ROBOT_VERSION = version.parse(RF_VERSION)
 

--- a/tests/utest/test_argument_validation.py
+++ b/tests/utest/test_argument_validation.py
@@ -160,15 +160,6 @@ class TestArgumentValidation(unittest.TestCase):
             self.config.parse_opts(["--version"])
         self.assertRegex(mock_stdout.getvalue(), __version__)
 
-    # test commented out due to PR #73 that changed 'paths' to optional parameter
-    # but it is not required during parsing args anymore
-    # subject to change in the future
-    # @patch('sys.stderr', new_callable=StringIO)
-    # def test_paths_empty(self, mock_stderr):
-    #     with self.assertRaises(SystemExit):
-    #         self.config.parse_opts([])
-    #     self.assertRegex(mock_stderr.getvalue(), r'error: the following arguments are required: paths')
-
     def test_paths_new_value(self):
         args = self.config.parse_opts(["tests.robot"])
         self.assertListEqual(args.paths, ["tests.robot"])

--- a/tests/utest/test_checker_invalid_conf.py
+++ b/tests/utest/test_checker_invalid_conf.py
@@ -1,6 +1,6 @@
 """
 Those exceptions usually happens when trying to add new rules for Robocop and using wrong configuration (already
-existing rule name or id, get value of non-existing parameter inside checker etc).
+existing rule name or id, get value of non-existing parameter inside checker etc.).
 """
 import pytest
 


### PR DESCRIPTION
I run `isort` on the code and fixed all typos and other issues suggested by IDE. Also run black at the end.