### PR TITLE
Parse and find issues in keywords in run keywords

### DIFF
--- a/robocop/utils/run_keywords.py
+++ b/robocop/utils/run_keywords.py
@@ -1,0 +1,121 @@
+from robocop.utils.misc import normalize_robot_name
+
+
+class RunKeywordVariant:
+    def __init__(self, name, resolve=1, branches=None, split_on_and=False):
+        self.name = normalize_robot_name(name)
+        self.resolve = resolve
+        self.branches = branches
+        self.split_on_and = split_on_and
+
+
+class RunKeywords(dict):
+    def __init__(self, keywords):
+        normalized_keywords = {}
+        for keyword_variant in keywords:
+            normalized_name = normalize_robot_name(keyword_variant.name)
+            name_with_lib = f"builtin.{normalized_name}"
+            normalized_keywords[normalized_name] = keyword_variant
+            normalized_keywords[name_with_lib] = keyword_variant
+        super().__init__(normalized_keywords)
+
+    def __setitem__(self, keyword_name, kw_variant):
+        normalized_name = normalize_robot_name(keyword_name)
+        name_with_lib = f"builtin.{normalized_name}"
+        super().__setitem__(normalized_name, kw_variant)
+        super().__setitem__(name_with_lib, kw_variant)
+
+    def __getitem__(self, keyword_name):
+        normalized_name = normalize_robot_name(keyword_name)
+        return super().__getitem__(normalized_name)
+
+    def __missing__(self, keyword_name):
+        return None
+
+
+RUN_KEYWORDS = RunKeywords(
+    [
+        RunKeywordVariant("Run Keyword"),
+        RunKeywordVariant("Run Keyword And Continue On Failure"),
+        RunKeywordVariant("Run Keyword And Expect Error", resolve=2),
+        RunKeywordVariant("Run Keyword And Ignore Error"),
+        RunKeywordVariant("Run Keyword And Return"),
+        RunKeywordVariant("Run Keyword And Return If", resolve=2),
+        RunKeywordVariant("Run Keyword And Return Status"),
+        RunKeywordVariant("Run Keyword And Warn On Failure"),
+        RunKeywordVariant("Run Keyword If", resolve=2, branches=["ELSE IF", "ELSE"]),
+        RunKeywordVariant("Run Keyword If All Tests Passed"),
+        RunKeywordVariant("Run Keyword If Any Tests Failed"),
+        RunKeywordVariant("Run Keyword If Test Failed"),
+        RunKeywordVariant("Run Keyword If Test Passed"),
+        RunKeywordVariant("Run Keyword If Timeout Occurred"),
+        RunKeywordVariant("Run Keyword Unless", resolve=2),
+        RunKeywordVariant("Run Keywords", split_on_and=True),
+        RunKeywordVariant("Repeat Keyword", resolve=2),
+        RunKeywordVariant("Wait Until Keyword Succeeds", resolve=3),
+    ]
+)
+
+
+def skip_leading_tokens(tokens, break_token):
+    for index, token in enumerate(tokens):
+        if token.type == break_token:
+            return tokens[index:]
+
+
+def is_token_value_in_tokens(value, tokens):
+    return any(value == token.value for token in tokens)
+
+
+def split_on_token_value(tokens, value, resolve: int):
+    """
+    Split list of tokens into three lists based on token value.
+    Returns tokens before found token, found token + `resolve` number of tokens, remaining tokens.
+    """
+    for index, token in enumerate(tokens):
+        if value == token.value:
+            prefix = tokens[:index]
+            branch = tokens[index : index + resolve]
+            remainder = tokens[index + resolve :]
+            return prefix, branch, remainder
+    else:
+        return [], [], tokens
+
+
+def iterate_keyword_names(keyword_node, name_token_type):
+    tokens = skip_leading_tokens(keyword_node.data_tokens, name_token_type)
+    yield from parse_run_keyword(tokens)
+
+
+def parse_run_keyword(tokens):
+    if not tokens:
+        return
+    yield tokens[0]
+    run_keyword = RUN_KEYWORDS[tokens[0].value]
+    if not run_keyword:
+        return
+    tokens = tokens[run_keyword.resolve :]
+    if run_keyword.branches:
+        if "ELSE IF" in run_keyword.branches:
+            while is_token_value_in_tokens("ELSE IF", tokens):
+                prefix, branch, tokens = split_on_token_value(tokens, "ELSE IF", 2)
+                yield from parse_run_keyword(prefix)
+        if "ELSE" in run_keyword.branches and is_token_value_in_tokens("ELSE", tokens):
+            prefix, branch, tokens = split_on_token_value(tokens, "ELSE", 1)
+            yield from parse_run_keyword(prefix)
+            yield from parse_run_keyword(tokens)
+            return
+    elif run_keyword.split_on_and:
+        yield from split_on_and(tokens)
+        return
+    yield from parse_run_keyword(tokens)
+
+
+def split_on_and(tokens):
+    if not is_token_value_in_tokens("AND", tokens):
+        yield from (token for token in tokens)
+        return
+    while is_token_value_in_tokens("AND", tokens):
+        prefix, branch, tokens = split_on_token_value(tokens, "AND", 1)
+        yield from parse_run_keyword(prefix)
+    yield from parse_run_keyword(tokens)

