### PR TITLE
Add unused-variable rule

### DIFF
--- a/docs/releasenotes/3.2.0.rst
+++ b/docs/releasenotes/3.2.0.rst
@@ -50,10 +50,21 @@ For example::
     Keyword with ${embedded} and ${not_used}  # will report ${not_used}
         Log    ${embedded}
 
+New rule for detecting not used variables (#209)
+------------------------------------------------
+
+Added new rule I0920 ``unused-variable`` for detecting not used variables.
+For example::
+
+    *** Keywords ***
+    Keyword
+        ${var}    ${var2}    Calculate Cutoff  # ${var2} is not used
+        Log    ${var}
+
 New rules for overwriting arguments and variables before first use (#836)
 --------------------------------------------------------------------------
 
-Added new rules W0920 ``argument-overwritten-before-usage`` and W0921 ``variable-overwritten-before-usage`` for
+Added new rules W0921 ``argument-overwritten-before-usage`` and W0922 ``variable-overwritten-before-usage`` for
 arguments or variables overwritten before first use::
 
     *** Keywords ***

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -375,21 +375,23 @@ rules = {
         msg="Variable '{{ name }}' is assigned but not used",
         severity=RuleSeverity.INFO,
         docs="""
-    Variable was assigned but not used::
-
-        *** Test Cases ***
-        Test
-            ${variable}    Keyword Call  # not used variable
-            ${variable2}    Keyword Call
-            Log    ${variable2}
-
-    Use ``${_}`` variable name if you purposefully do not use variable::
-
-        *** Keywords ***
-        Keyword
-            FOR    ${_}   IN RANGE    10
-                Process Value
-            END
+        Variable was assigned but not used::
+    
+            *** Keywords ***
+            Get Triangle Base Points
+                [Arguments]       ${triangle}
+                ${p1}    ${p2}    ${p3}    Get Triangle Points    ${triangle}
+                Log      Triangle base points are: ${p1} and ${p2}.
+                RETURN   ${p1}    ${p2}  # ${p3} is never used
+    
+        Use ``${_}`` variable name if you purposefully do not use variable::
+    
+            *** Keywords ***
+            Process Value 10 Times
+                [Arguments]    ${value}
+                FOR    ${_}   IN RANGE    10
+                    Process Value    ${value}
+                END
 
     """,
     ),

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -371,6 +371,30 @@ rules = {
     ),
     "0920": Rule(
         rule_id="0920",
+        name="unused-variable",
+        msg="Variable '{{ name }}' is assigned but not used",
+        severity=RuleSeverity.INFO,
+        docs="""
+    Variable was assigned but not used::
+
+        *** Test Cases ***
+        Test
+            ${variable}    Keyword Call  # not used variable
+            ${variable2}    Keyword Call
+            Log    ${variable2}
+
+    Use ``${_}`` variable name if you purposefully do not use variable::
+
+        *** Keywords ***
+        Keyword
+            FOR    ${_}   IN RANGE    10
+                Process Value
+            END
+
+    """,
+    ),
+    "0921": Rule(
+        rule_id="0921",
         name="argument-overwritten-before-usage",
         msg="Keyword argument '{{ name }}' is overwritten before usage",
         severity=RuleSeverity.WARNING,
@@ -384,8 +408,8 @@ rules = {
 
         """,
     ),
-    "0921": Rule(
-        rule_id="0921",
+    "0922": Rule(
+        rule_id="0922",
         name="variable-overwritten-before-usage",
         msg="Local variable '{{ name }}' is overwritten before usage",
         severity=RuleSeverity.WARNING,
@@ -831,7 +855,12 @@ CachedVariable = namedtuple("CachedVariable", "name token")
 
 
 class UnusedVariablesChecker(VisitorChecker):
-    reports = ("unused-argument", "argument-overwritten-before-usage", "variable-overwritten-before-usage")
+    reports = (
+        "unused-argument",
+        "unused-variable",
+        "argument-overwritten-before-usage",
+        "variable-overwritten-before-usage",
+    )
 
     def __init__(self):
         self.arguments = {}
@@ -842,6 +871,7 @@ class UnusedVariablesChecker(VisitorChecker):
     def visit_TestCase(self, node):  # noqa
         self.variables = [{}]
         self.generic_visit(node)
+        self.check_unused_variables()
 
     def visit_Keyword(self, node):  # noqa
         self.arguments = {}
@@ -856,6 +886,14 @@ class UnusedVariablesChecker(VisitorChecker):
         for arg in self.arguments.values():
             value, *_ = arg.token.value.split("=", maxsplit=1)
             self.report_arg_or_var_rule("unused-argument", arg.token, value)
+        self.check_unused_variables()
+
+    def check_unused_variables(self):
+        for scope in self.variables:
+            for variable in scope.values():
+                if variable.name == "${_}":
+                    continue
+                self.report_arg_or_var_rule("unused-variable", variable.token, variable.name)
 
     def report_arg_or_var_rule(self, rule, token, value=None):
         if value is None:

--- a/tests/atest/rules/misc/argument_overwritten_before_usage/expected_output.txt
+++ b/tests/atest/rules/misc/argument_overwritten_before_usage/expected_output.txt
@@ -1,4 +1,4 @@
-test.robot:22:31:22:46 [W] 0920 Keyword argument '${overwritten1}' is overwritten before usage
-test.robot:22:50:22:65 [W] 0920 Keyword argument '${overwritten2}' is overwritten before usage
-test.robot:22:69:22:84 [W] 0920 Keyword argument '${overwritten3}' is overwritten before usage
-test.robot:39:20:39:28 [W] 0920 Keyword argument '${error}' is overwritten before usage
+test.robot:22:31:22:46 [W] 0921 Keyword argument '${overwritten1}' is overwritten before usage
+test.robot:22:50:22:65 [W] 0921 Keyword argument '${overwritten2}' is overwritten before usage
+test.robot:22:69:22:84 [W] 0921 Keyword argument '${overwritten3}' is overwritten before usage
+test.robot:39:20:39:28 [W] 0921 Keyword argument '${error}' is overwritten before usage

--- a/tests/atest/rules/misc/argument_overwritten_before_usage/expected_output_rf3.txt
+++ b/tests/atest/rules/misc/argument_overwritten_before_usage/expected_output_rf3.txt
@@ -1,3 +1,3 @@
-test.robot:22:31:22:46 [W] 0920 Keyword argument '${overwritten1}' is overwritten before usage
-test.robot:22:50:22:65 [W] 0920 Keyword argument '${overwritten2}' is overwritten before usage
-test.robot:22:69:22:84 [W] 0920 Keyword argument '${overwritten3}' is overwritten before usage
+test.robot:22:31:22:46 [W] 0921 Keyword argument '${overwritten1}' is overwritten before usage
+test.robot:22:50:22:65 [W] 0921 Keyword argument '${overwritten2}' is overwritten before usage
+test.robot:22:69:22:84 [W] 0921 Keyword argument '${overwritten3}' is overwritten before usage

--- a/tests/atest/rules/misc/unused_variable/expected_output.txt
+++ b/tests/atest/rules/misc/unused_variable/expected_output.txt
@@ -1,0 +1,5 @@
+test.robot:14:5:14:11 [I] 0920 Variable '${var}' is assigned but not used
+test.robot:18:15:18:22 [I] 0920 Variable '${var2}' is assigned but not used
+test.robot:22:5:22:11 [I] 0920 Variable '${var}' is assigned but not used
+test.robot:30:5:30:14 [I] 0920 Variable '${assign}' is assigned but not used
+test.robot:40:12:40:18 [I] 0920 Variable '${var}' is assigned but not used

--- a/tests/atest/rules/misc/unused_variable/test.robot
+++ b/tests/atest/rules/misc/unused_variable/test.robot
@@ -1,0 +1,45 @@
+*** Variables ***
+${VARIABLE}    value
+
+
+*** Keywords ***
+No Variables
+    Keyword
+
+Used Variable
+    ${var}    Keyword
+    Log    ${var}
+
+Not Used Variable
+    ${var}    Keyword
+
+Mixed Use Variable
+    ${var}    ${var2}    Keyword
+    ${var}    ${var2}    Keyword  # overwritten, should report there
+    Log    ${var}
+
+Assignment Sign
+    ${var} =  Keyword
+
+Used In Return
+    @{variable}    Keyword
+    ...    ${GLOBAL}
+    RETURN    ${var_iable}
+
+Used In IF
+    ${assign}   IF    $arg2    Keyword
+    ${var}
+    ...    ${var2}    Keyword
+    IF    $var
+        Keyword    String with ${var2}
+
+Not Used From FOR
+    FOR    ${var}    IN    1  2  3
+        Keyword    ${VAR}
+    END
+    FOR    ${var}    IN    1  2  3
+        Keyword
+    END
+    FOR    ${_}    IN    1  2  3
+        Keyword
+    END

--- a/tests/atest/rules/misc/unused_variable/test_rule.py
+++ b/tests/atest/rules/misc/unused_variable/test_rule.py
@@ -1,0 +1,6 @@
+from tests.atest.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col")

--- a/tests/atest/rules/misc/variable_overwritten_before_usage/expected_output.txt
+++ b/tests/atest/rules/misc/variable_overwritten_before_usage/expected_output.txt
@@ -1,3 +1,3 @@
-test.robot:7:5 [W] 0921 Local variable '${value}' is overwritten before usage
-test.robot:15:5 [W] 0921 Local variable '${val_ue}' is overwritten before usage
-test.robot:27:5 [W] 0921 Local variable '${overwritten}' is overwritten before usage
+test.robot:7:5 [W] 0922 Local variable '${value}' is overwritten before usage
+test.robot:15:5 [W] 0922 Local variable '${val_ue}' is overwritten before usage
+test.robot:27:5 [W] 0922 Local variable '${overwritten}' is overwritten before usage

--- a/tests/atest/rules/misc/variable_overwritten_before_usage/expected_output_rf3.txt
+++ b/tests/atest/rules/misc/variable_overwritten_before_usage/expected_output_rf3.txt
@@ -1,4 +1,4 @@
-test.robot:7:5 [W] 0921 Local variable '${value}' is overwritten before usage
-test.robot:15:5 [W] 0921 Local variable '${val_ue}' is overwritten before usage
-test.robot:27:5 [W] 0921 Local variable '${overwritten}' is overwritten before usage
-test.robot:29:9 [W] 0921 Local variable '${longitude}' is overwritten before usage
+test.robot:7:5 [W] 0922 Local variable '${value}' is overwritten before usage
+test.robot:15:5 [W] 0922 Local variable '${val_ue}' is overwritten before usage
+test.robot:27:5 [W] 0922 Local variable '${overwritten}' is overwritten before usage
+test.robot:29:9 [W] 0922 Local variable '${longitude}' is overwritten before usage


### PR DESCRIPTION
Closes #209 

Thanks for previously added rules (such as ``unused-arguments``) it was easy to add this rule . And it was in our backlog for 2,5 years.. ;) 

I have also changed the ids of the rules. We didn't release them yet so it's fine. It made more sense to have ``unused-variable`` right after ``unused-argument``.