### PR TITLE
Support DDT for bad indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Will result in following output:
 \Users\OCP\test.robot:22:1 [E] 0801 Multiple test cases with name "Simple Test" (first occurrence in line 17) (duplicated-test-case)
 \Users\OCP\test.robot:42:1 [E] 0810 Both Task(s) and Test Case(s) section headers defined in file (both-tests-and-tasks)
 \Users\OCP\test.robot:48:1 [W] 0302 Keyword 'my keyword' does not follow case convention (wrong-case-in-keyword-name)
-\Users\OCP\test.robot:51:13 [I] 0606 Tag 'mytag' is already set by Force Tags in suite settings (tag-already-set-in-force-tags)
+\Users\OCP\test.robot:51:13 [I] 0606 Tag 'mytag' is already set by Test Tags in suite settings (tag-already-set-in-test-tags)
 
 Found 5 issues: 2 ERRORs, 2 WARNINGs, 1 INFO.
 ```

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -57,7 +57,7 @@ Will result in following output:
     \Users\OCP\test.robot:22:1 [E] 0801 Multiple test cases with name "Simple Test" (first occurrence in line 17) (duplicated-test-case)
     \Users\OCP\test.robot:42:1 [E] 0810 Both Task(s) and Test Case(s) section headers defined in file (both-tests-and-tasks)
     \Users\OCP\test.robot:48:1 [W] 0302 Keyword 'my keyword' does not follow case convention (wrong-case-in-keyword-name)
-    \Users\OCP\test.robot:51:13 [I] 0606 Tag 'mytag' is already set by Force Tags in suite settings (tag-already-set-in-force-tags)
+    \Users\OCP\test.robot:51:13 [I] 0606 Tag 'mytag' is already set by Test Tags in suite settings (tag-already-set-in-test-tags)
 
     Found 5 issues: 2 ERRORs, 2 WARNINGs, 1 INFO.
 

--- a/docs/releasenotes/3.0.0.rst
+++ b/docs/releasenotes/3.0.0.rst
@@ -7,6 +7,9 @@ This version of Robocop hugely improves the experience of using Robocop
 within the IDEs by fixing the locations of rule violations in code, which
 in turn results in correct underlining of the issues.
 
+There are backward-incompatible changes to the W1008 ``bad-indent`` rule
+and its parameters (described below in details).
+
 Additionally, we bumped the versions of the dependencies up.
 
     You can install the latest available version by running::
@@ -26,6 +29,10 @@ where the rule violation starts and ends, meaning that the precise position
 is now defined correctly. Thanks to that, the LSP will correctly pass that
 information to the IDE you're using and will underline every place that
 needs your attention.
+
+Changes to the locations of the issues may affect the locally used disablers,
+and in result may require doing reviewing them and updating. That's why we
+decided to release new major version.
 
 Bumped dependencies (#792)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,27 +56,46 @@ that any violation of this rule within the Documentation will be ignored.
 If you want to detect the violations in the Documentation setting or section,
 configure this rule with ``-c 1015:ignore_docs:False``.
 
-Deprecated parameters of W1008 ``bad-indent`` rule and new E1017 rule for bad indentation in code block (#793)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Deprecated parameters of W1008 ``bad-indent`` rule (#803)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Old ``bad-indent`` rule has been split into two:
 
-- the old one W1008 ``bad-indent`` stays, but it will only detect under- or
-  over-indented code. The ``ignore_uneven`` and ``strict`` are no longer available,
-  but ``indent`` parameter remains the same, with a new default value of -1,
-  which makes it being ignored by default.
-- the new E1017 ``bad-block-indent`` rule that detects invalid indentation
-  inside code block like FOR loops or TRY-EXCEPT statements.
+The old one W1008 ``bad-indent`` stays, but it will only detect under- or
+over-indented code. The ``ignore_uneven`` and ``strict`` are no longer available,
+but ``indent`` parameter remains the same, with a new default value of -1,
+which makes it being ignored by default.
 
 Using ``bad-indent`` rule now prints a deprecation warning in the console
 that suggests to replace old parameters with new E1017 rule. The parameters
 are still accepted, but they no longer control the behavior of W1008 rule.
 The warning will disappear in the next major release.
 
+The new rule is described below.
+
+New E1017 rule for bad indentation in code block (#803)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new E1017 ``bad-block-indent`` rule that detects invalid indentation
+inside code block like FOR loops or TRY-EXCEPT statements.
+
 The rule now reports only when the line is under- or over-indented.
 
-Also, there was a bug (#793) that prevented the severity of the old ``bad-indent``
+Severity for ``bad-indent`` rule can be configured now (#793)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There was a bug (#793) that prevented the severity of the old ``bad-indent``
 rule from being configured. It is fixed now.
+
+``bad-indent`` rule now supports data-driven tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 From now on, ``bad-indent`` also properly supports data-driven tests (#758)
 in templated suites. If you encounter any issues, please report them back to us.
+
+New bug report template
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The `bug report template
+<https://github.com/MarketSquare/robotframework-robocop/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBug%5D+Title>`_
+is now extended to make it easier for the users to report bugs and for us to reproduce them.

