### PR TITLE
Refactor usage of DisablersFinder class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.black]
 line-length = 120
+[tool.isort]
+profile = "black"
+line_length = 120
 [tool.coverage.run]
 omit = ["*tests*"]
 source = ["robocop"]

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -44,7 +44,6 @@ class Robocop:
         self.checkers = []
         self.rules = {}
         self.reports = {}
-        self.disabler = None
         self.root = os.getcwd()
         self.config = Config(from_cli=from_cli) if config is None else config
         self.from_cli = from_cli
@@ -125,10 +124,10 @@ class Robocop:
             self.reports["file_stats"].files_count = len(self.files)
 
     def run_check(self, ast_model, filename, source=None):
-        found_issues = []
-        self.register_disablers(filename, source)
-        if self.disabler.file_disabled:
+        disablers = DisablersFinder(filename=filename, source=source)
+        if disablers.file_disabled:
             return []
+        found_issues = []
         templated = is_suite_templated(ast_model)
         for checker in self.checkers:
             if checker.disabled:
@@ -136,13 +135,9 @@ class Robocop:
             found_issues += [
                 issue
                 for issue in checker.scan_file(ast_model, filename, source, templated)
-                if not self.disabler.is_rule_disabled(issue)
+                if not disablers.is_rule_disabled(issue)
             ]
         return found_issues
-
-    def register_disablers(self, filename, source):
-        """Parse content of file to find any disabler statements like # robocop: disable=rulename"""
-        self.disabler = DisablersFinder(filename=filename, source=source)
 
     def report(self, rule_msg: Message):
         for report in self.reports.values():

--- a/robocop/utils/disablers.py
+++ b/robocop/utils/disablers.py
@@ -26,7 +26,7 @@ class DisablersInFile:  # pylint: disable=too-few-public-methods
 class DisablersFinder:
     """Parse all scanned file and find and disablers (in line or blocks)"""
 
-    def __init__(self, filename, source=None):
+    def __init__(self, filename, source):
         self.file_disabled = False
         self.any_disabler = False
         self.disabler_pattern = re.compile(r"robocop: ?(?P<disabler>disable|enable)=?(?P<rules>[\w\-,]*)")


### PR DESCRIPTION
No need to store disablers for given file in core self if we're going to create new disabler class for every file anyway.