### PR TITLE
Preserve reports order

### DIFF
--- a/robocop/config.py
+++ b/robocop/config.py
@@ -29,7 +29,11 @@ def translate_pattern(pattern: str) -> Pattern:
 class ParseDelimitedArgAction(argparse.Action):  # pylint: disable=too-few-public-methods
     def __call__(self, parser, namespace, values, option_string=None):
         container = getattr(namespace, self.dest)
-        container.update(values.split(","))
+        config_values = values.split(",")
+        if isinstance(container, list):
+            container.extend(config_values)
+        else:
+            container.update(values.split(","))
 
 
 class ParseCheckerConfig(argparse.Action):  # pylint: disable=too-few-public-methods
@@ -87,7 +91,7 @@ class Config:
         self.exclude = set()
         self.ignore = set()
         self.ignore_default = re.compile(DEFAULT_EXCLUDES)
-        self.reports = {"return_status"}
+        self.reports = ["return_status"]
         self.threshold = RuleSeverity("I")
         self.configure = []
         self.format = "{source}:{line}:{col} [{severity}] {rule_id} {desc} ({name})"
@@ -225,7 +229,7 @@ class Config:
             "You can enable reports by listing them in comma-separated list:\n"
             "--reports rules_by_id,rules_by_error_type,scan_timer\n"
             "To enable all reports use all:\n"
-            "--report all",
+            "--reports all",
         )
         optional.add_argument(
             "-f",
@@ -450,8 +454,8 @@ class Config:
         if not toml_data:
             return False
         assign_type = {"paths", "format"}
-        set_type = {"include", "exclude", "reports", "ignore", "ext_rules"}
-        append_type = {"configure"}
+        set_type = {"include", "exclude", "ignore", "ext_rules"}
+        append_type = {"configure", "reports"}
         toml_data = {key.replace("-", "_"): value for key, value in toml_data.items()}
         for key, value in toml_data.items():
             if key in assign_type:

--- a/robocop/exceptions.py
+++ b/robocop/exceptions.py
@@ -63,3 +63,13 @@ class RuleParamFailedInitError(RobocopFatalError):
 class RuleReportsNotFoundError(RobocopFatalError):
     def __init__(self, rule, checker):
         super().__init__(f"{checker.__class__.__name__} checker `reports` attribute contains unknown rule `{rule}`")
+
+
+class InvalidReportName(ConfigGeneralError):
+    def __init__(self, report, reports):
+        from robocop.utils import RecommendationFinder
+
+        report_names = sorted(list(reports.keys()) + ["all"])
+        similar = RecommendationFinder().find_similar(report, report_names)
+        msg = f"Provided report '{report}' does not exist. {similar}"
+        super().__init__(msg)

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -1,7 +1,6 @@
 """
 Main class of Robocop module. Gathers files to be scanned, checkers, parses CLI arguments and scans files.
 """
-import inspect
 import os
 import sys
 from collections import Counter
@@ -48,7 +47,7 @@ class Robocop:
         self.config = Config(from_cli=from_cli) if config is None else config
         self.from_cli = from_cli
         if not from_cli:
-            self.config.reports.add("json_report")
+            self.config.reports.append("json_report")
         self.out = self.set_output()
 
     def set_output(self):

--- a/tests/utest/test_argument_validation.py
+++ b/tests/utest/test_argument_validation.py
@@ -22,7 +22,7 @@ class TestArgumentValidation(unittest.TestCase):
         self.assertSetEqual(self.config.filetypes, {".resource", ".robot", ".tsv"})
         self.assertSetEqual(self.config.include, set())
         self.assertSetEqual(self.config.exclude, set())
-        self.assertSetEqual(self.config.reports, {"return_status"})
+        self.assertListEqual(self.config.reports, ["return_status"])
         self.assertListEqual(self.config.configure, [])
         self.assertEqual(
             self.config.format,
@@ -37,7 +37,7 @@ class TestArgumentValidation(unittest.TestCase):
         self.assertSetEqual(args.filetypes, {".resource", ".robot", ".tsv"})
         self.assertSetEqual(args.include, set())
         self.assertSetEqual(args.exclude, set())
-        self.assertSetEqual(args.reports, {"return_status"})
+        self.assertListEqual(args.reports, ["return_status"])
         self.assertListEqual(args.configure, [])
         self.assertEqual(args.format, "{source}:{line}:{col} [{severity}] {rule_id} {desc} ({name})")
         self.assertListEqual(args.paths, [""])


### PR DESCRIPTION
Preserve order of the reports given in the configuration. Closes #664 

It is now possible to:
```
--reports x,y
```
to first run x and then y report.
```
--reports x,all
```
to first run x report and them remaining ones.

Also:
 - added missing error handling for invalid report name (it was possible to pass ``--report invalid`` and it was silently ignored)
 - fixed typos in the docs (``--reports`` instead of ``--report``)