### PR TITLE
Split unreleased changelog to format parsable by anote tool

### DIFF
--- a/docs/releasenotes/unreleased/fixes.1.rst
+++ b/docs/releasenotes/unreleased/fixes.1.rst
@@ -1,0 +1,4 @@
+Enable ``if-can-be-used`` rule for Robot Framework 5+
+-----------------------------------------------------
+
+I0908 ``if-can-be-used`` was incorrectly enabled only for Robot Framework 4.*. It should now work for all >=4 versions.

--- a/docs/releasenotes/unreleased/fixes.2.rst
+++ b/docs/releasenotes/unreleased/fixes.2.rst
@@ -1,0 +1,4 @@
+External rules with non-Python files in the directory
+-----------------------------------------------------
+
+Robocop no longer reports a problem when loading the external rules from a directory that also contains non-Python files.

--- a/docs/releasenotes/unreleased/most_important.1.rst
+++ b/docs/releasenotes/unreleased/most_important.1.rst
@@ -1,0 +1,5 @@
+New community rules
+-------------------
+
+<description here, together with first community rule (working as example)>
+<also describe somewhere robocop --list COMMUNITY and robocop --list ALL>

--- a/docs/releasenotes/unreleased/template.jinja
+++ b/docs/releasenotes/unreleased/template.jinja
@@ -1,7 +1,7 @@
 :orphan:
 
 =============
-Robocop 5.0.0
+Robocop {{ version }}
 =============
 
 You can install the latest available version by running
@@ -14,39 +14,36 @@ or to install exactly this version
 
 ::
 
-    pip install robotframework-robocop==5.0.0
+    pip install robotframework-robocop=={{ version }}
 
 .. contents::
    :depth: 2
    :local:
 
+{% if most_important|length > 0 %}
 Most important changes
 ======================
+{% for note in most_important %}{{ note }}{% endfor %}
+{% endif -%}
 
-New community rules
--------------------
-
-<description here, together with first community rule (working as example)>
-<also describe somewhere robocop --list COMMUNITY and robocop --list ALL>
-
+{% if rules|length > 0 %}
 Rule changes
 ============
 
-Other features
-==============
+{% for note in rules %}{{ note }}{% endfor %}
+{% endif -%}
 
+{% if fixes|length > 0 %}
 Fixes
 =====
+{% for note in fixes %}{{ note }}{% endfor %}
+{% endif -%}
 
-Enable ``if-can-be-used`` rule for Robot Framework 5+
----------------------------------------------
-
-I0908 ``if-can-be-used`` was incorrectly enabled only for Robot Framework 4.*. It should now work for all >=4 versions.
-
-External rules with non-Python files in the directory
------------------------------------------------------
-
-Robocop no longer reports a problem when loading the external rules from a directory that also contains non-Python files.
+{% if other|length > 0 %}
+Other features
+==============
+{% for note in other %}{{ note }}{% endfor %}
+{% endif -%}
 
 Acknowledgements
 ================


### PR DESCRIPTION
I have started working on small tool for changelog automation: https://github.com/bhirsz/anote

Nothing fancy but it will be able to merge release notes from fragments/files and create release notes based on the Jinja template. It should reduce number of merge conflicts when working on multiple things in the same time (due to changes in notes).

We still have some time before next release so I should be able to improve the tool in time being. It's usable right now (it's possible to generate release notes) but documentation and tests are missing.