### PR TITLE
Refactor Config class to override default configuration file

### DIFF
--- a/docs/releasenotes/2.7.0.rst
+++ b/docs/releasenotes/2.7.0.rst
@@ -1,0 +1,29 @@
+Robocop 2.7.0
+================
+
+You can install the latest available version by running::
+
+    pip install --upgrade robotframework-robocop
+
+or to install exactly this version::
+
+    pip install robotframework-robocop==2.7.0
+
+
+File configuration changes
+---------------------------
+
+We addressed several smaller issues and incoherence with Robocop file configuration.
+
+Overriding default configuration file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you're using Robocop from the command line it reads both the cli arguments and default
+configuration file (found in the disk). The default configuration file (either ``.robocop`` or ``pyproject.toml`` file)
+is used as a base that can be overridden by the cli arguments. The problem with the previous implementation was
+that when user specified path to argument file in the cli::
+
+    robocop --argumentfile myconfig.txt
+
+Robocop would read both default configuration file and configuration file from ``--argumentfile``. Now it will read
+default configuration file only if ``-A / --argumentfile`` options are not used.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -22,27 +22,33 @@ source code. More in :ref:`including-rules`.
 
 Loading configuration from file
 -------------------------------
-.. dropdown:: How to load configuratiom from file
+.. dropdown:: How to load configuration from the file
 
-    You can load arguments for Robocop from file with ``--argumentfile / -A`` option and path to argument file::
+    Robocop supports two formats of the configuration file: argument files and toml files. If argument file is not
+    provided using CLI, Robocop will try to find default configuration file using the following algorithm:
 
-        robocop --argumentfile argument_file.txt
-        robocop -A path/to/file.txt
+    - if the directory contains ``.robocop`` file, load it
+    - otherwise, if the directory contains ``pyproject.toml`` file, load it
+    - otherwise, go to parent directory. Stop search if ``.git`` or top disk directory is found
 
-    If no arguments are provided to Robocop it will try to find ``.robocop`` file and load it from there.
-    It will start looking from current directory and go up until it founds it or '.git' file is found. ``.robocop`` file
-    supports the same syntax as given from CLI::
+    .. dropdown:: ``.robocop`` argument file
 
-        --include rulename
-        # inline comment
-        --reports all
+        Argument file supports the same syntax as given from the CLI::
 
-    If there is no ``.robocop`` file present it will try to load ``pyproject.toml`` file (if there is toml module installed).
-    Robocop use [tool.robocop] section. Options have the same names as CLI arguments.
+            --include rulename
+            # inline comment
+            --reports all
 
-    .. dropdown:: Example pyproject.toml configuration file
+        You can load arguments for Robocop from file with ``--argumentfile / -A`` option and path to the argument file::
 
