### PR TITLE
Use library alias for duplicated library name check

### DIFF
--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -340,7 +340,8 @@ class DuplicationsChecker(VisitorChecker):
     def visit_LibraryImport(self, node):  # noqa
         if not node.name:
             return
-        name_with_args = node.name + "".join(token.value for token in node.data_tokens[2:])
+        lib_name = node.alias if node.alias else node.name
+        name_with_args = lib_name + "".join(token.value for token in node.get_tokens(Token.ARGUMENT))
         self.libraries[name_with_args].append(node)
 
     def visit_Metadata(self, node):  # noqa

--- a/tests/atest/rules/duplications/duplicated-library/expected_output.txt
+++ b/tests/atest/rules/duplications/duplicated-library/expected_output.txt
@@ -1,1 +1,2 @@
 ${rules_dir}${\}test.robot:7:1 [W] 0805 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 3)
+${rules_dir}${\}test.robot:9:1 [W] 0805 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 8)

--- a/tests/atest/rules/duplications/duplicated-library/expected_output_5.1.txt
+++ b/tests/atest/rules/duplications/duplicated-library/expected_output_5.1.txt
@@ -1,0 +1,3 @@
+${rules_dir}${\}test.robot:7:1 [W] 0805 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 3)
+${rules_dir}${\}test.robot:9:1 [W] 0805 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 8)
+${rules_dir}${\}test.robot:12:1 [W] 0805 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 10)

--- a/tests/atest/rules/duplications/duplicated-library/test.robot
+++ b/tests/atest/rules/duplications/duplicated-library/test.robot
@@ -5,6 +5,12 @@ Library    OtherLib
 Library
 Resource  some_resource.robot
 Library    MyLib
+Library    MyLib    arg
+Library    MyLib    arg
+Library    MyLib  WITH NAME    MyLib2
+Library    MyLib  AS    MyLib3
+Library    MyLib  AS    MyLib2
+Library    MyLib    argument    AS    MyLib2
 
 
 *** Test Cases ***


### PR DESCRIPTION
Fixes #699 