### PR TITLE
Improve RST formatting in docs and wording

### DIFF
--- a/robocop/checkers/comments.py
+++ b/robocop/checkers/comments.py
@@ -34,7 +34,7 @@ rules = {
         severity=RuleSeverity.WARNING,
         docs="""
         Report occurrences of the configured, case-insensitive marker in the comments.
-        By default, it reports TODO and FIXME markers.
+        By default, it reports ``TODO`` and ``FIXME`` markers.
 
         Example::
 
@@ -59,8 +59,8 @@ rules = {
         msg="Missing blank space after comment character",
         severity=RuleSeverity.WARNING,
         docs="""
-        Make sure to have one blank space after '#' comment character.
-        Configured regex for block comment should take into account the first character is `#`.
+        Make sure to have one blank space after ``#`` comment character.
+        Configured regex for block comment should take into account the first character is ``#``.
 
         Example::
 
@@ -111,7 +111,7 @@ rules = {
         docs="""
         All lines before first test data section
         (`ref <https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-data-sections>`_)
-        are ignored. It's recommended to add `*** Comments ***` section header for lines that should be ignored.
+        are ignored. It's recommended to add ``*** Comments ***`` section header for lines that should be ignored.
 
         Missing section header::
 
@@ -121,7 +121,7 @@ rules = {
             Keyword Name
                No Operation
 
-        Comment lines that should be inside `*** Comments ***`::
+        Comment lines that should be inside ``*** Comments ***``::
 
             Deprecated Test
                 Keyword

--- a/robocop/checkers/documentation.py
+++ b/robocop/checkers/documentation.py
@@ -50,7 +50,7 @@ rules = {
 
             robocop --configure missing-doc-test-case:ignore_templated:False
 
-        Possible values are: Yes / 1 / True (default) or No / False / 0.
+        Possible values are: ``Yes`` / ``1`` / ``True`` (default) or ``No`` / ``False`` / ``0``.
         """,
     ),
     "0203": Rule(

--- a/robocop/checkers/duplications.py
+++ b/robocop/checkers/duplications.py
@@ -164,8 +164,8 @@ rules = {
         msg="'{{ section_name }}' section header is defined in wrong order: {{ recommended_order }}",
         severity=RuleSeverity.WARNING,
         docs="""
-        Sections should be defined in order set by `sections_order` 
-        parameter (default: `settings,variables,testcases,keywords`).
+        Sections should be defined in order set by ``sections_order``
+        parameter (default: ``settings,variables,testcases,keywords``).
         
         To change the default order use following option::
         
@@ -190,7 +190,7 @@ rules = {
         msg="Both Task(s) and Test Case(s) section headers defined in file",
         severity=RuleSeverity.ERROR,
         docs="""
-        The file contains both Test Case and Task sections. Use only one of them. ::
+        The file contains both ``*** Test Cases ***`` and ``*** Tasks ***`` sections. Use only one of them. ::
         
             *** Test Cases ***
             

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -109,8 +109,8 @@ rules = {
         severity=RuleSeverity.ERROR,
         version=">=4.0",
         docs="""
-        Argument names should follow variable naming syntax: start with identifier (`$`, `@` or `&`) and enclosed in 
-        curly brackets (`{}`).
+        Argument names should follow variable naming syntax: start with identifier (``$``, ``@`` or ``&``) and enclosed in 
+        curly brackets (``{}``).
         
         Valid names::
         
@@ -132,7 +132,7 @@ rules = {
         docs="""
         Non-existing setting can't be used in the code.
         
-        Rule violation example::
+        Example of rule violation::
         
            *** Test Case ***
                [Not Existing]  arg
@@ -233,8 +233,8 @@ rules = {
         name="invalid-setting-in-resource",
         msg="Settings section in resource file can't contain '{{ section_name }}' setting",
         docs="""
-        The Setting section in resource files can contain only import settings (Library,
-        Resource, Variables), Documentation and Keyword Tags.
+        The Setting section in resource files can contain only import settings (``Library``,
+        ``Resource``, ``Variables``), ``Documentation`` and ``Keyword Tags``.
         """,
         severity=RuleSeverity.ERROR,
     ),

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -217,7 +217,8 @@ rules = {
         name="too-few-calls-in-test-case",
         msg="Test case '{{ test_name }}' has too few keywords inside ({{ keyword_count }}/{{ min_allowed_count }})",
         docs="""
-        Test without keywords will fail. Add more keywords or set results using Fail, Pass, Skip keywords::
+        Test without keywords will fail. Add more keywords or set results using ``Fail``, ``Pass Execution`` or
+        ``Skip`` keywords::
 
             *** Test Cases ***
             Test case

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -98,7 +98,7 @@ rules = {
         severity=RuleSeverity.INFO,
         version="==4.*",
         docs="""
-        Starting from Robot Framework 4.0 `Run Keyword If` and `Run Keyword Unless` can be replaced by IF block.
+        Starting from Robot Framework 4.0 ``Run Keyword If`` and ``Run Keyword Unless`` can be replaced by IF block.
         """,
     ),
     "0909": Rule(
@@ -134,8 +134,8 @@ rules = {
 
             robocop --configure inconsistent-assignment:assignment_sign_type:equal_sign
 
-        You can choose between following signs: 'autodetect' (default), 'none' (''), 'equal_sign' ('=') or
-        space_and_equal_sign (' =').
+        You can choose between following signs: 'autodetect' (default), 'none', 'equal_sign' (``=``) or
+        space_and_equal_sign (`` =``).
 
         """,
     ),
@@ -165,13 +165,13 @@ rules = {
             ${var4}     a
             ${var5}     b
 
-        By default Robocop looks for most popular assignment sign in the file. It is possible to define expected
+        By default, Robocop looks for the most popular assignment sign in the file. It is possible to define expected
         assignment sign by running::
 
             robocop --configure inconsistent-assignment-in-variables:assignment_sign_type:equal_sign
 
-        You can choose between following signs: 'autodetect' (default), 'none' (''), 'equal_sign' ('=') or
-        space_and_equal_sign (' =').
+        You can choose between following signs: 'autodetect' (default), 'none', 'equal_sign' (``=``) or
+        space_and_equal_sign (`` =``).
 
         """,
     ),
@@ -214,7 +214,7 @@ rules = {
         msg="No tests in '{{ file_name }}' file, consider renaming to '{{ file_name_stem }}.resource'",
         severity=RuleSeverity.INFO,
         docs="""
-        If the Robot file contains only keywords or variables it's a good practice to use `.resource` extension.
+        If the Robot file contains only keywords or variables, it's a good practice to use ``.resource`` extension.
         """,
     ),
     "0914": Rule(
@@ -224,7 +224,7 @@ rules = {
         severity=RuleSeverity.INFO,
         version=">=4.0",
         docs="""
-        IF statement follows another IF with identical conditions. It can be possibly merged into one.
+        ``IF`` statement follows another ``IF`` with identical conditions. It can be possibly merged into one.
 
         Example of rule violation::
 
@@ -236,9 +236,9 @@ rules = {
                 Keyword 2
             END
 
-        IF statement is considered identical only if all branches have identical conditions.
+        ``IF`` statement is considered identical only if all branches have identical conditions.
 
-        Similar but not identical IF::
+        Similar but not identical ``IF``::
 
             IF  ${variable}
                 Keyword
@@ -259,11 +259,11 @@ rules = {
         version=">=5.0",
         docs="""
         Following keywords and statements should only be used inside loop (``WHILE`` or ``FOR``):
-            - ``Exit For Loop``,
-            - ``Exit For Loop If``,
-            - ``Continue For Loop``,
+            - ``Exit For Loop``
+            - ``Exit For Loop If``
+            - ``Continue For Loop``
             - ``Continue For Loop If``
-            - ``CONTINUE``,
+            - ``CONTINUE``
             - ``BREAK``
 
         """,
@@ -282,9 +282,9 @@ rules = {
         severity=RuleSeverity.INFO,
         version=">=5.0",
         docs="""
-        Short and simple IFs can be replaced with inline IF.
+        Short and simple ``IF`` statements can be replaced with ``inline IF``.
 
-        Following IF::
+        Following ``IF``::
 
             IF    $condition
                 BREAK
@@ -303,7 +303,7 @@ rules = {
         severity=RuleSeverity.WARNING,
         version=">=5.0",
         docs="""
-        Detect the unreachable code after RETURN, BREAK or CONTINUE statements.
+        Detect the unreachable code after ``RETURN``, ``BREAK`` or ``CONTINUE`` statements.
 
         For example::
 
@@ -328,8 +328,8 @@ rules = {
         severity=RuleSeverity.WARNING,
         version=">=5.0",
         docs="""
-        It's allowed to create inline IF that spans multiple lines, but it should be avoided,
-        since it decreases readability. Try to use normal IF/ELSE instead.
+        It's allowed to create ``inline IF`` that spans multiple lines, but it should be avoided,
+        since it decreases readability. Try to use normal ``IF``/``ELSE`` instead.
 
         Bad::
 
@@ -340,7 +340,7 @@ rules = {
 
             IF  ${condition}    Log  hello     ELSE    Log  hi!
 
-        or::
+        or also good::
 
             IF  ${condition}
                 Log  hello
@@ -424,7 +424,7 @@ rules = {
                 ${value}    Keyword
                 ${value}    Keyword
 
-        In case the value of the variable is not important, it is possible to use `${_}` name::
+        In case the value of the variable is not important, it is possible to use ``${_}`` name::
         
             *** Test Cases ***
             Call keyword and ignore some return values

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -41,13 +41,13 @@ rules = {
         msg="Not allowed character '{{ character }}' found in {{ block_name }} name",
         severity=RuleSeverity.WARNING,
         docs="""
-        Reports not allowed pattern found in Test Case or Keyword names. By default it's dot (`.`). You can
+        Reports not allowed pattern found in Test Case or Keyword names. By default it's dot (``.``). You can
         configure what patterns are reported by calling::
 
              robocop --configure not-allowed-char-in-name:pattern:regex_pattern
 
-        `regex_pattern` should define regex pattern not allowed in names. For example `[@\[]` pattern
-        reports any occurrence of `@[` characters.
+        ``regex_pattern`` should define regex pattern not allowed in names. For example ``[@\[]`` pattern
+        reports any occurrence of ``@[`` characters.
         """,
     ),
     "0302": Rule(
@@ -232,7 +232,7 @@ rules = {
         Example of rule violation::
 
              *** Settings ***
-             Library  CustomLibrary  AS  CustomLibrary  # same as library name
+             Library  CustomLibrary  AS  CustomLibrary   # same as library name
              Library  CustomLibrary  AS  Custom Library  # same as library name (spaces are ignored)
 
         """,
@@ -323,8 +323,8 @@ rules = {
 
              robocop --configure not-allowed-char-in-filename:pattern:regex_pattern
 
-        `regex_pattern` should define regex pattern for characters not allowed in names. For example `[@\[]` pattern
-        reports any occurrence of `@[` characters.
+        ``regex_pattern`` should define regex pattern for characters not allowed in names. For example `[@\[]` pattern
+        reports any occurrence of ``@[`` characters.
         """,
     ),
     "0321": Rule(
@@ -406,19 +406,18 @@ rules = {
         severity=RuleSeverity.ERROR,
         version=">=6.1",
         docs="""
-            Robot Framework 6.1 detects unrecognized sections based on the language defined for the specific files.
-            Consider using --language parameter if the file is defined with different language.
+        Robot Framework 6.1 detects unrecognized sections based on the language defined for the specific files.
+        Consider using ``--language`` parameter if the file is defined with different language.
+        
+        It is also possible to configure language in the file::
             
-            It is also possible to configure language in the file:
-            
-            ```
             language: pl
             
             *** Przypadki Testowe ***
             Test case
                 Step
-            ```
-            """,
+
+        """,
     ),
 }
 

--- a/robocop/checkers/spacing.py
+++ b/robocop/checkers/spacing.py
@@ -136,7 +136,7 @@ rules = {
 
              Resource  file.resource
 
-        It can be configured using `empty_lines` parameter.
+        It can be configured using ``empty_lines`` parameter.
         """,
     ),
     "1010": Rule(
@@ -261,7 +261,7 @@ rules = {
         severity=RuleSeverity.ERROR,
         docs="""
         If the indentation is less than two spaces than current block parent element
-        (such as FOR/IF/WHILE/TRY header) the indentation is invalid and the rule reports an error::
+        (such as ``FOR``/``IF``/``WHILE``/``TRY`` header) the indentation is invalid and the rule reports an error::
 
             *** Keywords ***
             Some Keyword

--- a/robocop/checkers/tags.py
+++ b/robocop/checkers/tags.py
@@ -29,18 +29,18 @@ rules = {
         " Hint: make sure to include this tag using lowercase name to avoid issues",
         severity=RuleSeverity.INFO,
         docs="""
-        OR and AND words are used to combine tags when selecting tests to be run in Robot Framework. Using following 
+        ``OR`` and ``AND`` words are used to combine tags when selecting tests to be run in Robot Framework. Using following 
         configuration::
         
             robot --include tagANDtag2
         
-        Robot Framework will only execute tests that contain `tag` and `tag2`. That's why it's best to avoid AND and OR 
+        Robot Framework will only execute tests that contain ``tag`` and ``tag2``. That's why it's best to avoid ``AND`` and ``OR``
         in tag names. See 
-        `docs <https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tag-patterns>`_ 
+        `docs <https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tag-patterns>`_
         for more information.
         
-        Tag matching is case-insensitive. If your tag contains OR or AND you can use lowercase to match it.
-        For example, if your tag is `PORT` you can match it with `port`.
+        Tag matching is case-insensitive. If your tag contains ``OR`` or ``AND`` you can use lowercase to match it.
+        For example, if your tag is ``PORT``, you can match it with ``port``.
         """,
     ),
     "0603": Rule(
@@ -49,11 +49,12 @@ rules = {
         msg="Tag '{{ tag }}' prefixed with reserved word `robot:`",
         severity=RuleSeverity.WARNING,
         docs="""
-        This prefix is used by Robot Framework special tags. More details 
+        ``robot:`` prefix is used by Robot Framework special tags. More details 
         `here <https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#reserved-tags>`_.
         Special tags currently in use:
         
             - robot:exit
+            - robot:flatten
             - robot:no-dry-run
             - robot:continue-on-failure 
             - robot:recursive-continue-on-failure
@@ -83,7 +84,7 @@ rules = {
                 [Tag]  featureX
                 Step
         
-        In this example all tests share one common tag `featureX`. It can be declared just once using ``Test Tags``
+        In this example all tests share one common tag ``featureX``. It can be declared just once using ``Test Tags``
         or ``Task Tags``.
         """,
     ),
@@ -125,7 +126,7 @@ rules = {
                 [Tags]  tag4
                 Step
         
-        Since `Test` and `Test 2` have `[Tags]` section, `Default Tags` setting is never used.
+        Since ``Test`` and ``Test 2`` have ``[Tags]`` section, ``Default Tags`` setting is never used.
         """,
     ),
     "0608": Rule(
@@ -134,7 +135,7 @@ rules = {
         msg="[Tags] setting without values{{ optional_warning }}",
         severity=RuleSeverity.WARNING,
         docs="""
-        If you want to use empty `[Tags]` (for example to overwrite `Default Tags`) then use `NONE` value 
+        If you want to use empty ``[Tags]`` (for example to overwrite ``Default Tags``) then use ``NONE`` value 
         to be explicit.
         """,
     ),
@@ -170,6 +171,7 @@ class TagNameChecker(VisitorChecker):
     is_keyword = False
     reserved_tags = {
         "robot:exit",
+        "robot:flatten",
         "robot:no-dry-run",
         "robot:continue-on-failure",
         "robot:recursive-continue-on-failure",


### PR DESCRIPTION
- Replaced singular backticks with doubled, to properly apply RST code formatting
- Updated some sentences, fixed typos and improved wording
- Added new `robot:flatten` tags from RF 6.1