### PR TITLE
Add JSON report

### DIFF
--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -75,6 +75,19 @@ rule (E0417).
 Other features
 ==============
 
+New report ``json_report`` (#663)
+---------------------------------
+
+Added new ``json_report`` report that produces file with issues in JSON format. It's non default report which needs
+to be enabled using report name (it will not be loaded with ``--reports all``)::
+
+    robocop --reports json_report .
+
+It will save file to current working directory under ``robocop_output.json`` filename. Output directory and filename
+can be configured::
+
+    robocop --configure json_report:output_dir:output --configure json_report:report_filename:issues.json --reports json_report .
+
 Overhaul of rules & checkers importing (#790)
 ---------------------------------------------
 

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -19,4 +19,6 @@ Reports
 
 .. autoclass:: robocop.reports.timestamp_report.TimestampReport
 
+.. autoclass:: robocop.reports.json_report.JsonReport
+
 .. autoclass:: robocop.reports.sarif_report.SarifReport

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -289,8 +289,9 @@ class Config:
             help="Generate reports after scan.\n"
             "You can enable reports by listing them in comma-separated list:\n"
             "--reports rules_by_id,rules_by_error_type,scan_timer\n"
-            "To enable all reports use all:\n"
-            "--reports all",
+            "To enable all default reports use all:\n"
+            "--reports all\n"
+            "List available reports with --list-reports option.",
         )
         optional.add_argument(
             "-f",

--- a/robocop/reports/json_report.py
+++ b/robocop/reports/json_report.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from robocop.reports import Report
 from robocop.rules import Message
 
@@ -6,6 +9,55 @@ class JsonReport(Report):
     """
     Report name: ``json_report``
 
+    Report that returns list of found issues in JSON format. The output file will be generated
+    in the current working directory with the ``robocop_output.json`` name.
+
+    This report is not included in the default reports. The ``--reports all`` option will not enable this report.
+    You can still enable it using report name directly: ``--reports json_report`` or ``--reports all,json_report``.
+
+    You can configure output directory and report filename::
+
+        robocop --configure json_report:output_dir:C:/json_reports
+        robocop --configure json_report:report_filename:robocop.json
+
+    """
+
+    DEFAULT = False
+
+    def __init__(self):
+        self.name = "json_report"
+        self.description = "Accumulates found issues in JSON format"
+        self.output_dir = None
+        self.report_filename = "robocop_output.json"
+        self.issues = []
+
+    def add_message(self, message: Message):
+        self.issues.append(message.to_json())
+
+    def get_report(self):
+        if self.output_dir is not None:
+            output_path = self.output_dir / self.report_filename
+        else:
+            output_path = Path(self.report_filename)
+        with open(output_path, "w") as fp:
+            json_string = json.dumps(self.issues, indent=4)
+            fp.write(json_string)
+        return f"Generated JSON report in {output_path}"
+
+    def configure(self, name, value):
+        if name == "output_dir":
+            self.output_dir = Path(value)
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+        elif name == "report_filename":
+            self.report_filename = value
+        else:
+            super().configure(name, value)
+
+
+class InternalJsonReport(Report):
+    """
+    Report name: ``internal_json_report``
+
     Report that returns list of found issues in JSON format.
     """
 
@@ -13,7 +65,7 @@ class JsonReport(Report):
     INTERNAL = True
 
     def __init__(self):
-        self.name = "json_report"
+        self.name = "internal_json_report"
         self.description = "Accumulates found issues in JSON format"
         self.issues = []
 

--- a/robocop/rules.py
+++ b/robocop/rules.py
@@ -469,7 +469,9 @@ class Message:
         return {
             "source": self.source,
             "line": self.line,
+            "end_line": self.end_line,
             "column": self.col,
+            "end_column": self.end_col,
             "severity": self.severity.value,
             "rule_id": self.rule_id,
             "description": self.desc,

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -48,7 +48,7 @@ class Robocop:
         self.config = Config(from_cli=from_cli) if config is None else config
         self.from_cli = from_cli
         if not from_cli:
-            self.config.reports.append("json_report")
+            self.config.reports.append("internal_json_report")
         self.out = self.set_output()
 
     def set_output(self):
@@ -79,7 +79,7 @@ class Robocop:
         if self.from_cli:
             sys.exit(self.reports["return_status"].return_status)
         else:
-            return self.reports["json_report"].issues
+            return self.reports["internal_json_report"].issues
 
     def recognize_file_types(self):
         """

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -70,6 +70,7 @@ class TestE2E:
         exp_msg = (
             "Available reports:\n"
             "file_stats           - Prints overall statistics about number of processed files (disabled)\n"
+            "json_report          - Accumulates found issues in JSON format (disabled - non-default)\n"
             "rules_by_error_type  - Prints total number of issues grouped by severity (disabled)\n"
             "rules_by_id          - Groups detected issues by rule id and prints it ordered by most common (disabled)\n"
             "sarif                - Generate SARIF output file (disabled - non-default)\n"
@@ -115,6 +116,7 @@ class TestE2E:
             exp_msg = (
                 "Available reports:\n"
                 "file_stats           - Prints overall statistics about number of processed files (disabled)\n"
+                "json_report          - Accumulates found issues in JSON format (disabled - non-default)\n"
                 "rules_by_error_type  - Prints total number of issues grouped by severity (disabled)\n"
                 "rules_by_id          - Groups detected issues by rule id and prints it ordered by most common "
                 "(disabled)\n"
@@ -133,6 +135,7 @@ class TestE2E:
             exp_msg = (
                 "Available reports:\n"
                 "file_stats           - Prints overall statistics about number of processed files (disabled)\n"
+                "json_report          - Accumulates found issues in JSON format (disabled - non-default)\n"
                 "rules_by_error_type  - Prints total number of issues grouped by severity (disabled)\n"
                 "rules_by_id          - Groups detected issues by rule id and prints it ordered by most common "
                 "(disabled)\n"
@@ -288,7 +291,7 @@ class TestE2E:
         config.paths = [str(test_file)]
         robocop_instance = Robocop(config=config)
         robocop_instance.run()
-        assert not robocop_instance.reports["json_report"].issues
+        assert not robocop_instance.reports["internal_json_report"].issues
 
     @pytest.mark.skipif(ROBOT_VERSION > Version("4.0"), reason="Error occurs only in RF < 5")
     def test_handling_error_in_robot_module(self):
@@ -304,11 +307,15 @@ class TestE2E:
 class TestTranslatedRobot:
     @staticmethod
     def assert_issue_was_found(robocop_instance, issue_desc):
-        assert any(issue_desc in issue["description"] for issue in robocop_instance.reports["json_report"].issues)
+        assert any(
+            issue_desc in issue["description"] for issue in robocop_instance.reports["internal_json_report"].issues
+        )
 
     @staticmethod
     def assert_issue_was_not_found(robocop_instance, issue_desc):
-        assert all(issue_desc not in issue["description"] for issue in robocop_instance.reports["json_report"].issues)
+        assert all(
+            issue_desc not in issue["description"] for issue in robocop_instance.reports["internal_json_report"].issues
+        )
 
     def test_translated_default_lang(self):
         config = Config()

--- a/tests/utest/test_reports.py
+++ b/tests/utest/test_reports.py
@@ -9,7 +9,7 @@ from robocop.config import Config
 from robocop.exceptions import ConfigGeneralError
 from robocop.reports import get_reports
 from robocop.reports.file_stats_report import FileStatsReport
-from robocop.reports.json_report import JsonReport
+from robocop.reports.json_report import InternalJsonReport, JsonReport
 from robocop.reports.robocop_version_report import RobocopVersionReport
 from robocop.reports.sarif_report import SarifReport
 from robocop.reports.timestamp_report import TimestampReport
@@ -68,29 +68,6 @@ def test_get_unknown_report():
 
 
 class TestReports:
-    def test_json_report(self, rule):
-        report = JsonReport()
-        issue = Message(
-            rule=rule,
-            msg=rule.get_message(),
-            source="some/path/file.robot",
-            node=None,
-            lineno=50,
-            col=10,
-            end_lineno=None,
-            end_col=None,
-        )
-        report.add_message(issue)
-        assert report.issues[0] == {
-            "source": "some/path/file.robot",
-            "column": 10,
-            "line": 50,
-            "rule_id": "0101",
-            "rule_name": "some-message",
-            "severity": "W",
-            "description": "Some description",
-        }
-
     @pytest.mark.parametrize(
         "files, files_with_issues, output",
         [
@@ -191,6 +168,85 @@ class TestReports:
         report = TimestampReport()
         report.configure(name, value)
         assert re.search(expected, report.get_report())
+
+
+class TestJSONReport:
+    @pytest.mark.parametrize("json_class", [JsonReport, InternalJsonReport])
+    def test_json_report(self, rule, json_class):
+        report = json_class()
+        issue = Message(
+            rule=rule,
+            msg=rule.get_message(),
+            source="some/path/file.robot",
+            node=None,
+            lineno=50,
+            col=10,
+            end_lineno=None,
+            end_col=None,
+        )
+        report.add_message(issue)
+        assert report.issues[0] == {
+            "source": "some/path/file.robot",
+            "line": 50,
+            "end_line": 50,
+            "column": 10,
+            "end_column": 10,
+            "rule_id": "0101",
+            "rule_name": "some-message",
+            "severity": "W",
+            "description": "Some description",
+        }
+
+    def test_configure_output_dir(self):
+        output_dir = "path/to/dir"
+        report = JsonReport()
+        report.configure("output_dir", output_dir)
+        assert report.output_dir == Path(output_dir)
+
+    def test_configure_filename(self):
+        filename = ".robocop.json"
+        report = JsonReport()
+        report.configure("report_filename", filename)
+        assert report.report_filename == filename
+
+    def test_json_reports_saved_to_file(self, rule, rule2, tmp_path):
+        config = Config(from_cli=False)
+        rules = {m.rule_id: m for m in (rule, rule2)}
+        source1_rel = "tests/atest/rules/comments/ignored-data/test.robot"
+        source2_rel = "tests/atest/rules/misc/empty-return/test.robot"
+        source1 = str(config.root / source1_rel)
+        source2 = str(config.root / source2_rel)
+
+        report = JsonReport()
+        report.configure("output_dir", tmp_path)
+
+        issues = [
+            Message(
+                rule=r,
+                msg=r.get_message(),
+                source=source,
+                node=None,
+                lineno=line,
+                col=col,
+                end_lineno=end_line,
+                end_col=end_col,
+            )
+            for r, source, line, end_line, col, end_col in [
+                (rule, source1, 50, None, 10, None),
+                (rule2, source1, 50, 51, 10, None),
+                (rule, source2, 50, None, 10, 12),
+                (rule2, source2, 11, 15, 10, 15),
+            ]
+        ]
+
+        expected_report = [issue.to_json() for issue in issues]
+        for issue in issues:
+            report.add_message(issue)
+        report.get_report()
+        json_path = report.output_dir / report.report_filename
+        with open(json_path) as fp:
+            json_report = json.load(fp)
+        assert expected_report == json_report
 
 
 class TestSarifReport:


### PR DESCRIPTION
Closes #663

We already had JSON report but it was only used internally to return issues in json format when running Robocop programmatically. I renamed previous report to ``internal_json_report`` and created new ``json_report``.