### PR TITLE
Handle templated tests in too-many/few-calls-in-test-case rules

### DIFF
--- a/tests/atest/custom_tests.yaml
+++ b/tests/atest/custom_tests.yaml
@@ -59,12 +59,17 @@ tests:
         - too-few-calls-in-keyword:min_calls:2
         - too-few-calls-in-keyword:severity_threshold:warning=1:error=0
       src_dir: lengths/too-few-calls-in-keyword-severity-threshold
+  too-few-calls-in-test-case:
+    - config: too-few-calls-in-test-case:ignore_templated:True
+      src_dir: lengths/too-few-calls-in-test-case-ignore-templated
   too-many-calls-in-keyword:
     - config:
         - too-many-calls-in-keyword:max_calls:5
         - too-many-calls-in-keyword:severity_threshold:warning=5:error=10
       src_dir: lengths/too-many-calls-in-keyword-severity-threshold
   too-many-calls-in-test-case:
+    - config: too-many-calls-in-test-case:ignore_templated:True
+      src_dir: lengths/too-many-calls-in-test-case-ignore-templated
     - config:
         - too-many-calls-in-test-case:max_calls:5
         - too-many-calls-in-test-case:severity_threshold:warning=5:error=10

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/expected_output.txt
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/expected_output.txt
@@ -1,0 +1,2 @@
+${rules_dir}${\}test.robot:27:1 [E] 0528 Test case 'Test case with no keyword calls' has too few keywords inside (0/1)
+${rules_dir}${\}test.robot:29:1 [E] 0528 Test case 'Test case with settings and no keyword calls' has too few keywords inside (0/1)

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/templated_suite.robot
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/templated_suite.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation    Suite Documentation
+Test Template    Do Stuff
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/templated_test.robot
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/templated_test.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation    Suite Documentation
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+    [Template]    Do Stuff
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/test.robot
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case-ignore-templated/test.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Long test case
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    One More
+
+
+Test case with one keyword call
+    Skip
+
+Test case with no keyword calls
+
+Test case with settings and no keyword calls
+    [Tags]    smoke
+    [Setup]    Keyword
+    [Timeout]    1 min
+    [Documentation]    doc
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case/expected_output.txt
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case/expected_output.txt
@@ -1,2 +1,4 @@
 ${rules_dir}${\}test.robot:27:1 [E] 0528 Test case 'Test case with no keyword calls' has too few keywords inside (0/1)
 ${rules_dir}${\}test.robot:29:1 [E] 0528 Test case 'Test case with settings and no keyword calls' has too few keywords inside (0/1)
+${rules_dir}${\}templated_suite.robot:7:1 [E] 0528 Test case 'Template Case' has too few keywords inside (0/1)
+${rules_dir}${\}templated_test.robot:6:1 [E] 0528 Test case 'Template Case' has too few keywords inside (0/1)

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case/templated_suite.robot
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case/templated_suite.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation    Suite Documentation
+Test Template    Do Stuff
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-few-calls-in-test-case/templated_test.robot
+++ b/tests/atest/rules/lengths/too-few-calls-in-test-case/templated_test.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation    Suite Documentation
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+    [Template]    Do Stuff
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/expected_output.txt
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/expected_output.txt
@@ -1,0 +1,1 @@
+${rules_dir}${\}test.robot:6:1 [W] 0505 Test case 'Test' has too many keywords inside (13/10)

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/templated_suite.robot
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/templated_suite.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation    Suite Documentation
+Test Template    Do Stuff
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/templated_test.robot
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/templated_test.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation    Suite Documentation
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Template]    Do Stuff
+    [Tags]    Tags
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/test.robot
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case-ignore-templated/test.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case/expected_output.txt
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case/expected_output.txt
@@ -1,1 +1,3 @@
 ${rules_dir}${\}test.robot:6:1 [W] 0505 Test case 'Test' has too many keywords inside (13/10)
+${rules_dir}${\}templated_suite.robot:7:1 [W] 0505 Test case 'Template Case' has too many keywords inside (12/10)
+${rules_dir}${\}templated_test.robot:6:1 [W] 0505 Test case 'Template Case' has too many keywords inside (12/10)

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case/templated_suite.robot
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case/templated_suite.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation    Suite Documentation
+Test Template    Do Stuff
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/atest/rules/lengths/too-many-calls-in-test-case/templated_test.robot
+++ b/tests/atest/rules/lengths/too-many-calls-in-test-case/templated_test.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation    Suite Documentation
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Template]    Do Stuff
+    [Tags]    Tags
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}


### PR DESCRIPTION
Count template arguments as keyword calls. 
Allow to ignore templated tests by using ``ignore_templated`` parameter.

Fixes #685 