--- a/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf3.txt
+++ b/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf3.txt
@@ -4,6 +4,4 @@ ${rules_dir}${\}if_blocks.robot:20:5 [E] 0303 'END' is a reserved keyword. It mu
 ${rules_dir}${\}if_blocks.robot:24:9 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR' loop. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:21:5 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'FOR' loop. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:22:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR' loop. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:24:10 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:41:67 [E] 0303 'else if' is a reserved keyword. It must be in uppercase (ELSE IF) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:28:5 [E] 0303 'END' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR' loop. Each marker should have minimum of 2 spaces as separator.

--- a/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf4.txt
+++ b/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf4.txt
@@ -3,5 +3,3 @@ ${rules_dir}${\}if_blocks.robot:8:5 [E] 0303 'End' is a reserved keyword. It mus
 ${rules_dir}${\}if_blocks.robot:24:9 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR' or 'IF'. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:21:5 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'FOR' loop. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:22:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR' or 'IF'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:24:10 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:41:67 [E] 0303 'else if' is a reserved keyword. It must be in uppercase (ELSE IF) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.

--- a/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf5.txt
+++ b/tests/atest/rules/naming/keyword-name-is-reserved-word/expected_output_rf5.txt
@@ -5,7 +5,6 @@ ${rules_dir}${\}if_blocks.robot:8:5 [E] 0303 'End' is a reserved keyword. It mus
 ${rules_dir}${\}if_blocks.robot:24:9 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR', 'IF' or 'TRY EXCEPT'. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:21:5 [E] 0303 'For' is a reserved keyword. It must be in uppercase (FOR) when used as a marker with 'FOR' loop. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:22:5 [E] 0303 'End' is a reserved keyword. It must be in uppercase (END) when used as a marker with 'FOR', 'IF' or 'TRY EXCEPT'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:24:10 [E] 0303 'else' is a reserved keyword. It must be in uppercase (ELSE) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:27:9 [E] 0303 'Return' is a reserved keyword. It must be in uppercase (RETURN) when used as a statement
 ${rules_dir}${\}test.robot:31:1 [E] 0303 'While' is a reserved keyword. It must be in uppercase (WHILE) when used as a statement
 ${rules_dir}${\}test.robot:32:5 [E] 0303 'While' is a reserved keyword. It must be in uppercase (WHILE) when used as a statement
@@ -13,4 +12,3 @@ ${rules_dir}${\}test.robot:33:5 [E] 0303 'Continue' is a reserved keyword. It mu
 ${rules_dir}${\}test.robot:34:5 [E] 0303 'Try' is a reserved keyword. It must be in uppercase (TRY) when used as a marker with 'TRY EXCEPT'. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:35:5 [E] 0303 'Except' is a reserved keyword. It must be in uppercase (EXCEPT) when used as a marker with 'TRY EXCEPT'. Each marker should have minimum of 2 spaces as separator.
 ${rules_dir}${\}test.robot:36:5 [E] 0303 'finally' is a reserved keyword. It must be in uppercase (FINALLY) when used as a marker with 'TRY EXCEPT'. Each marker should have minimum of 2 spaces as separator.
