### PR TITLE
Fix variable-overwritten-before-usage using single scope for all TRY/EXCEPT branches

### DIFF
--- a/docs/releasenotes/unreleased/fixes.3.rst
+++ b/docs/releasenotes/unreleased/fixes.3.rst
@@ -1,7 +1,7 @@
 TRY/EXCEPT with shared variables scope for all branches (#925)
 --------------------------------------------------------------
 
-``variable-overwritten-before-usage`` will no longer be raised  if the same variable names are used in different
+``variable-overwritten-before-usage`` will no longer be raised if the same variable names are used in different
 branches of the ``TRY/EXCEPT`` block::
 
     *** Test Cases ***

--- a/docs/releasenotes/unreleased/fixes.3.rst
+++ b/docs/releasenotes/unreleased/fixes.3.rst
@@ -1,0 +1,14 @@
+TRY/EXCEPT with shared variables scope for all branches (#925)
+--------------------------------------------------------------
+
+``variable-overwritten-before-usage`` will no longer be raised  if the same variable names are used in different
+branches of the ``TRY/EXCEPT`` block::
+
+    *** Test Cases ***
+    Example Test
+        TRY
+            ${value}    Possibly Failing Keyword
+        EXCEPT
+            ${value}    Set Variable    Keyword failed  # each TRY/EXCEPT/ELSE/FINALLY branch is now separate scope
+        END
+        Log To Console    ${value}

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -1155,11 +1155,16 @@ class UnusedVariablesChecker(VisitorChecker):
     def visit_Try(self, node):  # noqa
         if node.errors or node.header.errors:
             return node
+        self.variables.append({})
         if node.variable is not None:
             error_var = node.header.get_token(Token.VARIABLE)
             if error_var is not None:
                 self.handle_assign_variable(error_var)
-        return self.generic_visit(node)
+        for item in node.body:
+            self.visit(item)
+        self.variables.pop()
+        if node.next:
+            self.visit_Try(node.next)
 
     def visit_KeywordCall(self, node):  # noqa
         for token in node.get_tokens(Token.ARGUMENT, Token.KEYWORD):  # argument can be used in keyword name

--- a/tests/atest/rules/misc/variable_overwritten_before_usage/expected_output_loops.txt
+++ b/tests/atest/rules/misc/variable_overwritten_before_usage/expected_output_loops.txt
@@ -1,0 +1,1 @@
+loops.robot:43:9:43:20 [W] 0922 Local variable '${variable}' is overwritten before usage

--- a/tests/atest/rules/misc/variable_overwritten_before_usage/loops.robot
+++ b/tests/atest/rules/misc/variable_overwritten_before_usage/loops.robot
@@ -36,3 +36,18 @@ Keyword With FOR
         ${variable}    Get New Value
     END
 
+Each Try Branch Is Separate Scope
+    TRY
+        ${variable}    Set Variable    value
+    EXCEPT    Error message
+        ${variablE}    Error Handler 1
+        ${variable}    Error Handler 2
+    EXCEPT    Another error    # comment
+        ${variable}    Error Handler 2
+    EXCEPT    ${message}       # match with variable
+        ${Variable}    Error Handler 3
+    ELSE
+        ${variable}    Set Variable    value
+    FINALLY
+        ${variable}    Set Variable    value  # technically FINALLY should be in the same scope as all try/excepts
+    END


### PR DESCRIPTION
Fixes #925