### PR TITLE
Deprecate Force Tags in RF 6 for Test Tags

### DIFF
--- a/docs/releasenotes/2.6.0.rst
+++ b/docs/releasenotes/2.6.0.rst
@@ -30,7 +30,7 @@ the multiple of ``indent`` space (default 4).
 The ``Force Tags`` setting has been renamed to ``Test Tags``. To support this change, Robocop
 renamed ``could-be-forced-tags`` rule to ``could-be-test-tags`` and ``tag-already-set-in-force-tags``
 to ``tag-already-set-in-test-tags``.
-Usage of ``Force Tags`` will result in deprecation warning from ``<PLACEHOLDER>`` new rule.
+Usage of ``Force Tags`` will result in deprecation warning from ``deprecated-statement`` rule.
 
 ## Fixes
 

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -796,6 +796,20 @@ class DeprecatedStatementChecker(VisitorChecker):
             version="5.*",
         )
 
+    def visit_ForceTags(self, node):  # noqa
+        if ROBOT_VERSION.major < 6:
+            return
+        setting_name = node.data_tokens[0].value.lower()
+        if setting_name == "force tags":
+            self.report(
+                "deprecated-statement",
+                statement_name="Force Tags",
+                alternative="Test Tags",
+                node=node,
+                col=token_col(node, Token.FORCE_TAGS),
+                version="6.0",
+            )
+
     def check_if_keyword_is_deprecated(self, keyword_name, node):
         normalized_keyword_name = normalize_robot_name(keyword_name, remove_prefix="builtin.")
         deprecated_statements = self.deprecated_keywords.get(ROBOT_VERSION.major, {})

--- a/tests/atest/rules/naming/deprecated_statement/expected_output_rf6.txt
+++ b/tests/atest/rules/naming/deprecated_statement/expected_output_rf6.txt
@@ -1,0 +1,1 @@
+force_tags.robot:2:1 [W] 0319 'Force Tags' is deprecated since Robot Framework version 6.0, use 'Test Tags' instead

--- a/tests/atest/rules/naming/deprecated_statement/force_tags.robot
+++ b/tests/atest/rules/naming/deprecated_statement/force_tags.robot
@@ -1,0 +1,3 @@
+*** Settings ***
+Force Tags    tag
+Test Tags    other tag

--- a/tests/atest/rules/naming/deprecated_statement/test_rule.py
+++ b/tests/atest/rules/naming/deprecated_statement/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_pre_rf5(self):
         self.check_rule(src_files=["test.robot"], expected_file=None, target_version="<5.0")
+
+    def test_force_tags(self):
+        self.check_rule(src_files=["force_tags.robot"], expected_file="expected_output_rf6.txt", target_version=">=6")


### PR DESCRIPTION
Closes #643 