-${rules_dir}${\}test.robot:41:67 [E] 0303 'else if' is a reserved keyword. It must be in uppercase (ELSE IF) when used as a marker with 'Run Keyword If'. Each marker should have minimum of 2 spaces as separator.

--- a/tests/atest/rules/naming/underscore-in-keyword-name/expected_output.txt
+++ b/tests/atest/rules/naming/underscore-in-keyword-name/expected_output.txt
@@ -1,1 +1,4 @@
-${rules_dir}${\}test.robot:11:1 [W] 0305 Underscores in keyword name 'One_More' can be replaced with spaces
+${rules_dir}${\}test.robot:11:5 [W] 0305 Underscores in keyword name 'One_More' can be replaced with spaces
+${rules_dir}${\}test.robot:29:12 [W] 0305 Underscores in keyword name 'Run_keywords' can be replaced with spaces
+${rules_dir}${\}test.robot:31:16 [W] 0305 Underscores in keyword name '_Underscore' can be replaced with spaces
+${rules_dir}${\}test.robot:32:16 [W] 0305 Underscores in keyword name 'Under_sc ore' can be replaced with spaces

--- a/tests/atest/rules/naming/underscore-in-keyword-name/test.robot
+++ b/tests/atest/rules/naming/underscore-in-keyword-name/test.robot
@@ -23,3 +23,10 @@ Keyword
 
 Embedded Keyword With ${variable_with_underscore}
     Log    ${variable_with_underscore}
+
+Run Keywords
+    Run Keyword If    ${condition}
+    ...    Run_keywords
+    ...        Name    ${arg}    AND
+    ...        _Underscore    1    AND
+    ...        Under_sc ore

--- a/tests/atest/rules/naming/wrong-case-in-keyword-name-configured/expected_output.txt
+++ b/tests/atest/rules/naming/wrong-case-in-keyword-name-configured/expected_output.txt
@@ -1,2 +1,2 @@
-${rules_dir}${\}test.robot:4:1 [W] 0302 Keyword name 'Not Allowed Dot In Keyword Foo.baz' does not follow case convention
+${rules_dir}${\}test.robot:4:3 [W] 0302 Keyword name 'Not Allowed Dot In Keyword Foo.baz' does not follow case convention
 ${rules_dir}${\}test.robot:10:1 [W] 0302 Keyword name 'Not Allowed Dot In Keyword Foo.baz' does not follow case convention

--- a/tests/atest/rules/naming/wrong-case-in-keyword-name-first-word/expected_output.txt
+++ b/tests/atest/rules/naming/wrong-case-in-keyword-name-first-word/expected_output.txt
@@ -1,8 +1,8 @@
-${rules_dir}${\}test.robot:3:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:4:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:5:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:6:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:14:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:15:1 [W] 0302 Keyword name 'pass' does not follow case convention
-${rules_dir}${\}test.robot:18:1 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:3:14 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:4:17 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:5:13 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:6:16 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:14:14 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:15:5 [W] 0302 Keyword name 'pass' does not follow case convention
+${rules_dir}${\}test.robot:18:17 [W] 0302 Keyword name 'keyword' does not follow case convention
 ${rules_dir}${\}test.robot:36:1 [W] 0302 Keyword name 'keyword' does not follow case convention

--- a/tests/atest/rules/naming/wrong-case-in-keyword-name/expected_output.txt
+++ b/tests/atest/rules/naming/wrong-case-in-keyword-name/expected_output.txt
@@ -1,10 +1,22 @@
-${rules_dir}${\}test.robot:3:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:4:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:5:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:6:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:14:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:15:1 [W] 0302 Keyword name 'pass' does not follow case convention
-${rules_dir}${\}test.robot:18:1 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:3:14 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:4:17 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:5:13 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:6:16 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:14:14 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}test.robot:15:5 [W] 0302 Keyword name 'pass' does not follow case convention
+${rules_dir}${\}test.robot:18:17 [W] 0302 Keyword name 'keyword' does not follow case convention
 ${rules_dir}${\}test.robot:36:1 [W] 0302 Keyword name 'keyword' does not follow case convention
