### PR TITLE
Provide end line/col information to invalid-argument rule

### DIFF
--- a/docs/releasenotes/2.6.0.rst
+++ b/docs/releasenotes/2.6.0.rst
@@ -20,3 +20,10 @@ Such headers will raise deprecation warning and eventually will not be supported
 
 - unrecognized header is now only reported by ``parsing-error`` and not by ``duplicated-setting`` (#683)
 - empty lines and standalone comments are now not counted towards keyword/test length in ``too-long-test-case`` and ``too-long-keyword`` rules (#671)
+
+## Issue end location (#290)
+
+Our test framework now supports custom format of the issue - which should help in enhancing the precision of the reported
+issues. Following rules has improved precision (reported beginning and end of the rule) in this release:
+
+- ``invalid-argument``

--- a/docs/releasenotes/2.6.0.rst
+++ b/docs/releasenotes/2.6.0.rst
@@ -23,7 +23,7 @@ Such headers will raise deprecation warning and eventually will not be supported
 
 ## Issue end location (#290)
 
-Our test framework now supports custom format of the issue - which should help in enhancing the precision of the reported
-issues. Following rules has improved precision (reported beginning and end of the rule) in this release:
+Our test framework now supports custom format of the issue - which should help with enhancing the precision of the reported
+issues. The following rules have improved precision (reported beginning and end of the rule) in this release:
 
 - ``invalid-argument``

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -348,7 +348,9 @@ class ParsingErrorChecker(VisitorChecker):
         for arg in node.get_tokens(Token.ARGUMENT):
             value, *_ = arg.value.split("=", maxsplit=1)
             if value == match.group(1):
-                self.report("invalid-argument", error_msg=error[:-1], node=arg, col=arg.col_offset + 1)
+                col = arg.col_offset + 1
+                end_col = arg.end_col_offset + 1
+                self.report("invalid-argument", error_msg=error[:-1], node=arg, col=col, end_col=end_col)
                 return
         self.report("parsing-error", error_msg=error, node=node)
 

--- a/tests/atest/rules/errors/invalid_argument/expected_output.txt
+++ b/tests/atest/rules/errors/invalid_argument/expected_output.txt
@@ -1,3 +1,3 @@
-test.robot:8:20 [E] 0407 Invalid argument syntax '{var}'
-test.robot:13:12 [E] 0407 Invalid argument syntax 'value'
-test.robot:17:30 [E] 0407 Invalid argument syntax 'value'
+test.robot:8:20:8:25 [E] 0407 Invalid argument syntax '{var}'
+test.robot:13:12:13:17 [E] 0407 Invalid argument syntax 'value'
+test.robot:17:30:17:37 [E] 0407 Invalid argument syntax 'value'

--- a/tests/atest/rules/errors/invalid_argument/test_rule.py
+++ b/tests/atest/rules/errors/invalid_argument/test_rule.py
@@ -3,4 +3,6 @@ from tests.atest.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")
+        self.check_rule(
+            src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4", issue_format="end_col"
+        )


### PR DESCRIPTION
Relates #290

The goal is to slowly add end col information to all rules - whenever it is necessary. For that purpose I'm overwriting default issue format (with ``end_col`` argument). In the end it's likely that I will replace default issue format in our test framework with the one that has end col information and then remove all ``issue_format="end_col"`` arguments.