### PR TITLE
Fix if-can-be-used and deprecated-statement double reporting from RF 5.0

### DIFF
--- a/docs/releasenotes/unreleased/fixes.9.rst
+++ b/docs/releasenotes/unreleased/fixes.9.rst
@@ -1,0 +1,9 @@
+if-can-be-used and deprecated-statement double reporting on Run Keyword Unless (#945)
+-------------------------------------------------------------------------------------
+
+I0908 ``if-can-be-used`` was introduced in Robot Framework 4.0 to suggest replacing ``Run Keyword If`` and
+``Run Keyword Unless`` keywords by ``IF``. Since Robot Framework 5.0 W0319 ``deprecated-statement`` started to warn
+on the use of those keywords. Because of that there were 2 issues reported starting from Robot Framework 5.0.
+
+``if-can-be-used`` was updated to only report for Robot Framework 4.0 code. Starting from RF version 5.0 only
+``deprecated-statement`` will be reported.

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -98,7 +98,7 @@ rules = {
         name="if-can-be-used",
         msg="'{{ run_keyword }}' can be replaced with IF block since Robot Framework 4.0",
         severity=RuleSeverity.INFO,
-        version=">=4",
+        version="==4.*",
         docs="""
         Starting from Robot Framework 4.0 ``Run Keyword If`` and ``Run Keyword Unless`` can be replaced by IF block.
         """,

--- a/tests/atest/rules/misc/if_can_be_used/test_rule.py
+++ b/tests/atest/rules/misc/if_can_be_used/test_rule.py
@@ -3,4 +3,4 @@ from tests.atest.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version="==4")


### PR DESCRIPTION
Fixes #945