--- a/docs/releasenotes/3.0.0.rst
+++ b/docs/releasenotes/3.0.0.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 Robocop 3.0.0
-================
+=============
 
 This version of Robocop hugely improves the experience of using Robocop
 within the IDEs by fixing the locations of rule violations in code, which
@@ -18,7 +18,7 @@ Additionally, we bumped the versions of the dependencies up.
         pip install robotframework-robocop==3.0.0
 
 Precise locations of the rule violations (#290)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The main improvement focused around adjusting the locations
 where the rules are violated in the code. More specifically, it improves
@@ -31,40 +31,45 @@ Bumped dependencies (#792)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There were some compatibility issues due to outdated packages.
-Now, all of them are updated, especially `packaging` now allows to use v23.
+Now, all of them are updated, especially ``packaging`` now allows to use v23.
 
 Improved internal quality (#652)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A couple of new GitHub Actions have been added to our GitHub CI.
 New Black action now scans Robocop code to ensure code quality.
 There is also new pre-commit job and additional unit tests.
 
-`misaligned-continuation-row` rule now ignores documentation by default (#789)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``misaligned-continuation-row`` rule now ignores documentation by default (#789)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is a new `ignore_docs` parameter added to 1015
-`misaligned-continuation-row` rule set to `True` by default, which means
+There is a new ``ignore_docs`` parameter added to 1015
+``misaligned-continuation-row`` rule set to ``True`` by default, which means
 that any violation of this rule within the Documentation will be ignored.
 If you want to detect the violations in the Documentation setting or section,
-configure this rule with `-c 1015:ignore_docs:False`.
+configure this rule with ``-c 1015:ignore_docs:False``.
 
-Deprecated parameters of W1008 `bad-indent rule` and 
-new E1017 rule for bad indentation in code block (#793)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Deprecated parameters of W1008 ``bad-indent`` rule and new E1017 rule for bad indentation in code block (#793)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Old `bad-indent` rule has been split into two:
-- the old one W1008 `bad-indent` stays, but it will only detect under- or
-  over-indented code. The `ignore_uneven` and `strict` are no longer available,
-  but `indent` parameter remains the same, with a new default value of -1,
+Old ``bad-indent`` rule has been split into two:
+
+- the old one W1008 ``bad-indent`` stays, but it will only detect under- or
+  over-indented code. The ``ignore_uneven`` and ``strict`` are no longer available,
+  but ``indent`` parameter remains the same, with a new default value of -1,
   which makes it being ignored by default.
-- the new E1017 `bad-block-indent` rule that detects invalid indentation
+- the new E1017 ``bad-block-indent`` rule that detects invalid indentation
   inside code block like FOR loops or TRY-EXCEPT statements.
 
-Using `bad-indent` rule now prints a deprecation warning in the console
+Using ``bad-indent`` rule now prints a deprecation warning in the console
 that suggests to replace old parameters with new E1017 rule. The parameters
 are still accepted, but they no longer control the behavior of W1008 rule.
 The warning will disappear in the next major release.
 
-Also, there was a bug (#793) that prevented the severity of the old `bad-indent`
-rule from being configured. It is now fixed and the rule can be configured.
+The rule now reports only when the line is under- or over-indented.
+
+Also, there was a bug (#793) that prevented the severity of the old ``bad-indent``
+rule from being configured. It is fixed now.
+
+From now on, ``bad-indent`` also properly supports data-driven tests (#758)
+in templated suites. If you encounter any issues, please report them back to us.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -129,7 +129,7 @@ Rules list can be filtered out by glob pattern:
     Rule - 0601 [W]: tag-with-space: Tag '{{ tag }}' should not contain spaces (enabled)
     Rule - 0602 [I]: tag-with-or-and: Tag '{{ tag }}' with reserved word OR/AND. Hint: make sure to include this tag using lowercase name to avoid issues (enabled)
     Rule - 0603 [W]: tag-with-reserved-word: Tag '{{ tag }}' prefixed with reserved word `robot:` (enabled)
-    Rule - 0606 [I]: tag-already-set-in-force-tags: Tag 'mytag' is already set by Force Tags in suite settings (enabled)
+    Rule - 0606 [I]: tag-already-set-in-test-tags: Tag 'mytag' is already set by Test Tags in suite settings (enabled)
 
 Use ``-lc \ --list-configurables`` argument to list rules together with available configurable parameters. Optional pattern argument is also supported:
 

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -517,6 +517,11 @@ class InconsistentUseOfTabsAndSpacesChecker(VisitorChecker, ModelVisitor):
 
 
 def get_indent(node):
+    """Calculate the indentation length for given node
+
+    Returns:
+        int: Indentation length
+    """
     tokens = node.tokens if hasattr(node, "tokens") else node.header.tokens
     indent_len = 0
     for token in tokens:
@@ -527,17 +532,34 @@ def get_indent(node):
 
 
 def count_indents(node):
+    """Counts number of occurrences for unique indent values
+
+    Returns:
+        Counter: A counter of unique indent values with associated number of occurrences in given node
+    """
     indents = Counter()
     if node is None:
         return indents
     for line in node.body:
         if isinstance(line, (EmptyLine, Comment)):
             continue
-        indents[(get_indent(line))] += 1
+        # for templated suite, there can be data on the same line where the test case name is
+        if node.lineno == line.lineno and isinstance(node, TestCase):
+            indents[len(node.name) + (get_indent(line))] += 1
+        else:
+            indents[(get_indent(line))] += 1
     return indents
 
 
 def most_common_indent(indents):
+    """Returns most commonly occurred indent
+
+    Args:
+        indents (Counter): A counter of unique indent values with associated number of occurrences in given node
+
+    Returns:
+        indent (int): Most common indent or the first one
+    """
     common_indents = indents.most_common(1)
     if not common_indents:
         return 0

--- a/tests/atest/rules/spacing/bad_indent/bug758/expected_output.txt
+++ b/tests/atest/rules/spacing/bad_indent/bug758/expected_output.txt
@@ -1,0 +1,3 @@
+bug758${/}templated_suite.robot:21:1 [W] 1008 Line is under-indented
+bug758${/}templated_suite.robot:26:1 [W] 1008 Line is under-indented
+bug758${/}templated_suite.robot:30:1 [W] 1008 Line is under-indented

--- a/tests/atest/rules/spacing/bad_indent/bug758/templated_suite.robot
+++ b/tests/atest/rules/spacing/bad_indent/bug758/templated_suite.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Documentation       Templated suite with cases from #758 bug
+Test Template       Login with invalid credentials should fail
+
+
+*** Test Cases ***                  USERNAME            PASSWORD
+Invalid User Name                   [Tags]              foo
+                                    invalid             ${VALID PASSWORD}
+Invalid Password                    [Documentation]     foo
+                                    [Tags]              bar
+                                    ${VALID USER}       invalid
+Invalid User Name and Password      [Tags]              baz
+                                    invalid             invalid
+Empty User Name
+                                    ${EMPTY}            ${VALID PASSWORD}
+Empty Password                      ${VALID USER}       ${EMPTY}
+                                    [Tags]              spam  eggs
+Empty User Name and Password        ${EMPTY}            ${EMPTY}
+# Wrong cases below
+Invalid User Name                   [Tags]              foo
+                   invalid             ${VALID PASSWORD}
+Invalid Password                    [Documentation]     foo
+                                    [Tags]              bar
+                                    ${VALID USER}       invalid
+Invalid User Name and Password      [Tags]              baz
+      nvalid             invalid
+Empty User Name
+                                    ${EMPTY}            ${VALID PASSWORD}
+Empty Password                      ${VALID USER}       ${EMPTY}
+                      [Tags]              spam  eggs
+Empty User Name and Password        ${EMPTY}            ${EMPTY}
+
+
+*** Keywords ***
+Login With Invalid Credentials Should Fail
+    [Documentation]    Templated keyword
+    [Arguments]    ${username}    ${password}
+    No Operation

--- a/tests/atest/rules/spacing/bad_indent/test_rule.py
+++ b/tests/atest/rules/spacing/bad_indent/test_rule.py
@@ -12,6 +12,7 @@ class TestRuleAcceptance(RuleAcceptance):
     def test_strict_3_spaces(self, file_suffix, target_version):
         self.check_rule(
             config="-c bad-indent:indent:3",
+            src_files=["bug375.robot", "comments.robot", "test.robot"],
             expected_file=f"indent_3spaces/expected_output{file_suffix}.txt",
             target_version=target_version,
         )
@@ -20,6 +21,14 @@ class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self, file_suffix, target_version):
         self.check_rule(
             config="-c bad-indent:indent:-1",
+            src_files=["bug375.robot", "comments.robot", "test.robot"],
             expected_file=f"expected_output{file_suffix}.txt",
             target_version=target_version,
+        )
+
+    def test_758_bug(self):
+        self.check_rule(
+            config="-c bad-indent:indent:-1",
+            src_files=["bug758/templated_suite.robot"],
+            expected_file="bug758/expected_output.txt",
         )


### PR DESCRIPTION
- Added support for templated suite for `bad-indent` rule
- Added tests for the `bad-indent` rule
- Removed mentions of the old rules from docs
- Added docstrings to mysterious functions that I debugged
- Reformatted release notes and added more info

Please take a look at line 547 in `robocop/checkers/spacing.py` file below. This is what handles templated suites properly, but I'm not entirely sure if this is a desired implementation. I added a comment here, so maybe it can stay like this.

Fixes #758 