### PR TITLE
Skip empty lines and standalone comments at the end of the keyword/test

### DIFF
--- a/docs/releasenotes/2.6.0.rst
+++ b/docs/releasenotes/2.6.0.rst
@@ -11,4 +11,4 @@ or to install exactly this version::
 ## Fixes
 
 - unrecognized header is now only reported by ``parsing-error`` and not by ``duplicated-setting`` (#683)
-- empty lines and standalone comments are now not counted towards keyword/test lenght in ``too-long-test-case`` and ``too-long-keyword`` rules (#671)
+- empty lines and standalone comments are now not counted towards keyword/test length in ``too-long-test-case`` and ``too-long-keyword`` rules (#671)

--- a/docs/releasenotes/2.6.0.rst
+++ b/docs/releasenotes/2.6.0.rst
@@ -11,3 +11,4 @@ or to install exactly this version::
 ## Fixes
 
 - unrecognized header is now only reported by ``parsing-error`` and not by ``duplicated-setting`` (#683)
+- empty lines and standalone comments are now not counted towards keyword/test lenght in ``too-long-test-case`` and ``too-long-keyword`` rules (#671)

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from robocop.checkers import RawFileChecker, VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity, SeverityThreshold
-from robocop.utils import get_section_name, last_non_empty_line, normalize_robot_name, pattern_type, str2bool
+from robocop.utils import get_section_name, normalize_robot_name, pattern_type, str2bool
 
 rules = {
     "0501": Rule(

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -3,6 +3,7 @@ Lengths checkers
 """
 import re
 
+from robot.api import Token
 from robot.parsing.model.blocks import CommentSection, TestCase
 from robot.parsing.model.statements import (
     Arguments,
@@ -224,10 +225,23 @@ rules = {
 }
 
 
+def is_data_statement(node):
+    return not isinstance(node, (EmptyLine, Comment))
+
+
+def is_not_standalone_comment(node):
+    return isinstance(node, Comment) and node.tokens[0].type == Token.SEPARATOR
+
+
 def check_node_length(node, ignore_docs):
+    last_node = node
+    for child in node.body[::-1]:
+        if is_data_statement(child) or is_not_standalone_comment(child):
+            last_node = child
+            break
     if ignore_docs:
-        return node.end_lineno - node.lineno - get_documentation_length(node)
-    return node.end_lineno - node.lineno
+        return (last_node.end_lineno - node.lineno - get_documentation_length(node)), last_node.end_lineno
+    return (last_node.end_lineno - node.lineno), last_node.end_lineno
 
 
 def get_documentation_length(node):
@@ -282,7 +296,7 @@ class LengthChecker(VisitorChecker):
                         sev_threshold_value=args_number,
                     )
                 break
-        length = check_node_length(node, ignore_docs=self.param("too-long-keyword", "ignore_docs"))
+        length, node_end_line = check_node_length(node, ignore_docs=self.param("too-long-keyword", "ignore_docs"))
         if length > self.param("too-long-keyword", "max_len"):
             self.report(
                 "too-long-keyword",
@@ -290,8 +304,8 @@ class LengthChecker(VisitorChecker):
                 keyword_length=length,
                 allowed_length=self.param("too-long-keyword", "max_len"),
                 node=node,
-                lineno=node.end_lineno,
-                ext_disablers=(node.lineno, last_non_empty_line(node)),
+                lineno=node_end_line,
+                ext_disablers=(node.lineno, node_end_line),
                 sev_threshold_value=length,
             )
             return
@@ -328,7 +342,7 @@ class LengthChecker(VisitorChecker):
         return False
 
     def visit_TestCase(self, node):  # noqa
-        length = check_node_length(node, ignore_docs=self.param("too-long-test-case", "ignore_docs"))
+        length, _ = check_node_length(node, ignore_docs=self.param("too-long-test-case", "ignore_docs"))
         if length > self.param("too-long-test-case", "max_len"):
             self.report(
                 "too-long-test-case",
@@ -368,7 +382,11 @@ class LengthChecker(VisitorChecker):
     @staticmethod
     def count_keyword_calls(node):
         # ReturnStatement is imported and evaluates to true in RF 5.0+, we don't need to also check Break/Continue
-        if isinstance(node, (KeywordCall, TemplateArguments)) or ReturnStatement and isinstance(node, (Break, Continue, ReturnStatement)):
+        if (
+            isinstance(node, (KeywordCall, TemplateArguments))
+            or ReturnStatement
+            and isinstance(node, (Break, Continue, ReturnStatement))
+        ):
             return 1
         if not hasattr(node, "body"):
             return 0

--- a/robocop/utils/__init__.py
+++ b/robocop/utils/__init__.py
@@ -13,7 +13,6 @@ from robocop.utils.misc import (
     is_suite_templated,
     issues_to_lsp_diagnostic,
     keyword_col,
-    last_non_empty_line,
     modules_from_path,
     modules_from_paths,
     modules_in_current_dir,

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -253,13 +253,6 @@ def is_suite_templated(model):
     return finder.templated
 
 
-def last_non_empty_line(node):
-    for child in node.body[::-1]:
-        if not isinstance(child, EmptyLine):
-            return child.lineno
-    return node.lineno
-
-
 def next_char_is(string: str, i: int, char: str) -> bool:
     if not i < len(string) - 1:
         return False

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output.txt
@@ -1,1 +1,1 @@
-test.robot:61:1 [W] 0501 Keyword 'Keyword' is too long (46/40)
+test.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (45/40)

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output_ignore_docs.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output_ignore_docs.txt
@@ -1,1 +1,1 @@
-ignore_docs.robot:61:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
+ignore_docs.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (44/40)

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output_severity_threshold.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output_severity_threshold.txt
@@ -1,2 +1,2 @@
-severity_threshold.robot:60:1 [W] 0501 Keyword 'Keyword' is too long (45/40)
+severity_threshold.robot:59:1 [W] 0501 Keyword 'Keyword' is too long (44/40)
 severity_threshold.robot:112:1 [E] 0501 Keyword 'Keyword2' is too long (51/40)

--- a/tests/atest/rules/lengths/too_long_keyword/test.robot
+++ b/tests/atest/rules/lengths/too_long_keyword/test.robot
@@ -59,3 +59,63 @@ Keyword
     ...   ${var}
     ...   ${var}
 
+
+Keyword with comments at the end
+    Pass
+    Keyword
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    One More
+    # comments
+    # comments
+    # comments
+    # comments
+
+Keyword with comments that are not part of the test
+    Pass
+    Keyword
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    One More
+    # comments
+    # comments
+    # comments
+    # comments
+
+# standalone comment
+
+
+Short Keyword
+    No Operation
+    # comment
+
+# standalone comment
+

--- a/tests/atest/rules/lengths/too_long_test_case/expected_output.txt
+++ b/tests/atest/rules/lengths/too_long_test_case/expected_output.txt
@@ -1,1 +1,3 @@
-test.robot:6:1 [W] 0504 Test case 'Test' is too long (23/20)
+test.robot:6:1 [W] 0504 Test case 'Test' is too long (21/20)
+test.robot:29:1 [W] 0504 Test case 'Test with comments at the end' is too long (23/20)
+test.robot:54:1 [W] 0504 Test case 'Test with comments that are not part of the test' is too long (23/20)

--- a/tests/atest/rules/lengths/too_long_test_case/expected_output_ignore_docs.txt
+++ b/tests/atest/rules/lengths/too_long_test_case/expected_output_ignore_docs.txt
@@ -1,1 +1,2 @@
-test.robot:6:1 [W] 0504 Test case 'Test' is too long (22/20)
+test.robot:29:1 [W] 0504 Test case 'Test with comments at the end' is too long (23/20)
+test.robot:54:1 [W] 0504 Test case 'Test with comments that are not part of the test' is too long (23/20)

--- a/tests/atest/rules/lengths/too_long_test_case/expected_output_severity.txt
+++ b/tests/atest/rules/lengths/too_long_test_case/expected_output_severity.txt
@@ -1,2 +1,2 @@
-severity.robot:6:1 [E] 0504 Test case 'Test' is too long (21/10)
-severity.robot:32:1 [W] 0504 Test case 'Bit longer test' is too long (18/10)
+severity.robot:6:1 [E] 0504 Test case 'Test' is too long (22/10)
+severity.robot:33:1 [W] 0504 Test case 'Bit longer test' is too long (13/10)

--- a/tests/atest/rules/lengths/too_long_test_case/severity.robot
+++ b/tests/atest/rules/lengths/too_long_test_case/severity.robot
@@ -24,6 +24,7 @@ Test
     ...  ${var}
     ...  ${var}
     ...  ${var}
+    ...  ${var}
     One More
 
 Golden test

--- a/tests/atest/rules/lengths/too_long_test_case/test.robot
+++ b/tests/atest/rules/lengths/too_long_test_case/test.robot
@@ -26,6 +26,65 @@ Test
     ...  ${var}
     One More
 
+Test with comments at the end
+    Pass
+    Keyword
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    One More
+    # comments
+    # comments
+    # comments
+    # comments
+
+Test with comments that are not part of the test
+    Pass
+    Keyword
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    ...  ${var}
+    One More
+    # comments
+    # comments
+    # comments
+    # comments
+
+# standalone comment
+
+
+Short test
+    No Operation
+    # comment
+
+# standalone comment
+
 
 *** Keywords ***
 Keyword

--- a/tests/atest/rules/lengths/too_long_test_case/test_rule.py
+++ b/tests/atest/rules/lengths/too_long_test_case/test_rule.py
@@ -14,7 +14,11 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_severity(self):
         self.check_rule(
-            config="-c too-long-test-case:severity_threshold:error=20 -c too-long-test-case:max_len:10",
+            # FIXME There is issue where previous rule configuration remains even with new Robocop instance
+            # that's why we need to 'unset' ignore_docs parameter value
+            config="-c too-long-test-case:ignore_docs:False "
+            "-c too-long-test-case:severity_threshold:error=20 "
+            "-c too-long-test-case:max_len:10",
             src_files=["severity.robot"],
             expected_file="expected_output_severity.txt",
         )

--- a/tests/utest/test_disablers.py
+++ b/tests/utest/test_disablers.py
@@ -79,10 +79,17 @@ class TestDisablers:
         disabler = DisablersFinder(disablers_test_data / "enabled.robot", None)
         assert not disabler.any_disabler
 
-    @pytest.mark.parametrize("file", [1, 2, 3, 4])
+    @pytest.mark.parametrize("file", [1, 2, 3])
     def test_extended_disabling(self, file, disablers_test_data):
         source = disablers_test_data / f"extended_lines{file}.robot"
         with open(source) as f:
             data = f.read()
         issues = run_check_on_string(data, include={"too-long-keyword"}, configure=["too-long-keyword:max_len:1"])
         assert not issues
+
+    def test_disabling_after_keyword(self, disablers_test_data):
+        source = disablers_test_data / "extended_lines4.robot"
+        with open(source) as f:
+            data = f.read()
+        issues = run_check_on_string(data, include={"too-long-keyword"}, configure=["too-long-keyword:max_len:1"])
+        assert issues


### PR DESCRIPTION
Fixes #671 