### PR TITLE
Override severity of the rule

### DIFF
--- a/robocop/run.py
+++ b/robocop/run.py
@@ -64,9 +64,10 @@ class Robocop:
         """Reload checkers and reports based on current config"""
         self.load_checkers()
         self.config.validate_rule_names(self.rules)
-        self.list_checkers()
         self.load_reports()
         self.configure_checkers_or_reports()
+        self.check_for_disabled_rules()
+        self.list_checkers()
 
     def run(self):
         """Entry point for running scans"""
@@ -222,12 +223,15 @@ class Robocop:
             sys.exit()
 
     def register_checker(self, checker):
-        if not self.any_rule_enabled(checker):
-            checker.disabled = True
         for rule_name, rule in checker.rules.items():
             self.rules[rule_name] = rule
             self.rules[rule.rule_id] = rule
         self.checkers.append(checker)
+
+    def check_for_disabled_rules(self):
+        """Check checker configuration to disable rules."""
+        for checker in self.checkers:
+            checker.enabled = not self.any_rule_enabled(checker)
 
     def make_reports(self):
         for report in self.reports.values():

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -231,7 +231,8 @@ class Robocop:
     def check_for_disabled_rules(self):
         """Check checker configuration to disable rules."""
         for checker in self.checkers:
-            checker.enabled = not self.any_rule_enabled(checker)
+            if not self.any_rule_enabled(checker):
+                checker.disabled = True
 
     def make_reports(self):
         for report in self.reports.values():

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from robocop.config import Config
+from robocop.rules import RuleSeverity
 from robocop.exceptions import ArgumentFileNotFoundError, ConfigGeneralError, FileError, NestedArgumentFileError
 from robocop.run import Robocop
 
@@ -191,3 +192,15 @@ class TestE2E:
         should_run_with_config(robocop_instance, str(test_data_dir / "encodings.robot"))
         out, _ = capsys.readouterr()
         assert "Failed to decode" not in out
+
+    def test_override_severity(self, test_data_dir):
+        config = Config()
+        config.threshold = RuleSeverity("W")
+        config.configure = [
+            "missing-doc-test-case:severity:i"
+        ]
+        test_file = test_data_dir / "override_severity" / "test.robot"
+        config.paths = [str(test_file)]
+        robocop_instance = Robocop(config=config)
+        robocop_instance.run()
+        assert not robocop_instance.reports["json_report"].issues

--- a/tests/test_data/override_severity/.robocop
+++ b/tests/test_data/override_severity/.robocop
@@ -1,0 +1,10 @@
+# Rule Configuration:
+-c missing-doc-test-case:severity:i
+
+# Severity values for info, warning, error: I, W, E
+# values i, w, e don't work here!
+# To only report rules with severity W and above:
+--threshold W
+#--threshold E
+
+--report rules_by_idf

--- a/tests/test_data/override_severity/test.robot
+++ b/tests/test_data/override_severity/test.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Documentation    Testing Robocop
+Force Tags       comeANDgo    # Evoke rule 0602 with severity I
+
+
+*** Test Cases ***
+Log Something
+    # Missing [Documentation] evokes rule 0202 with severity W
+    Log To Console    \nNice day today

--- a/tests/utest/test_listing_rules.py
+++ b/tests/utest/test_listing_rules.py
@@ -94,6 +94,7 @@ def init_empty_checker(robocop_instance_pre_load, rule, exclude=False, **kwargs)
         robocop_instance_pre_load.config.exclude.update(set(rule.keys()))
         robocop_instance_pre_load.config.translate_patterns()
     robocop_instance_pre_load.register_checker(checker)
+    robocop_instance_pre_load.check_for_disabled_rules()
     return checker
 
 


### PR DESCRIPTION
Fixes #623

The bug happens because we're checking is rule should be enabled and then we're loading rule configuration (including possible overriden severity). This fix moves the check after configuring the rules.