-        ::
+            robocop --argumentfile argument_file.txt
+            robocop -A path/to/file.txt
+
+    .. dropdown:: ``pyproject.toml`` configuration file
+
+        Robocop use [tool.robocop] section. Options have the same names as the CLI arguments.
+
+        Example pyproject.toml configuration file::
 
             [tool.robocop]
             paths = [

--- a/robocop/files.py
+++ b/robocop/files.py
@@ -8,13 +8,15 @@ from robocop.exceptions import FileError
 DEFAULT_EXCLUDES = r"(\.direnv|\.eggs|\.git|\.hg|\.nox|\.tox|\.venv|venv|\.svn)"
 
 
-def find_project_root(srcs):
-    """Return a directory containing .git, .robocop or pyproject.toml.
-    That directory will be a common parent of all files and directories
-    passed in `srcs`.
-    If no directory in the tree contains a marker that would specify it's the
-    project root, the root of the file system is returned.
+def find_project_root(root, srcs):
     """
+    Find project root.
+    If not provided in ``root`` argument, the first parent directory containing either .git, .robocop or pyproject.toml
+    file in any of  ``srcs`` paths will be root category.
+    If not found, returns the root of the file system.
+    """
+    if root is not None:
+        return Path(root)
     if not srcs:
         return Path("/").resolve()
 

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -62,7 +62,7 @@ class Robocop:
     def reload_config(self):
         """Reload checkers and reports based on current config"""
         self.load_checkers()
-        self.config.validate_rule_names(self.rules)
+        self.config.reload(self.rules)
         self.load_reports()
         self.configure_checkers_or_reports()
         self.check_for_disabled_rules()

--- a/tests/atest/utils/__init__.py
+++ b/tests/atest/utils/__init__.py
@@ -70,7 +70,7 @@ def configure_robocop_with_rule(args, runner, rule, path, src_files: Optional[Li
             *paths,
         ]
     )
-    config.parse_opts(arguments)
+    config.parse_args(arguments)
     runner.config = config
     return runner
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,6 +1,5 @@
 """ General E2E tests to catch any general issue in Robocop """
 
-import importlib
 import sys
 from pathlib import Path
 from unittest import mock
@@ -41,8 +40,8 @@ INVALID_TEST_DATA = Path(__file__).parent.parent / "test_data_invalid"
 
 
 def should_run_with_config(robocop_instance, cfg):
-    config = Config()
-    config.parse_opts(cfg.split())
+    with mock.patch.object(sys, "argv", ["robocop", *cfg.split()]):
+        config = Config(from_cli=True)
     robocop_instance.config = config
     with pytest.raises(SystemExit):
         robocop_instance.run()
@@ -50,12 +49,10 @@ def should_run_with_config(robocop_instance, cfg):
 
 
 def configure_robocop(robocop_instance, args):
-    config = Config()
-    config.parse_opts(args.split())
+    with mock.patch.object(sys, "argv", ["robocop", *args.split()]):
+        config = Config(from_cli=True)
     robocop_instance.config = config
-    robocop_instance.load_checkers()
-    robocop_instance.load_reports()
-    robocop_instance.configure_checkers_or_reports()
+    robocop_instance.reload_config()
 
 
 class TestE2E:
@@ -85,7 +82,7 @@ class TestE2E:
 
     def test_run_non_existing_file(self, robocop_instance):
         config = Config()
-        config.parse_opts(["some_path"])
+        config.paths = ["some_path"]
         robocop_instance.config = config
         with pytest.raises(FileError) as err:
             robocop_instance.run()
@@ -138,7 +135,7 @@ class TestE2E:
     def test_include_exclude_invalid_rule(self, robocop_instance, rules, expected):
         for method in ("--include", "--exclude"):
             config = Config()
-            config.parse_opts([method, rules, "."])
+            config.parse_args([method, rules, "."])
             robocop_instance.config = config
             with pytest.raises(ConfigGeneralError) as err:
                 robocop_instance.reload_config()
@@ -167,25 +164,25 @@ class TestE2E:
 
     def test_use_argument_file(self, robocop_instance, test_data_dir):
         config = Config()
-        config.parse_opts(["-A", str(test_data_dir / "argument_file" / "args.txt")])
+        config.parse_args(["-A", str(test_data_dir / "argument_file" / "args.txt")])
 
     def test_use_not_existing_argument_file(self, test_data_dir):
         config = Config()
         with pytest.raises(ArgumentFileNotFoundError) as err:
-            config.parse_opts(["--argumentfile", "some_file", str(test_data_dir)])
+            config.parse_args(["--argumentfile", "some_file", str(test_data_dir)])
         assert 'Argument file "some_file" does not exist' in str(err)
 
     def test_argument_file_without_path(self):
         config = Config()
         with pytest.raises(ArgumentFileNotFoundError) as err:
-            config.parse_opts(["--argumentfile"])
+            config.parse_args(["--argumentfile"])
         assert 'Argument file "" does not exist' in str(err)
 
     def test_use_nested_argument_file(self, test_data_dir):
         config = Config()
         nested_args_path = str(test_data_dir / "argument_file" / "args_nested.txt")
         with pytest.raises(NestedArgumentFileError) as err:
-            config.parse_opts(["-A", nested_args_path, str(test_data_dir)])
+            config.parse_args(["-A", nested_args_path, str(test_data_dir)])
         assert "Nested argument file in " in str(err)
 
     @pytest.mark.parametrize("threshold", ["i", "I", "e", "error", "W", "WARNING"])

--- a/tests/utest/test_argument_validation.py
+++ b/tests/utest/test_argument_validation.py
@@ -14,10 +14,12 @@ def config():
 
 class TestArgumentValidation:
     def test_prog_name(self, config):
-        assert config.parser.prog == "robocop"
+        parser = config._create_parser()
+        assert parser.prog == "robocop"
 
     def test_parser_default_help_disabled(self, config):
-        assert not config.parser.add_help
+        parser = config._create_parser()
+        assert not parser.add_help
 
     def test_default_args(self, config):
         assert config.filetypes == {".resource", ".robot", ".tsv"}
@@ -31,101 +33,101 @@ class TestArgumentValidation:
         assert not config.list_reports
 
     def test_default_args_after_parse(self, config):
-        args = config.parse_opts([""])
-        assert args.filetypes == {".resource", ".robot", ".tsv"}
-        assert args.include == set()
-        assert args.exclude == set()
-        assert args.reports == ["return_status"]
-        assert args.configure == []
-        assert args.format == "{source}:{line}:{col} [{severity}] {rule_id} {desc} ({name})"
-        assert args.paths == [""]
-        assert args.output is None
+        config.parse_args([""])
+        assert config.filetypes == {".resource", ".robot", ".tsv"}
+        assert config.include == set()
+        assert config.exclude == set()
+        assert config.reports == ["return_status"]
+        assert config.configure == []
+        assert config.format == "{source}:{line}:{col} [{severity}] {rule_id} {desc} ({name})"
+        assert config.paths == [""]
+        assert config.output is None
 
     def test_filetypes_duplicate_defaults(self, config):
-        args = config.parse_opts(["--filetypes", "robot,resource", ""])
-        assert args.filetypes == {".resource", ".robot", ".tsv"}
+        config.parse_args(["--filetypes", "robot,resource", ""])
+        assert config.filetypes == {".resource", ".robot", ".tsv"}
 
     def test_filetypes_duplicate_dot_prefixed_defaults(self, config):
-        args = config.parse_opts(["--filetypes", ".robot,.resource", ""])
-        assert args.filetypes == {".resource", ".robot", ".tsv"}
+        config.parse_args(["--filetypes", ".robot,.resource", ""])
+        assert config.filetypes == {".resource", ".robot", ".tsv"}
 
     def test_include_one_rule(self, config):
         rule_name = "missing-doc-keyword"
-        args = config.parse_opts(["--include", rule_name, ""])
-        assert args.include == {rule_name}
+        config.parse_args(["--include", rule_name, ""])
+        assert config.include == {rule_name}
 
     def test_include_two_same_rules_comma_separated(self, config):
         rule_name = "missing-doc-keyword"
-        args = config.parse_opts(["--include", ",".join([rule_name, rule_name]), ""])
-        assert args.include == {rule_name}
+        config.parse_args(["--include", ",".join([rule_name, rule_name]), ""])
+        assert config.include == {rule_name}
 
     def test_include_two_same_rules_provided_separately(self, config):
         rule_name = "missing-doc-keyword"
-        args = config.parse_opts(["--include", rule_name, "--include", rule_name, ""])
-        assert args.include == {rule_name}
+        config.parse_args(["--include", rule_name, "--include", rule_name, ""])
+        assert config.include == {rule_name}
 
     def test_include_two_different_rules_comma_separated(self, config):
         rule_name1 = "missing-doc-keyword"
         rule_name2 = "not-allowed-char-in-name"
         rules_names = ",".join([rule_name1, rule_name2])
-        args = config.parse_opts(["--include", rules_names, ""])
-        assert args.include == {rule_name1, rule_name2}
+        config.parse_args(["--include", rules_names, ""])
+        assert config.include == {rule_name1, rule_name2}
 
     def test_include_two_different_rules_provided_separately(self, config):
         rule_name1 = "missing-doc-keyword"
         rule_name2 = "not-allowed-char-in-name"
-        args = config.parse_opts(["--include", rule_name1, "--include", rule_name2, ""])
-        assert args.include == {rule_name1, rule_name2}
+        config.parse_args(["--include", rule_name1, "--include", rule_name2, ""])
+        assert config.include == {rule_name1, rule_name2}
 
     def test_exclude_one_rule(self, config):
         rule_name = "missing-doc-keyword"
-        args = config.parse_opts(["--exclude", rule_name, ""])
-        assert args.exclude == {rule_name}
+        config.parse_args(["--exclude", rule_name, ""])
+        assert config.exclude == {rule_name}
 
     def test_exclude_two_same_rules_comma_separated(self, config):
         rule_name = "missing-doc-keyword"
-        args = config.parse_opts(["--exclude", ",".join([rule_name, rule_name]), ""])
-        assert args.exclude == {rule_name}
+        config.parse_args(["--exclude", ",".join([rule_name, rule_name]), ""])
+        assert config.exclude == {rule_name}
 
     def test_exclude_two_same_rules_provided_separately(self, config):
         rule_name = "missing-doc-keyword"
-        args = config.parse_opts(["--exclude", rule_name, "--exclude", rule_name, ""])
-        assert args.exclude == {rule_name}
+        config.parse_args(["--exclude", rule_name, "--exclude", rule_name, ""])
+        assert config.exclude == {rule_name}
 
     def test_exclude_two_different_rules_comma_separated(self, config):
         rule_name1 = "missing-doc-keyword"
         rule_name2 = "not-allowed-char-in-name"
         rules_names = ",".join([rule_name1, rule_name2])
-        args = config.parse_opts(["--exclude", rules_names, ""])
-        assert args.exclude == {rule_name1, rule_name2}
+        config.parse_args(["--exclude", rules_names, ""])
+        assert config.exclude == {rule_name1, rule_name2}
 
     def test_exclude_two_different_rules_provided_separately(self, config):
         rule_name1 = "missing-doc-keyword"
         rule_name2 = "not-allowed-char-in-name"
-        args = config.parse_opts(["--exclude", rule_name1, "--exclude", rule_name2, ""])
-        assert args.exclude == {rule_name1, rule_name2}
+        config.parse_args(["--exclude", rule_name1, "--exclude", rule_name2, ""])
+        assert config.exclude == {rule_name1, rule_name2}
 
     def test_format_overwrite_default(self, config):
         default_format = "{source}:{line}:{col} [{severity}] {rule_id} {desc}"
-        args = config.parse_opts(["--format", default_format, ""])
-        assert args.format == default_format
+        config.parse_args(["--format", default_format, ""])
+        assert config.format == default_format
 
     def test_format_empty(self, config):
         empty_format = ""
-        args = config.parse_opts(["--format", empty_format, ""])
-        assert args.format == ""
+        config.parse_args(["--format", empty_format, ""])
+        assert config.format == ""
 
     def test_format_new_value(self, config):
         new_format = "{source}: {rule_id} {desc}"
-        args = config.parse_opts(["--format", new_format, ""])
-        assert args.format == new_format
+        config.parse_args(["--format", new_format, ""])
+        assert config.format == new_format
 
     def test_output_new_value(self, config):
         output_file = "results"
-        args = config.parse_opts(["--output", output_file, ""])
-        assert isinstance(args.output, io.TextIOWrapper)
-        assert args.output.name == output_file
-        assert args.output.mode == "w"
+        config.parse_args(["--output", output_file, ""])
+        assert isinstance(config.output, io.TextIOWrapper)
+        assert config.output.name == output_file
+        assert config.output.mode == "w"
         assert pathlib.Path(output_file).exists()
         # parser will not close the file itself
         if not config.output.closed:
@@ -136,33 +138,33 @@ class TestArgumentValidation:
     @pytest.mark.parametrize("cmd", ["-h", "--help"])
     def test_help_message(self, config, cmd, capsys):
         with pytest.raises(SystemExit):
-            config.parse_opts([cmd])
+            config.parse_args([cmd])
         out, _ = capsys.readouterr()
         assert "usage:" in out
 
     @pytest.mark.parametrize("cmd", ["-v", "--version"])
     def test_version_number(self, config, cmd, capsys):
         with pytest.raises(SystemExit):
-            config.parse_opts(["-v"])
+            config.parse_args(["-v"])
         out, _ = capsys.readouterr()
         assert __version__ in out
 
     def test_paths_new_value(self, config):
-        args = config.parse_opts(["tests.robot"])
-        assert args.paths == ["tests.robot"]
+        config.parse_args(["tests.robot"])
+        assert config.paths == ["tests.robot"]
 
     def test_paths_two_values(self, config):
-        args = config.parse_opts(["tests.robot", "test2.robot"])
-        assert args.paths == ["tests.robot", "test2.robot"]
+        config.parse_args(["tests.robot", "test2.robot"])
+        assert config.paths == ["tests.robot", "test2.robot"]
 
     def test_list_reports(self, config):
-        args = config.parse_opts(["--list-reports"])
-        assert args.list_reports
+        config.parse_args(["--list-reports"])
+        assert config.list_reports
 
     def test_single_language(self, config):
-        args = config.parse_opts(["--lang", "fi"])
-        assert ["fi"] == args.language
+        config.parse_args(["--lang", "fi"])
+        assert ["fi"] == config.language
 
     def test_two_languages(self, config):
-        args = config.parse_opts(["--lang", "fi,pl"])
-        assert ["fi", "pl"] == args.language
+        config.parse_args(["--lang", "fi,pl"])
+        assert ["fi", "pl"] == config.language

--- a/tests/utest/test_thresholds.py
+++ b/tests/utest/test_thresholds.py
@@ -49,7 +49,8 @@ class TestRuleSeverityThreshold:
     def test_invalid_threshold_config(self):
         thresholds = SeverityThreshold("line_length")
         exp_error = (
-            "Invalid severity value 'error'. " "It should be list of `severity=param_value` pairs, separated by `:`."
+            "Invalid configuration for Robocop:\n"
+            "Invalid severity value 'error'. It should be list of `severity=param_value` pairs, separated by `:`."
         )
         with pytest.raises(robocop.exceptions.InvalidArgumentError, match=exp_error):
             thresholds.value = "error"


### PR DESCRIPTION
Fixes #751

Now if user run:

```
robocop --verbose
```
it will use configuration from both cli and default configuration file (if it exists). This works like before.

When user run:

```
robocop --argumentfile path/to/file.txt
```
It will only use configuration from the cli and configuration file passed using ``--argumentfile`` (default configuration file will not be loaded).