### PR TITLE
Fix if-can-be-used disabled in RF >4

### DIFF
--- a/docs/releasenotes/5.0.0.rst
+++ b/docs/releasenotes/5.0.0.rst
@@ -32,7 +32,7 @@ Other features
 Fixes
 =====
 
-Enable if-can-be-used for Robot Framework 5+
+Enable ``if-can-be-used`` rule for Robot Framework 5+
 ---------------------------------------------
 
 I0908 ``if-can-be-used`` was incorrectly enabled only for Robot Framework 4.*. It should now work for all >=4 versions.

--- a/docs/releasenotes/5.0.0.rst
+++ b/docs/releasenotes/5.0.0.rst
@@ -1,0 +1,53 @@
+:orphan:
+
+=============
+Robocop 5.0.0
+=============
+
+You can install the latest available version by running
+
+::
+
+    pip install --upgrade robotframework-robocop
+
+or to install exactly this version
+
+::
+
+    pip install robotframework-robocop==5.0.0
+
+.. contents::
+   :depth: 2
+   :local:
+
+Most important changes
+======================
+
+Rule changes
+============
+
+Other features
+==============
+
+Fixes
+=====
+
+Enable if-can-be-used for Robot Framework 5+
+---------------------------------------------
+
+I0908 ``if-can-be-used`` was incorrectly enabled only for Robot Framework 4.*. It should now work for all >=4 versions.
+
+Acknowledgements
+================
+
+Thanks to the whole community for submitting bug reports and feature requests.
+Without you, Robocop wouldn't be in the place where it is now. All the feedback
+is essential to drive the tool towards higher quality and better user
+experience.
+
+If you want to help us more, consider contributing to the project directly.
+We can offer our constant support to make the work fun and effective. We do
+our best to create a supportive and welcoming environment for everyone.
+Feel free to ping us on our official `#robocop-linter Slack channel`_ anytime.
+
+.. _#robocop-linter Slack channel: https://robotframework.slack.com/archives/C01AWSNKC2H

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -98,7 +98,7 @@ rules = {
         name="if-can-be-used",
         msg="'{{ run_keyword }}' can be replaced with IF block since Robot Framework 4.0",
         severity=RuleSeverity.INFO,
-        version="==4.*",
+        version=">=4",
         docs="""
         Starting from Robot Framework 4.0 ``Run Keyword If`` and ``Run Keyword Unless`` can be replaced by IF block.
         """,

--- a/tests/atest/rules/misc/if_can_be_used/test_rule.py
+++ b/tests/atest/rules/misc/if_can_be_used/test_rule.py
@@ -3,4 +3,4 @@ from tests.atest.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")


### PR DESCRIPTION
I used 5.0.0 release notes template since it's not critical issue and can be released together with next feature release.