### PR TITLE
Handle VAR syntax in variable naming rules

### DIFF
--- a/docs/releasenotes/unreleased/rules.1.rst
+++ b/docs/releasenotes/unreleased/rules.1.rst
@@ -1,0 +1,8 @@
+Updated existing rules with VAR support (#973)
+-----------------------------------------------
+
+Following rules now support ``VAR`` syntax:
+
+- W0310 ``non-local-variables-should-be-uppercase``
+- I0317 ``hyphen-in-variable-name``
+- W0324 ``overwriting-reserved-variable``

--- a/tests/atest/rules/naming/hyphen_in_variable_name/VAR_syntax.robot
+++ b/tests/atest/rules/naming/hyphen_in_variable_name/VAR_syntax.robot
@@ -1,0 +1,8 @@
+*** Test Cases ***
+My Test Case
+    VAR    ${r}   ${2-1}  # this is fine
+    VAR    ${a-b}    1  # this will warn - because if it's later used as ${a-b} it can lead to ambiguous results
+    VAR    ${a\-b}  1  # this will warn
+    VAR    ${-}    1   scope=GLOBAL  # this will warn
+    VAR    ${a-}   1   # this will warn
+    VAR    ${-b}   1   # this will warn

--- a/tests/atest/rules/naming/hyphen_in_variable_name/expected_output_var.txt
+++ b/tests/atest/rules/naming/hyphen_in_variable_name/expected_output_var.txt
@@ -1,0 +1,5 @@
+VAR_syntax.robot:4:12 [I] 0317 Use underscore in variable name '${a-b}' instead of hyphens to avoid treating them like minus sign
+VAR_syntax.robot:5:12 [I] 0317 Use underscore in variable name '${a\-b}' instead of hyphens to avoid treating them like minus sign
+VAR_syntax.robot:6:12 [I] 0317 Use underscore in variable name '${-}' instead of hyphens to avoid treating them like minus sign
+VAR_syntax.robot:7:12 [I] 0317 Use underscore in variable name '${a-}' instead of hyphens to avoid treating them like minus sign
+VAR_syntax.robot:8:12 [I] 0317 Use underscore in variable name '${-b}' instead of hyphens to avoid treating them like minus sign

--- a/tests/atest/rules/naming/hyphen_in_variable_name/test_rule.py
+++ b/tests/atest/rules/naming/hyphen_in_variable_name/test_rule.py
@@ -4,3 +4,6 @@ from tests.atest.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
+
+    def test_var_syntax(self):
+        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", target_version=">=7")

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/VAR_syntax.robot
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/VAR_syntax.robot
@@ -1,0 +1,10 @@
+*** Keywords ***
+VAR syntax
+    VAR    ${suite}    value    scope=SUITE
+    VAR    ${global}    value    scope=GLOBAL
+    VAR    ${test}    value    scope=TEST
+    VAR    ${task}    value    scope=TASK
+    VAR    ${local_default}    value    scope=local
+    VAR    ${local_default}    value
+    VAR    ${invalid
+

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/expected_output_var.txt
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/expected_output_var.txt
@@ -1,0 +1,4 @@
+VAR_syntax.robot:3:12 [W] 0310 Test, suite and global variables should be uppercase
+VAR_syntax.robot:4:12 [W] 0310 Test, suite and global variables should be uppercase
+VAR_syntax.robot:5:12 [W] 0310 Test, suite and global variables should be uppercase
+VAR_syntax.robot:6:12 [W] 0310 Test, suite and global variables should be uppercase

--- a/tests/atest/rules/naming/non_local_variables_should_be_uppercase/test_rule.py
+++ b/tests/atest/rules/naming/non_local_variables_should_be_uppercase/test_rule.py
@@ -4,3 +4,6 @@ from tests.atest.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
+
+    def test_var(self):
+        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", target_version=">=7")

--- a/tests/atest/rules/naming/overwriting_reserved_variable/VAR_syntax.robot
+++ b/tests/atest/rules/naming/overwriting_reserved_variable/VAR_syntax.robot
@@ -1,0 +1,12 @@
+*** Test Cases ***
+Overwrite reserved with VAR
+    VAR     ${TEST_NAME}    new_value
+    VAR    ${TEST DOCUMENTATION}    new value    scope=GLOBAL
+    VAR    ${LOG LEVEL}    ${OPTIONS}    scope=LOCAL
+
+
+*** Keywords ***
+Overwrite reserved with VAR
+    VAR     ${TEST_NAME}    new_value
+    VAR    ${TEST DOCUMENTATION}    new value    scope=GLOBAL
+    VAR    ${LOG LEVEL}    ${OPTIONS}    scope=LOCAL

--- a/tests/atest/rules/naming/overwriting_reserved_variable/expected_output_var.txt
+++ b/tests/atest/rules/naming/overwriting_reserved_variable/expected_output_var.txt
@@ -1,0 +1,6 @@
+VAR_syntax.robot:3:13 [W] 0324 Variable '${TEST_NAME}' overwrites reserved variable '${TEST_NAME}'
+VAR_syntax.robot:4:12 [W] 0324 Variable '${TEST DOCUMENTATION}' overwrites reserved variable '${TEST_DOCUMENTATION}'
+VAR_syntax.robot:5:12 [W] 0324 Variable '${LOG LEVEL}' overwrites reserved variable '${LOG_LEVEL}'
+VAR_syntax.robot:10:13 [W] 0324 Variable '${TEST_NAME}' overwrites reserved variable '${TEST_NAME}'
+VAR_syntax.robot:11:12 [W] 0324 Variable '${TEST DOCUMENTATION}' overwrites reserved variable '${TEST_DOCUMENTATION}'
+VAR_syntax.robot:12:12 [W] 0324 Variable '${LOG LEVEL}' overwrites reserved variable '${LOG_LEVEL}'

--- a/tests/atest/rules/naming/overwriting_reserved_variable/test_rule.py
+++ b/tests/atest/rules/naming/overwriting_reserved_variable/test_rule.py
@@ -4,3 +4,6 @@ from tests.atest.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col")
+
+    def test_var(self):
+        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", target_version=">=7")


### PR DESCRIPTION
Relates #973

It does only handle variable naming rules - other rules (like unused-variable or any rule related to variable) still does not support VAR.