### PR TITLE
Clean dependencies

### DIFF
--- a/docs/including_rules.rst
+++ b/docs/including_rules.rst
@@ -38,7 +38,7 @@ most linters.
 
 It is possible to disable rule for particular line or lines::
 
-    Some Keyword  # robocop: disable:rule1,rule2
+    Some Keyword  # robocop: disable=rule1,rule2
 
 In this example no message will be printed for this line for rules named ``rule1``, ``rule2``.
 

--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -21,14 +21,13 @@ import inspect
 import json
 import sys
 from collections import OrderedDict, defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from operator import itemgetter
 from pathlib import Path
 from timeit import default_timer as timer
 from warnings import warn
 
 import pytz
-from dateutil import tz
 
 import robocop.exceptions
 from robocop.rules import Message
@@ -374,8 +373,11 @@ class TimestampReport(Report):
 
     def _get_timestamp(self) -> str:
         try:
-            timezone = tz.tzlocal() if self.timezone == "local" else pytz.timezone(self.timezone)
-            return datetime.now(timezone).strftime(self.format)
+            if self.timezone == "local":
+                timezone_code = datetime.now(timezone.utc).astimezone().tzinfo
+            else:
+                timezone_code = pytz.timezone(self.timezone)
+            return datetime.now(timezone_code).strftime(self.format)
         except pytz.exceptions.UnknownTimeZoneError as err:
             raise robocop.exceptions.ConfigGeneralError(
                 f"Provided timezone '{self.timezone}' for report '{getattr(self, 'name')}' is not valid. "

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
             "coverage",
             "pytest",
             "pyyaml",
+            "pytest-benchmark",
         ],
         "doc": [
             "furo",


### PR DESCRIPTION
- Remove `dateutil` dependency (closes #743)
- Add `pytest-benchmark` as dev dependency
- Fix an example in docs with disabling rule