### PR TITLE
Remove code warnings from Robocop output

### DIFF
--- a/docs/releasenotes/unreleased/fixes.4.rst
+++ b/docs/releasenotes/unreleased/fixes.4.rst
@@ -1,5 +1,5 @@
-Robot Framework 7.0 backward incompatible changes: Deprecation warnings when using Robocop
--------------------------------------------------------------------------------------------
+Robot Framework 7.0 backward incompatible changes: Deprecation warnings in Robocop output (#993)
+-------------------------------------------------------------------------------------------------
 
 Several rules started to issue additional deprecation warnings such as `'For.variables' is deprecated and will be
 removed in Robot Framework 8.0. Use 'For.assign' instead`. Those warnings were for Robocop code only and should not

--- a/docs/releasenotes/unreleased/fixes.4.rst
+++ b/docs/releasenotes/unreleased/fixes.4.rst
@@ -1,0 +1,6 @@
+Robot Framework 7.0 backward incompatible changes: Deprecation warnings when using Robocop
+-------------------------------------------------------------------------------------------
+
+Several rules started to issue additional deprecation warnings such as `'For.variables' is deprecated and will be
+removed in Robot Framework 8.0. Use 'For.assign' instead`. Those warnings were for Robocop code only and should not
+appear anymore.

--- a/docs/releasenotes/unreleased/fixes.5.rst
+++ b/docs/releasenotes/unreleased/fixes.5.rst
@@ -1,0 +1,4 @@
+Python 3.12 support: invalid escape sequence warnings (#1003)
+-------------------------------------------------------------
+
+`SyntaxWarning: invalid escape sequence '\S'` warnings should not appear anymore when importing Robocop with Python 3.12.

--- a/robocop/checkers/lengths.py
+++ b/robocop/checkers/lengths.py
@@ -113,7 +113,7 @@ rules = {
 
             robocop --configure line-too-long:ignore_pattern:pattern
 
-        The default pattern is ``https?://\S+`` that ignores the lines that look like an URL.
+        The default pattern is ``https?://\\S+`` that ignores the lines that look like an URL.
 
         """,
         added_in_version="1.0.0",

--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -1179,11 +1179,17 @@ class UnusedVariablesChecker(VisitorChecker):
 
     visit_ForLoop = visit_For
 
+    @staticmethod
+    def try_assign(try_node) -> str:
+        if ROBOT_VERSION.major < 7:
+            return try_node.variable
+        return try_node.assign
+
     def visit_Try(self, node):  # noqa
         if node.errors or node.header.errors:
             return node
         self.variables.append({})
-        if node.variable is not None:
+        if self.try_assign(node) is not None:
             error_var = node.header.get_token(Token.VARIABLE)
             if error_var is not None:
                 self.handle_assign_variable(error_var)

--- a/robocop/checkers/naming.py
+++ b/robocop/checkers/naming.py
@@ -5,6 +5,7 @@ import re
 import string
 from collections import defaultdict
 from pathlib import Path
+from typing import Iterable
 
 from robot.api import Token
 from robot.errors import VariableError
@@ -1105,10 +1106,17 @@ class SimilarVariableChecker(VisitorChecker):
             self.find_not_nested_variable(token, token.value, is_var=False)
         return self.generic_visit(node)
 
+    @staticmethod
+    def for_assign_vars(for_node) -> Iterable[str]:
+        if ROBOT_VERSION.major < 7:
+            yield from for_node.variables
+        else:
+            yield from for_node.assign
+
     def visit_For(self, node):  # noqa
         for token in node.header.get_tokens(Token.ARGUMENT):
             self.find_not_nested_variable(token, token.value, is_var=False)
-        for var in node.variables:
+        for var in self.for_assign_vars(node):
             self.assigned_variables[normalize_robot_var_name(var)].append(var)
         self.generic_visit(node)
 

--- a/robocop/config.py
+++ b/robocop/config.py
@@ -537,9 +537,9 @@ class Config:
         }
         deprecated = {
             # "rule-name": "deprecation message"
-            "bad-indent": "'strict' and 'ignore_uneven' parameters are no longer available for this rule. "
-            "Take a look at new E1017 bad-block-indent rule that replaces them."  # warning added in v.3.0.0
         }
+        if not (deprecated or renamed):
+            return
         deprecation_header = "### DEPRECATION WARNING ###"
         deprecation_footer = "This information will disappear in the next version.\n\n"
         # get all rules mentioned in include and exclude CLI options

--- a/tests/atest/utils/__init__.py
+++ b/tests/atest/utils/__init__.py
@@ -13,6 +13,8 @@ from robocop.config import Config
 from robocop.utils.misc import ROBOT_VERSION
 from robocop.utils.version_matching import VersionSpecifier
 
+DEPRECATION_PERIOD = False
+
 
 @contextlib.contextmanager
 def isolated_output():
@@ -113,7 +115,10 @@ class RuleAcceptance:
             finally:
                 sys.stdout.flush()
                 result = get_result(output)
-                parsed_results = remove_deprecation_warning(result).splitlines()
+                if DEPRECATION_PERIOD:
+                    parsed_results = remove_deprecation_warning(result).splitlines()
+                else:
+                    parsed_results = result.splitlines()
         actual = normalize_result(parsed_results, test_data)
         if actual != expected:
             missing_expected = sorted(set(actual) - set(expected))

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings


### PR DESCRIPTION
Fixes #993
Fixes #1003

I have also added pytest option to not ignore warnings - any warning in the tests will now result in failed test.