### PR TITLE
Fix non-path option values resolved as a path in argument files

### DIFF
--- a/docs/releasenotes/2.8.1.rst
+++ b/docs/releasenotes/2.8.1.rst
@@ -1,0 +1,15 @@
+:orphan:
+
+Robocop 2.8.1
+================
+
+Recent update to configuration argument files introduces a bug where option values were appended by a path to the
+argument file directory. It should be fixed with this release.
+
+You can install the latest available version by running::
+
+    pip install --upgrade robotframework-robocop
+
+or to install exactly this version::
+
+    pip install robotframework-robocop==2.8.1

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -133,12 +133,16 @@ class ArgumentFileParser:
         prev_arg = "option"
         resolved = []
         for arg in args:
-            if (prev_option_like and prev_arg in self.RESOLVE_PATHS_OPTIONS) or prev_option_like:
+            option_like = arg.startswith("-")
+            # resolve path if previous arg was an option that can be path, or the arg is a source
+            if (prev_option_like and prev_arg in self.RESOLVE_PATHS_OPTIONS) or (
+                not prev_option_like and not option_like
+            ):
                 ensure_exists = prev_arg in self.ENSURE_EXIST_PATHS_OPTIONS
                 # TODO: If the --rules is provided as comma separated list, it will not resolve paths
                 arg = resolve_relative_path(arg, root_dir, ensure_exists)
             resolved.append(arg)
-            prev_option_like = arg.startswith("-")
+            prev_option_like = option_like
             prev_arg = arg
         return resolved
 

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -135,8 +135,8 @@ class ArgumentFileParser:
         for arg in args:
             option_like = arg.startswith("-")
             # resolve path if previous arg was an option that can be path, or the arg is a source
-            if (prev_option_like and prev_arg in self.RESOLVE_PATHS_OPTIONS) or (
-                not prev_option_like and not option_like
+            if (prev_option_like and prev_arg in self.RESOLVE_PATHS_OPTIONS) or (  # option value that can be path
+                not prev_option_like and not option_like  # source
             ):
                 ensure_exists = prev_arg in self.ENSURE_EXIST_PATHS_OPTIONS
                 # TODO: If the --rules is provided as comma separated list, it will not resolve paths

--- a/tests/test_data/argument_file/base.txt
+++ b/tests/test_data/argument_file/base.txt
@@ -1,1 +1,2 @@
 --ext-rules rflinter.robocop.naming
+--configure too-long-test-case:severity:I

--- a/tests/utest/test_default_config.py
+++ b/tests/utest/test_default_config.py
@@ -244,3 +244,4 @@ def test_nested_argument_files(path_to_test_data):
     ):
         config = Config(from_cli=True)
         assert config.ext_rules == {"rflinter.robocop.spacing", "rflinter.robocop.naming"}
+        assert config.configure == ["too-long-test-case:severity:I"]


### PR DESCRIPTION
Last release introduced regression. This PR introduces fix and next fix release (since it could break pipelines if someones uses Robocop argumentfile and always instant most recent version). 

The bug was in forcefully resolving option values as a path even if they are not a path. For example if you had configuration:

```
--configure rule:param:value
```

Robocop would read it as:

```
--configure path/to/configuration.file/rule:param:value
```
