### PR TITLE
Fix ReadTheDocs config after major update

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,12 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 python:
-  version: "3.7"
   install:
     - method: pip
       path: .[doc]


### PR DESCRIPTION
There was equivalent change some time ago in Robotidy as well - Robotidy changed the configuration file format (different keys etc) and gradually 'forced to migrate'.