### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         include:
           - os: 'ubuntu-latest'
-            python-version: '3.7'
+            python-version: '3.8'
             rf-version: 'rf3'
           - os: 'ubuntu-latest'
-            python-version: '3.7'
+            python-version: '3.8'
             rf-version: 'rf4'
           - os: 'ubuntu-latest'
             python-version: '3.8'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.8"
 
 python:
   install:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,7 +103,7 @@ comments are generally not needed.
 
 All code, including test code, must be compatible with all supported Python
 interpreters and versions. Most importantly this means that the code must
-support Python 3.7+ and Robot Framework 3.2.2+.
+support Python 3.8+ and Robot Framework 3.2.2+.
 
 To ensure high quality of the code we use `pylama
 <https://github.com/klen/pylama>`_ static code analysis tool to check

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Most common questions with answers can be found at the bottom ⬇ of this README
 Requirements
 ------------
 
-Python 3.7+ :snake: and Robot Framework 3.2.2+ :robot:.
+Python 3.8+ :snake: and Robot Framework 3.2.2+ :robot:.
 
 Installation
 ------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -14,7 +14,7 @@ looking for potential errors or violations to code quality standards (commonly r
 Requirements
 ============
 
-Python 3.7+ |:snake:| and Robot Framework 3.2.2+ |:robot:|.
+Python 3.8+ |:snake:| and Robot Framework 3.2.2+ |:robot:|.
 
 Installation
 ============

--- a/docs/releasenotes/unreleased/other.1.rst
+++ b/docs/releasenotes/unreleased/other.1.rst
@@ -1,0 +1,5 @@
+Drop Python 3.7 support (#942)
+-------------------------------
+
+Robocop dropped support for Python 3.7 as it is no longer officially supported. See more details at
+https://endoflife.date/python .

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+UNIT_TEST_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 nox.options.sessions = [
     "unit",
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ Development Status :: 5 - Production/Stable
 License :: OSI Approved :: Apache Software License
 Operating System :: OS Independent
 Programming Language :: Python
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
@@ -48,7 +47,7 @@ setup(
     keywords=KEYWORDS,
     packages=["robocop"],
     project_urls=PROJECT_URLS,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
     install_requires=[
         "jinja2>=3.0,<4.0",


### PR DESCRIPTION
Any code updates (now possible since we only support Py 3.8+) can be done in separate refactors - this PR only focus on the dropping the 3.7 support. 

Closes #942