### PR TITLE
Move reports only code to reports module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.black]
 line-length = 120
+[tool.isort]
+profile = "black"
+line_length = 120
 [tool.coverage.run]
 omit = ["*tests*"]
 source = ["robocop"]

--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -11,14 +11,16 @@ You can use separate arguments (``-r report1 -r report2``) or comma-separated li
 
 To enable all reports use ``--report all``.
 """
+import inspect
+import sys
 from collections import defaultdict
+from datetime import datetime
 from operator import itemgetter
 from timeit import default_timer as timer
 from warnings import warn
 
-from datetime import datetime
-from dateutil import tz
 import pytz
+from dateutil import tz
 
 import robocop.exceptions
 from robocop.rules import Message
@@ -33,6 +35,35 @@ class Report:
 
     def add_message(self, *args):
         pass
+
+
+def get_reports(configured_reports):
+    """
+    Returns dictionary with list of valid, enabled reports (listed in `configured_reports` set of str).
+    If `configured_reports` contains `all` then all reports are enabled.
+    Report is considered valid if it inherits from `Report` class
+    and contains both `name` and `description` attributes.
+    """
+    reports = {}
+    classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
+    for report_class in classes:
+        if not issubclass(report_class[1], Report):
+            continue
+        report = report_class[1]()
+        if not hasattr(report, "name") or not hasattr(report, "description"):
+            continue
+        if "all" in configured_reports or report.name in configured_reports:
+            reports[report.name] = report
+    return reports
+
+
+def list_reports(reports):
+    """Returns description of enabled reports."""
+    sorted_by_name = sorted(reports.values(), key=lambda x: x.name)
+    available_reports = "Available reports:\n"
+    available_reports += "\n".join(f"{report.name:20} - {report.description}" for report in sorted_by_name) + "\n"
+    available_reports += "all" + " " * 18 + "- Turns on all available reports"
+    return available_reports
 
 
 class RulesByIdReport(Report):

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -205,20 +205,9 @@ class Robocop:
         sys.exit()
 
     def load_reports(self):
-        self.reports = {}
-        classes = inspect.getmembers(reports, inspect.isclass)
-        available_reports = "Available reports:\n"
-        for report_class in classes:
-            if not issubclass(report_class[1], reports.Report):
-                continue
-            report = report_class[1]()
-            if not hasattr(report, "name"):
-                continue
-            if "all" in self.config.reports or report.name in self.config.reports:
-                self.reports[report.name] = report
-            available_reports += f"{report.name:20} - {report.description}\n"
+        self.reports = reports.get_reports(self.config.reports)
         if self.config.list_reports:
-            available_reports += "all" + " " * 18 + "- Turns on all available reports"
+            available_reports = reports.list_reports(self.reports)
             print(available_reports)
             sys.exit()
 


### PR DESCRIPTION
Small refactor - we had code in the main app module that should be in reports module. Also split the listing available reports from loading the reports.