### PR TITLE
Fix not-capitalized-test-case-title reporting if the test case starts with non-letter

### DIFF
--- a/docs/releasenotes/unreleased/fixes.7.rst
+++ b/docs/releasenotes/unreleased/fixes.7.rst
@@ -1,0 +1,13 @@
+not-capitalized-test-case-title should ignore non letters (#948)
+----------------------------------------------------------------
+
+W0308 ``not-capitalized-test-case-title`` was also reporting if the test case started with character other than letter:
+
+```
+15 - Test case with test identifier
+    Prepare
+    Run
+    Assert
+```
+
+It should now properly check if first letter found in the test case name (ignoring other characters) is capitalized.

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -898,13 +898,18 @@ class TestCaseNamingChecker(VisitorChecker):
     def visit_TestCase(self, node):  # noqa
         if not node.name:
             self.report("test-case-name-is-empty", node=node)
-        elif not node.name[0].isupper():
-            self.report(
-                "not-capitalized-test-case-title",
-                test_name=node.name,
-                node=node,
-                end_col=node.col_offset + len(node.name) + 1,
-            )
+        else:
+            for c in node.name:
+                if not c.isalpha():
+                    continue
+                if not c.isupper():
+                    self.report(
+                        "not-capitalized-test-case-title",
+                        test_name=node.name,
+                        node=node,
+                        end_col=node.col_offset + len(node.name) + 1,
+                    )
+                break
 
 
 class VariableNamingChecker(VisitorChecker):

--- a/tests/atest/rules/naming/not_capitalized_test_case_title/test.robot
+++ b/tests/atest/rules/naming/not_capitalized_test_case_title/test.robot
@@ -11,6 +11,16 @@ TEST UPPERCASE
 Test with first letter capitalized
     Pass Execution
 
+JIRA-123 Test case
+    Pass Execution
+
+1 - Ordered test case
+    Pass Execution
+
+! Special chars are ignored
+    Pass Execution
+
+
 *** Test Case ***
 
 #  no test case name


### PR DESCRIPTION
Fixes #948