### PR TITLE
Ignore nested variables in rules 0309 and 0310

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
     id: run-command
     attributes:
       label: What command/code did you try to run?
-      description: Please include as much details as possible
+      description: Please include as much details as possible. Consider using \`\`\` for formatting.
       placeholder: Paste the command and/or the code snippet
     validations:
       required: true

--- a/docs/releasenotes/3.1.0.rst
+++ b/docs/releasenotes/3.1.0.rst
@@ -1,0 +1,56 @@
+:orphan:
+
+=============
+Robocop 3.1.0
+=============
+
+<Release description>
+
+You can install the latest available version by running
+
+::
+
+    pip install --upgrade robotframework-robocop
+
+or to install exactly this version
+
+::
+
+    pip install robotframework-robocop==3.1.0
+
+.. contents::
+   :depth: 2
+   :local:
+
+Most important changes
+======================
+
+Change title (#0)
+-----------------------------------------------
+
+Description
+
+Rule changes
+============
+
+Rules W0310 and W0309 now ignore nested variables (#678)
+------------------------------------------------------------------------------------------
+
+Rules W0310 ``non-local-variables-should-be-uppercase`` and W0309 ``section-variable-not-uppercase``
+were previously reporting when the variable had another nested variable with lowercase name,
+e.g. `${EXAMPLE_${lowercase}}`.
+Now, the nested variables are ignored and if the rest of the name is uppercase, the rules
+will not report the issue anymore.
+
+Other features
+==============
+
+Feature title (#0)
+--------------------------------
+
+Description
+
+Acknowledgements
+================
+
+Thanks to...

--- a/docs/releasenotes/3.1.0.rst
+++ b/docs/releasenotes/3.1.0.rst
@@ -33,14 +33,18 @@ Description
 Rule changes
 ============
 
-Rules W0310 and W0309 now ignore nested variables (#678)
+Rules W0310 and W0309 now handle nested variables (#678)
 ------------------------------------------------------------------------------------------
 
 Rules W0310 ``non-local-variables-should-be-uppercase`` and W0309 ``section-variable-not-uppercase``
 were previously reporting when the variable had another nested variable with lowercase name,
 e.g. `${EXAMPLE_${lowercase}}`.
-Now, the nested variables are ignored and if the rest of the name is uppercase, the rules
+Now, the nested variable names passed as an argument to one of the keywords `Set Test Variable`,
+`Set Suite Variable` or `Set Global Variable` are ignored and if the rest of the name is uppercase, the rules
 will not report the issue anymore.
+For variables in Variables section, the name still needs to be all uppercase (including
+nested variable), because all nested variables in this section need to be global anyway.
+
 
 Other features
 ==============

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -666,25 +666,24 @@ class VariableNamingChecker(VisitorChecker):
         }
         super().__init__()
 
-    def visit_VariableSection(self, node):  # noqa
-        for child in node.body:
-            if not child.data_tokens:
-                continue
-            token = child.data_tokens[0]
-            if token.type != Token.VARIABLE or not token.value:
-                continue
-            var_name = search_variable(token.value).base
-            if var_name is None:
-                continue  # in RF<=5, a continuation mark ` ...` is wrongly considered a variable
-            normalized_var_name = remove_nested_variables(var_name)
-            if not normalized_var_name.isupper():
-                self.report(
-                    "section-variable-not-uppercase",
-                    variable_name=token.value.strip(),
-                    lineno=token.lineno,
-                    col=token.col_offset + 1,
-                    end_col=token.col_offset + len(token.value) + 1,
-                )
+    def visit_Variable(self, node):  # noqa
+        if not node.data_tokens:
+            return
+        token = node.data_tokens[0]
+        if not token.value:
+            return
+        var_name = search_variable(token.value).base
+        if var_name is None:
+            return  # in RF<=5, a continuation mark ` ...` is wrongly considered a variable
+        normalized_var_name = remove_nested_variables(var_name)
+        if not normalized_var_name.isupper():
+            self.report(
+                "section-variable-not-uppercase",
+                variable_name=token.value.strip(),
+                lineno=token.lineno,
+                col=token.col_offset + 1,
+                end_col=token.col_offset + len(token.value) + 1,
+            )
 
     def visit_KeywordCall(self, node):  # noqa
         for token in node.get_tokens(Token.ASSIGN):
@@ -703,7 +702,7 @@ class VariableNamingChecker(VisitorChecker):
             if len(node.data_tokens) < 2:
                 return
             token = node.data_tokens[1]
-            if token.type != Token.ARGUMENT or not token.value:
+            if not token.value:
                 return
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -675,8 +675,9 @@ class VariableNamingChecker(VisitorChecker):
         var_name = search_variable(token.value).base
         if var_name is None:
             return  # in RF<=5, a continuation mark ` ...` is wrongly considered a variable
-        normalized_var_name = remove_nested_variables(var_name)
-        if not normalized_var_name.isupper():
+        # in Variables section, everything needs to be in uppercase
+        # because even when the variable is nested, it needs to be global
+        if not var_name.isupper():
             self.report(
                 "section-variable-not-uppercase",
                 variable_name=token.value.strip(),
@@ -706,6 +707,8 @@ class VariableNamingChecker(VisitorChecker):
                 return
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)
+            # a variable as a keyword argument can contain lowercase nested variable
+            # because the actual value of it may be uppercase
             if not normalized_var_name.isupper():
                 self.report(
                     "non-local-variables-should-be-uppercase",

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -671,9 +671,11 @@ class VariableNamingChecker(VisitorChecker):
             if not child.data_tokens:
                 continue
             token = child.data_tokens[0]
+            if token.type != Token.VARIABLE or not token.value:
+                return
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)
-            if token.type == Token.VARIABLE and token.value and not normalized_var_name.isupper():
+            if not normalized_var_name.isupper():
                 self.report(
                     "section-variable-not-uppercase",
                     variable_name=token.value,
@@ -699,9 +701,11 @@ class VariableNamingChecker(VisitorChecker):
             if len(node.data_tokens) < 2:
                 return
             token = node.data_tokens[1]
+            if token.type != Token.VARIABLE or not token.value:
+                return
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)
-            if token.type == Token.ARGUMENT and not normalized_var_name.isupper():
+            if not normalized_var_name.isupper():
                 self.report(
                     "non-local-variables-should-be-uppercase",
                     node=node,

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from robot.api import Token
 from robot.parsing.model.blocks import Keyword
 from robot.parsing.model.statements import Arguments, KeywordCall
+from robot.variables.search import search_variable
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleParam, RuleSeverity
@@ -22,6 +23,7 @@ from robocop.utils import (
     remove_robot_vars,
     token_col,
 )
+from robocop.utils.misc import remove_nested_variables
 from robocop.utils.run_keywords import iterate_keyword_names
 
 rules = {
@@ -165,6 +167,22 @@ rules = {
         name="non-local-variables-should-be-uppercase",
         msg="Test, suite and global variables should be uppercase",
         severity=RuleSeverity.WARNING,
+        docs="""
+        Good::
+
+            Set Task Variable    ${MY_VAR}           1
+            Set Suite Variable   ${MY VAR}           1
+            Set Test Variable    ${MY_VAR}           1
+            Set Global Variable  ${MY VAR${nested}}  1
+
+        Bad::
+
+            Set Task Variable    ${my_var}           1
+            Set Suite Variable   ${My Var}           1
+            Set Test Variable    ${myvar}            1
+            Set Global Variable  ${my_var${NESTED}}  1
+
+        """,
     ),
     "0311": Rule(
         rule_id="0311",
@@ -679,7 +697,9 @@ class VariableNamingChecker(VisitorChecker):
             if len(node.data_tokens) < 2:
                 return
             token = node.data_tokens[1]
-            if token.type == Token.ARGUMENT and not token.value.isupper():
+            var_name = search_variable(token.value).base
+            normalized_var_name = remove_nested_variables(var_name)
+            if token.type == Token.ARGUMENT and not normalized_var_name.isupper():
                 self.report(
                     "non-local-variables-should-be-uppercase",
                     node=node,

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -671,8 +671,8 @@ class VariableNamingChecker(VisitorChecker):
             if not child.data_tokens:
                 continue
             token = child.data_tokens[0]
-            if token.type != Token.VARIABLE or not token.value:
-                return
+            if not (token.type == Token.VARIABLE or token.value):
+                continue
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)
             if not normalized_var_name.isupper():
@@ -701,7 +701,7 @@ class VariableNamingChecker(VisitorChecker):
             if len(node.data_tokens) < 2:
                 return
             token = node.data_tokens[1]
-            if token.type != Token.VARIABLE or not token.value:
+            if not (token.type == Token.VARIABLE or token.value):
                 return
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -667,11 +667,7 @@ class VariableNamingChecker(VisitorChecker):
         super().__init__()
 
     def visit_Variable(self, node):  # noqa
-        if not node.data_tokens:
-            return
         token = node.data_tokens[0]
-        if not token.value:
-            return
         var_name = search_variable(token.value).base
         if var_name is None:
             return  # in RF<=5, a continuation mark ` ...` is wrongly considered a variable

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -671,7 +671,9 @@ class VariableNamingChecker(VisitorChecker):
             if not child.data_tokens:
                 continue
             token = child.data_tokens[0]
-            if token.type == Token.VARIABLE and token.value and not token.value.isupper():
+            var_name = search_variable(token.value).base
+            normalized_var_name = remove_nested_variables(var_name)
+            if token.type == Token.VARIABLE and token.value and not normalized_var_name.isupper():
                 self.report(
                     "section-variable-not-uppercase",
                     variable_name=token.value,

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -671,14 +671,16 @@ class VariableNamingChecker(VisitorChecker):
             if not child.data_tokens:
                 continue
             token = child.data_tokens[0]
-            if not (token.type == Token.VARIABLE or token.value):
+            if token.type != Token.VARIABLE or not token.value:
                 continue
             var_name = search_variable(token.value).base
+            if var_name is None:
+                continue  # in RF<=5, a continuation mark ` ...` is wrongly considered a variable
             normalized_var_name = remove_nested_variables(var_name)
             if not normalized_var_name.isupper():
                 self.report(
                     "section-variable-not-uppercase",
-                    variable_name=token.value,
+                    variable_name=token.value.strip(),
                     lineno=token.lineno,
                     col=token.col_offset + 1,
                     end_col=token.col_offset + len(token.value) + 1,
@@ -701,7 +703,7 @@ class VariableNamingChecker(VisitorChecker):
             if len(node.data_tokens) < 2:
                 return
             token = node.data_tokens[1]
-            if not (token.type == Token.VARIABLE or token.value):
+            if token.type != Token.ARGUMENT or not token.value:
                 return
             var_name = search_variable(token.value).base
             normalized_var_name = remove_nested_variables(var_name)

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -504,7 +504,7 @@ class Config:
         }
         deprecated = {
             # "rule-name": "deprecation message"
-            "bad-indent": "`strict` and `ignore_uneven` parameters are no longer available for this rule. Take a look at new E1017 bad-block-indent rule that replaces them."  # warning added in v.3.0.0
+            "bad-indent": "'strict' and 'ignore_uneven' parameters are no longer available for this rule. Take a look at new E1017 bad-block-indent rule that replaces them."  # warning added in v.3.0.0
         }
         deprecation_header = "### DEPRECATION WARNING ###"
         deprecation_footer = "This information will disappear in the next version.\n\n"

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     from robot.parsing.model.statements import Variable
 
+from robot.variables.search import VariableIterator
 from robot.version import VERSION as RF_VERSION
 
 from robocop.exceptions import InvalidExternalCheckerError
@@ -82,6 +83,15 @@ def normalize_robot_name(name: str, remove_prefix: Optional[str] = None) -> str:
 
 def normalize_robot_var_name(name: str) -> str:
     return normalize_robot_name(name)[2:-1] if name else ""
+
+
+def remove_nested_variables(var_name):
+    for prefix, match, suffix in VariableIterator(var_name, ignore_errors=True):
+        if match:  # if nested variable exists
+            # take what surrounds it and run the check again
+            var_name = remove_nested_variables(prefix + suffix)
+            break
+    return var_name.strip()
 
 
 def keyword_col(node) -> int:

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/expected_output.txt
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/expected_output.txt
@@ -6,7 +6,7 @@ test.robot:15:24 [W] 0310 Test, suite and global variables should be uppercase
 test.robot:16:25 [W] 0310 Test, suite and global variables should be uppercase
 test.robot:17:24 [W] 0310 Test, suite and global variables should be uppercase
 test.robot:18:26 [W] 0310 Test, suite and global variables should be uppercase
-test.robot:25:24 [W] 0310 Test, suite and global variables should be uppercase
-test.robot:26:25 [W] 0310 Test, suite and global variables should be uppercase
-test.robot:27:24 [W] 0310 Test, suite and global variables should be uppercase
-test.robot:28:26 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:28:24 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:29:25 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:30:24 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:31:26 [W] 0310 Test, suite and global variables should be uppercase

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/expected_output.txt
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/expected_output.txt
@@ -6,3 +6,7 @@ test.robot:15:24 [W] 0310 Test, suite and global variables should be uppercase
 test.robot:16:25 [W] 0310 Test, suite and global variables should be uppercase
 test.robot:17:24 [W] 0310 Test, suite and global variables should be uppercase
 test.robot:18:26 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:25:24 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:26:25 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:27:24 [W] 0310 Test, suite and global variables should be uppercase
+test.robot:28:26 [W] 0310 Test, suite and global variables should be uppercase

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/test.robot
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/test.robot
@@ -20,6 +20,9 @@ Some Keyword
     Set Suite Variable  ${MY VAR}  1
     Set Test Variable  ${MY_VAR}  1
     Set Global Variable  ${MY VAR}  1
+    Set Global Variable
+    ...
+    ...    previous arg is empty now
 
 Keyword With Nested Variables
     Set Task Variable  ${${var@{var}}multiple_nestings&{var}}  0

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/test.robot
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/test.robot
@@ -1,9 +1,9 @@
 *** Test Cases ***
 Test
-    Set Task Variable  ${my_var}  1
-    Set Suite Variable  ${my var}  1
-    Set Test Variable  ${My Var}  1
-    Set Global Variable  ${My_Var}  1
+    Set Task Variable  ${my_var}  0
+    Set Suite Variable  ${my var}  0
+    Set Test Variable  ${My Var}  0
+    Set Global Variable  ${My_Var}  0
     Set Task Variable  ${MY_VAR}  1
     Set Suite Variable  ${MY VAR}  1
     Set Test Variable  ${MY_VAR}  1
@@ -12,11 +12,22 @@ Test
 
 *** Keywords ***
 Some Keyword
-    Set Task Variable  ${my_var}  1
-    Set Suite Variable  ${my var}  1
-    Set Test Variable  ${My Var}  1
-    Set Global Variable  ${My_Var}  1
+    Set Task Variable  ${my_var}  0
+    Set Suite Variable  ${my var}  0
+    Set Test Variable  ${My Var}  0
+    Set Global Variable  ${My_Var}  0
     Set Task Variable  ${MY_VAR}  1
     Set Suite Variable  ${MY VAR}  1
     Set Test Variable  ${MY_VAR}  1
     Set Global Variable  ${MY VAR}  1
+
+Keyword With Nested Variables
+    Set Task Variable  ${${var@{var}}multiple_nestings&{var}}  0
+    Set Suite Variable  ${nesting at the end${VAR}}  0
+    Set Test Variable  ${${var}Front Nesting}  0
+    Set Global Variable  ${Middle_${var}_Nesting}  0
+    Set Task Variable  ${CAPITAL_${var}}  1
+    Set Suite Variable  ${CAPITAL SPACE @{var}}  1
+    Set Test Variable  ${CAPITAL_&{VAR}}  1
+    Set Global Variable  ${${Var} MY VAR}  1
+    Set Global Variable  ${${Var} TWO VARS${var}}  1

--- a/tests/atest/rules/naming/section_variable_not_uppercase/expected_output.txt
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/expected_output.txt
@@ -9,6 +9,10 @@ test.robot:14:1 [W] 0309 Section variable '${my_var}' name should be uppercase
 test.robot:16:1 [W] 0309 Section variable '${var}' name should be uppercase
 test.robot:17:1 [W] 0309 Section variable '@{var3}' name should be uppercase
 test.robot:21:1 [W] 0309 Section variable '@{var4}' name should be uppercase
+test.robot:25:1 [W] 0309 Section variable '${MY_VAR${var}}' name should be uppercase
+test.robot:27:1 [W] 0309 Section variable '${${var}MY VAR${VAR}}' name should be uppercase
+test.robot:28:1 [W] 0309 Section variable '${${var${VAR}}MY VAR${VAR}}' name should be uppercase
+test.robot:29:1 [W] 0309 Section variable '${@{VAR}[1]MY_VAR&{var.param}}' name should be uppercase
 test.robot:30:1 [W] 0309 Section variable '${${var${VAR}}my_var}' name should be uppercase
 test.robot:31:1 [W] 0309 Section variable '${${VAR}my_var}' name should be uppercase
 test.robot:32:1 [W] 0309 Section variable '${${VAR}my_var${var}}' name should be uppercase

--- a/tests/atest/rules/naming/section_variable_not_uppercase/expected_output.txt
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/expected_output.txt
@@ -5,3 +5,8 @@ test.robot:8:1 [W] 0309 Section variable '${MyVar}' name should be uppercase
 test.robot:9:1 [W] 0309 Section variable '${My_Var}' name should be uppercase
 test.robot:10:1 [W] 0309 Section variable '${myVar}' name should be uppercase
 test.robot:11:1 [W] 0309 Section variable '${MY_var}' name should be uppercase
+test.robot:18:1 [W] 0309 Section variable '${${var${VAR}}my_var}' name should be uppercase
+test.robot:19:1 [W] 0309 Section variable '${${VAR}my_var}' name should be uppercase
+test.robot:20:1 [W] 0309 Section variable '${${VAR}my_var${var}}' name should be uppercase
+test.robot:21:1 [W] 0309 Section variable '${@{VAR}[1]my_var}' name should be uppercase
+test.robot:22:1 [W] 0309 Section variable '${@{VAR}[1]my_var&{var.param}}' name should be uppercase

--- a/tests/atest/rules/naming/section_variable_not_uppercase/expected_output.txt
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/expected_output.txt
@@ -5,8 +5,12 @@ test.robot:8:1 [W] 0309 Section variable '${MyVar}' name should be uppercase
 test.robot:9:1 [W] 0309 Section variable '${My_Var}' name should be uppercase
 test.robot:10:1 [W] 0309 Section variable '${myVar}' name should be uppercase
 test.robot:11:1 [W] 0309 Section variable '${MY_var}' name should be uppercase
-test.robot:18:1 [W] 0309 Section variable '${${var${VAR}}my_var}' name should be uppercase
-test.robot:19:1 [W] 0309 Section variable '${${VAR}my_var}' name should be uppercase
-test.robot:20:1 [W] 0309 Section variable '${${VAR}my_var${var}}' name should be uppercase
-test.robot:21:1 [W] 0309 Section variable '${@{VAR}[1]my_var}' name should be uppercase
-test.robot:22:1 [W] 0309 Section variable '${@{VAR}[1]my_var&{var.param}}' name should be uppercase
+test.robot:14:1 [W] 0309 Section variable '${my_var}' name should be uppercase
+test.robot:16:1 [W] 0309 Section variable '${var}' name should be uppercase
+test.robot:17:1 [W] 0309 Section variable '@{var3}' name should be uppercase
+test.robot:21:1 [W] 0309 Section variable '@{var4}' name should be uppercase
+test.robot:30:1 [W] 0309 Section variable '${${var${VAR}}my_var}' name should be uppercase
+test.robot:31:1 [W] 0309 Section variable '${${VAR}my_var}' name should be uppercase
+test.robot:32:1 [W] 0309 Section variable '${${VAR}my_var${var}}' name should be uppercase
+test.robot:33:1 [W] 0309 Section variable '${@{VAR}[1]my_var}' name should be uppercase
+test.robot:34:1 [W] 0309 Section variable '${@{VAR}[1]my_var&{var.param}}' name should be uppercase

--- a/tests/atest/rules/naming/section_variable_not_uppercase/expected_output_rf3.txt
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/expected_output_rf3.txt
@@ -1,0 +1,9 @@
+test.robot:5:1 [W] 0309 Section variable '${my_var}' name should be uppercase
+test.robot:6:1 [W] 0309 Section variable '${My Var}' name should be uppercase
+test.robot:7:1 [W] 0309 Section variable '${my var}' name should be uppercase
+test.robot:8:1 [W] 0309 Section variable '${MyVar}' name should be uppercase
+test.robot:9:1 [W] 0309 Section variable '${My_Var}' name should be uppercase
+test.robot:10:1 [W] 0309 Section variable '${myVar}' name should be uppercase
+test.robot:11:1 [W] 0309 Section variable '${MY_var}' name should be uppercase
+test.robot:14:1 [W] 0309 Section variable '${my_var}' name should be uppercase
+test.robot:21:1 [W] 0309 Section variable '@{var4}' name should be uppercase

--- a/tests/atest/rules/naming/section_variable_not_uppercase/test.robot
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/test.robot
@@ -9,6 +9,18 @@ ${MyVar}   7
 ${My_Var}  8
 ${myVar}   9
 ${MY_var}  10
+${MY_VAR}
+...         11
+${my_var}
+...         12
+ ${var}  1
+ @{var3}  a
+ ...      b
+ ...      c
+...      d
+@{var4}  a
+...      1
+ ...     2
 
 ${MY_VAR${var}}  11
 ${MY VAR${VAR}}  11

--- a/tests/atest/rules/naming/section_variable_not_uppercase/test.robot
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/test.robot
@@ -10,6 +10,17 @@ ${My_Var}  8
 ${myVar}   9
 ${MY_var}  10
 
+${MY_VAR${var}}  11
+${MY VAR${VAR}}  11
+${${var}MY VAR${VAR}}  11
+${${var${VAR}}MY VAR${VAR}}  11
+${@{VAR}[1]MY_VAR&{var.param}}  11
+${${var${VAR}}my_var}  11
+${${VAR}my_var}  11
+${${VAR}my_var${var}}  11
+${@{VAR}[1]my_var}  11
+${@{VAR}[1]my_var&{var.param}}  11
+
 
 *** Test Cases ***
 Test

--- a/tests/atest/rules/naming/section_variable_not_uppercase/test_rule.py
+++ b/tests/atest/rules/naming/section_variable_not_uppercase/test_rule.py
@@ -3,4 +3,8 @@ from tests.atest.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")
+
+    def test_rule_rf3(self):
+        # RF3 doesn't recognize nested variables in Variables section
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", target_version="==3.*")

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -9,6 +9,7 @@ from robocop.utils import (
     pattern_type,
     remove_robot_vars,
 )
+from robocop.utils.misc import remove_nested_variables
 from robocop.utils.version_matching import Version, VersionSpecifier
 
 
@@ -191,6 +192,26 @@ class TestMisc:
         with pytest.raises(ValueError) as error:
             pattern_type(r"[\911]")
         assert r"Invalid regex pattern: bad escape \\9 at position 1" in str(error)
+
+    @pytest.mark.parametrize(
+        "var_name, normalized_var_name",
+        [
+            ("var", "var"),
+            ("my_var", "my_var"),
+            ("my var", "my var"),
+            ("my_var${var}", "my_var"),
+            ("my_var${MY_VAR}", "my_var"),
+            ("my_var${my var}", "my_var"),
+            ("${VAR}var${var}", "var"),
+            ("${VAR${var}}var${var}", "var"),
+            ("@{VAR${var}}var&{var}", "var"),
+            ("@{VAR}[1]var&{var}", "var"),
+            ("@{VAR}[1]var&{var.param}", "var"),
+            ("my ${VAR} var", "my  var"),
+        ],
+    )
+    def test_remove_nested_variables(self, var_name, normalized_var_name):
+        assert remove_nested_variables(var_name) == normalized_var_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Rules W0310 `non-local-variables-should-be-uppercase` and W0309 `section-variable-not-uppercase`
were previously reporting when the variable had another nested variable with lowercase name,
e.g. `${EXAMPLE_${lowercase}}`.
Now, the nested variables are ignored and if the rest of the name is uppercase, the rules
will not report the issue anymore.

Closes #678 