### PR TITLE
Remove predefined severity for 1008 bad-indent rule

### DIFF
--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -618,7 +618,6 @@ class UnevenIndentChecker(VisitorChecker):
                     self.report(
                         "bad-indent",
                         bad_indent_msg="Line is over-indented",
-                        severity=RuleSeverity.WARNING,
                         node=child,
                         col=token_col(child, Token.COMMENT),
                     )
@@ -710,7 +709,6 @@ class UnevenIndentChecker(VisitorChecker):
             self.report(
                 "bad-indent",
                 bad_indent_msg="Indent expected. Provide 2 or more spaces of indentation for statements inside block",
-                severity=RuleSeverity.ERROR,
                 node=statement,
                 col=indent + 1,
             )
@@ -724,7 +722,6 @@ class UnevenIndentChecker(VisitorChecker):
         self.report(
             "bad-indent",
             bad_indent_msg=f"Line is {over_or_under}-indented",
-            severity=RuleSeverity.WARNING,
             node=statement,
             col=indent + 1,
         )


### PR DESCRIPTION
For some reason, we preconfigured this rule with specific severity, based on the different cases. This made it impossible to configure the rule, because the severity specified in the code always overwrote it.

Fixes #793 