### PR TITLE
update sarif config example to use colon delimiters

### DIFF
--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -398,7 +398,7 @@ class SarifReport(Report):
 
     You can configure output directory and report filename::
 
-        robocop --configure sarif:output_dir=C:/sarif_reports --configure sarif:report_filename=.sarif
+        robocop --configure sarif:output_dir:C:/sarif_reports --configure sarif:report_filename:.sarif
 
     """
 


### PR DESCRIPTION
Thanks for robocop!

This docs-only change helps avoid unexpected copy-pasta errors like:

```
Error: Provided invalid config: 'sarif:output_dir=build/reports/sarif' (general pattern: <rule>:<param>:<value>)
```