-${rules_dir}${\}test.robot:61:1 [W] 0302 Keyword name 'Keyword_With_underscores' does not follow case convention
+${rules_dir}${\}test.robot:61:5 [W] 0302 Keyword name 'Keyword_With_underscores' does not follow case convention
 ${rules_dir}${\}test.robot:107:1 [W] 0302 Keyword name 'Dot in name foo.bar' does not follow case convention
+${rules_dir}${\}run_keywords.robot:2:32 [W] 0302 Keyword name 'some keyword' does not follow case convention
+${rules_dir}${\}run_keywords.robot:8:12 [W] 0302 Keyword name 'Run Keyword if' does not follow case convention
+${rules_dir}${\}run_keywords.robot:9:14 [W] 0302 Keyword name 'Run keywords' does not follow case convention
+${rules_dir}${\}run_keywords.robot:10:16 [W] 0302 Keyword name 'log' does not follow case convention
+${rules_dir}${\}run_keywords.robot:13:14 [W] 0302 Keyword name 'log' does not follow case convention
+${rules_dir}${\}run_keywords.robot:17:35 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}run_keywords.robot:21:47 [W] 0302 Keyword name 'run Keywords' does not follow case convention
+${rules_dir}${\}run_keywords.robot:21:63 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}run_keywords.robot:25:12 [W] 0302 Keyword name 'log' does not follow case convention
+${rules_dir}${\}run_keywords.robot:31:17 [W] 0302 Keyword name 'keyword' does not follow case convention
+${rules_dir}${\}run_keywords.robot:33:16 [W] 0302 Keyword name 'other_keyword' does not follow case convention
+${rules_dir}${\}run_keywords.robot:36:35 [W] 0302 Keyword name 'keyword' does not follow case convention

--- a/tests/atest/rules/naming/wrong-case-in-keyword-name/run_keywords.robot
+++ b/tests/atest/rules/naming/wrong-case-in-keyword-name/run_keywords.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Suite Setup    Run Keywords    some keyword  AND  SOME_Keyword
+
+
+*** Test Cases ***
+Test with run keywords
+    Run Keyword And Continue On Failure
+    ...    Run Keyword if    ${True}
+    ...      Run keywords
+    ...        log    foo    AND
+    ...        Log    bar
+    ...    ELSE
+    ...      log    baz
+
+Settings
+    [Setup]    Keyword
+    [Teardown]    Run Keywords    keyword    Keyword
+
+*** Keywords ***
+Keyword With Run Keywords
+    Builtin.Run Keyword_If    ${condition}    run Keywords    keyword    Keyword
+    Run Keywords
+    ...    Log    a
+    ...    AND
+    ...    log    b
+    ...    AND
+    ...    Log    c
+
+More Branches
+    Run Keyword If    ${condition
+    ...         keyword
+    ...    ELSE IF    ${other_cond}
+    ...        other_keyword
+
+Settings
+    [Teardown]    Run Keywords    keyword    Keyword
+
+Empty Run Keyword
+    Run Keywords
+
+Run Keyword With Variable
+    Run Keywords    ${Variable}    ${variable}


### PR DESCRIPTION
Keywords inside run keywords (such as Run Keywords, Run Keyword If, Run Keyword And Continue On Failure..) will be detected and Robocop rules will be applied to them. Fixes #691 and closes #520 .

Fixed reported positions for several naming rules - instead of pointing on first column in the line it points directly to the token position. Relates #290 

The only downside of all the changes is that in some cases inproper case for Robot Framework markers is not detected (such as ``Run Keyword If`` and ``else`` instead of ``ELSE``). I will think of a way to detect it like it's done now.