### PR TITLE
Add new rule for unsupported settings in resource files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ robocop.log
 
 # OS-related files
 .DS_Store
+
+# Robot Framework output files
+log.html
+output.xml
+report.html

--- a/docs/releasenotes/3.3.0.rst
+++ b/docs/releasenotes/3.3.0.rst
@@ -1,0 +1,45 @@
+:orphan:
+
+=============
+Robocop 3.3.0
+=============
+
+Description.
+
+You can install the latest available version by running
+
+::
+
+    pip install --upgrade robotframework-robocop
+
+or to install exactly this version
+
+::
+
+    pip install robotframework-robocop==3.3.0
+
+.. contents::
+   :depth: 2
+   :local:
+
+Rule changes
+============
+
+New rule for detecting not supported settings in resource files (#827)
+----------------------------------------------------------------------
+
+According to the official RF User Guide:
+
+"Additionally, the Setting section in resource files can contain only
+import settings (Library, Resource, Variables) and Documentation.
+The Variable section and Keyword section are used exactly the same way
+as in test case files."
+
+New E0416 ``invalid-setting-in-resource`` rule detects unsupported
+settings in resource files.
+
+
+Acknowledgements
+================
+
+Thanks to...

--- a/docs/releasenotes/3.3.0.rst
+++ b/docs/releasenotes/3.3.0.rst
@@ -30,10 +30,9 @@ New rule for detecting not supported settings in resource files (#827)
 
 According to the official RF User Guide:
 
-"Additionally, the Setting section in resource files can contain only
-import settings (Library, Resource, Variables) and Documentation.
-The Variable section and Keyword section are used exactly the same way
-as in test case files."
+"Setting section in resource files can contain only import settings (Library, Resource, Variables)
+and Documentation. The Variable section and Keyword section are used exactly the same way
+as in test case files.
 
 New E0416 ``invalid-setting-in-resource`` rule detects unsupported
 settings in resource files.

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from robocop.checkers import VisitorChecker
 from robocop.rules import Rule, RuleSeverity
-from robocop.utils import get_errors, ROBOT_VERSION, find_robot_vars
+from robocop.utils import ROBOT_VERSION, find_robot_vars, get_errors
 
 rules = {
     "0401": Rule(

--- a/tests/atest/rules/errors/invalid_setting_in_resource/expected_output_pre_rf6.txt
+++ b/tests/atest/rules/errors/invalid_setting_in_resource/expected_output_pre_rf6.txt
@@ -1,0 +1,9 @@
+test.resource:10:1 [E] 0416 Settings section in resource file can't contain 'Metadata' setting
+test.resource:11:1 [E] 0416 Settings section in resource file can't contain 'Suite Setup' setting
+test.resource:12:1 [E] 0416 Settings section in resource file can't contain 'Suite Teardown' setting
+test.resource:14:1 [E] 0416 Settings section in resource file can't contain 'Test Setup' setting
+test.resource:15:1 [E] 0416 Settings section in resource file can't contain 'Test Teardown' setting
+test.resource:16:1 [E] 0416 Settings section in resource file can't contain 'Test Template' setting
+test.resource:17:1 [E] 0416 Settings section in resource file can't contain 'Test Timeout' setting
+test.resource:18:1 [E] 0416 Settings section in resource file can't contain 'Force Tags' setting
+test.resource:19:1 [E] 0416 Settings section in resource file can't contain 'Default Tags' setting

--- a/tests/atest/rules/errors/invalid_setting_in_resource/expected_output_rf6.txt
+++ b/tests/atest/rules/errors/invalid_setting_in_resource/expected_output_rf6.txt
@@ -1,0 +1,11 @@
+test.resource:9:1 [E] 0416 Settings section in resource file can't contain 'Name' setting
+test.resource:10:1 [E] 0416 Settings section in resource file can't contain 'Metadata' setting
+test.resource:11:1 [E] 0416 Settings section in resource file can't contain 'Suite Setup' setting
+test.resource:12:1 [E] 0416 Settings section in resource file can't contain 'Suite Teardown' setting
+test.resource:13:1 [E] 0416 Settings section in resource file can't contain 'Test Tags' setting
+test.resource:14:1 [E] 0416 Settings section in resource file can't contain 'Test Setup' setting
+test.resource:15:1 [E] 0416 Settings section in resource file can't contain 'Test Teardown' setting
+test.resource:16:1 [E] 0416 Settings section in resource file can't contain 'Test Template' setting
+test.resource:17:1 [E] 0416 Settings section in resource file can't contain 'Test Timeout' setting
+test.resource:18:1 [E] 0416 Settings section in resource file can't contain 'Force Tags' setting
+test.resource:19:1 [E] 0416 Settings section in resource file can't contain 'Default Tags' setting

--- a/tests/atest/rules/errors/invalid_setting_in_resource/test.resource
+++ b/tests/atest/rules/errors/invalid_setting_in_resource/test.resource
@@ -1,0 +1,19 @@
+*** Settings ***
+Documentation       docs
+
+Library             String
+Resource            some_file.py
+Variables           some_file.py
+Keyword Tags        tag
+
+Name                Some name
+Metadata            something
+Suite Setup         Keyword
+Suite Teardown      Keyword
+Test Tags           one    two
+Test Setup          Keyword
+Test Teardown       Keyword
+Test Template       Template
+Test Timeout        1000
+Force Tags          tag
+Default Tags        tag

--- a/tests/atest/rules/errors/invalid_setting_in_resource/test_rule.py
+++ b/tests/atest/rules/errors/invalid_setting_in_resource/test_rule.py
@@ -1,0 +1,9 @@
+from tests.atest.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(expected_file="expected_output_rf6.txt", target_version="==6.*")
+
+    def test_rule_pre6(self):
+        self.check_rule(expected_file="expected_output_pre_rf6.txt", target_version="<=5")

--- a/tests/atest/rules/errors/invalid_setting_in_resource/test_rule.py
+++ b/tests/atest/rules/errors/invalid_setting_in_resource/test_rule.py
@@ -3,7 +3,7 @@ from tests.atest.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output_rf6.txt", target_version="==6.*")
+        self.check_rule(expected_file="expected_output_rf6.txt", target_version=">=6")
 
     def test_rule_pre6(self):
         self.check_rule(expected_file="expected_output_pre_rf6.txt", target_version="<=5")


### PR DESCRIPTION
Closes #827 

Added new rule E0416 `invalid-setting-in-resource` that detects unsupported settings in resource files.

Also, updated `.gitignore` with RF output files.