### PR TITLE
Remove common rules_dir prefix from expected files

### DIFF
--- a/tests/atest/rules/lengths/empty_arguments/expected_output.txt
+++ b/tests/atest/rules/lengths/empty_arguments/expected_output.txt
@@ -1,1 +1,1 @@
-${rules_dir}${\}test.robot:17:17 [E] 0526 Arguments of 'Keyword Without Arguments' Keyword are empty
+test.robot:17:17 [E] 0526 Arguments of 'Keyword Without Arguments' Keyword are empty

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output.txt
@@ -1,1 +1,1 @@
-${rules_dir}${\}test.robot:61:1 [W] 0501 Keyword 'Keyword' is too long (46/40)
+test.robot:61:1 [W] 0501 Keyword 'Keyword' is too long (46/40)

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output_ignore_docs.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output_ignore_docs.txt
@@ -1,1 +1,1 @@
-${rules_dir}${\}ignore_docs.robot:61:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
+ignore_docs.robot:61:1 [W] 0501 Keyword 'Keyword' is too long (45/40)

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output_severity_threshold.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output_severity_threshold.txt
@@ -1,2 +1,2 @@
-${rules_dir}${\}severity_threshold.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
-${rules_dir}${\}severity_threshold.robot:112:1 [E] 0501 Keyword 'Keyword2' is too long (51/40)
+severity_threshold.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
+severity_threshold.robot:112:1 [E] 0501 Keyword 'Keyword2' is too long (51/40)

--- a/tests/atest/utils/__init__.py
+++ b/tests/atest/utils/__init__.py
@@ -8,20 +8,17 @@ from robocop import Robocop
 from robocop.config import Config
 
 
-def replace_paths(line, rules_dir):
-    return line.replace("${rules_dir}", rules_dir).replace(r"${\}", os.path.sep).rstrip("\n")
-
-
 def load_expected_file(test_data, expected_file):
-    expected_path = test_data / expected_file
-    with open(expected_path, encoding="utf-8") as f:
-        return sorted([replace_paths(line, str(test_data)) for line in f])
+    expected = test_data / expected_file
+    with open(expected, encoding="utf-8") as f:
+        return sorted([line.rstrip("\n") for line in f])
 
 
-def load_actual_results(capsys):
+def load_actual_results(capsys, test_data):
     out, _ = capsys.readouterr()
     actual = out.splitlines()
-    return sorted([line.rstrip() for line in actual])
+    test_data_str = f"{test_data}{os.path.sep}"
+    return sorted([line.replace(test_data_str, "") for line in actual])
 
 
 def configure_robocop_with_rule(args, runner, rule, path, src_files):
@@ -64,7 +61,7 @@ class RuleAcceptance:
         robocop_instance = configure_robocop_with_rule(config, robocop_instance, rule, test_data, src_files)
         with pytest.raises(SystemExit):
             robocop_instance.run()
-        actual = load_actual_results(capsys)
+        actual = load_actual_results(capsys, test_data)
         assert actual == expected
 
     @property


### PR DESCRIPTION
Thanks to new framework it was easier to finally remove the need of having ``${rules_dir}${\}`` prefix in every line in expected results. Now it looks better:

old:
```
${rules_dir}${\}severity_threshold.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
${rules_dir}${\}severity_threshold.robot:112:1 [E] 0501 Keyword 'Keyword2' is too long (51/40)
```

new:
```
severity_threshold.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
severity_threshold.robot:112:1 [E] 0501 Keyword 'Keyword2' is too long (51/40)
```