### PR TITLE
Refactor Github actions to run on all OS, Python and RF versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,31 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: 'ubuntu-latest'
-            python-version: '3.8'
-            rf-version: 'rf3'
-          - os: 'ubuntu-latest'
-            python-version: '3.8'
-            rf-version: 'rf4'
-          - os: 'ubuntu-latest'
-            python-version: '3.8'
-            rf-version: 'rf5'
-          - os: 'ubuntu-latest'
-            python-version: '3.9'
-            rf-version: 'rf6'
-          - os: 'ubuntu-latest'
-            python-version: '3.10'
-            rf-version: 'rf6'
-          - os: 'ubuntu-latest'
-            python-version: '3.11'
-            rf-version: 'rf5'
-          - os: 'ubuntu-latest'
-            python-version: '3.12'
-            rf-version: 'rf7'
-          - os: 'windows-latest'
-            python-version: '3.11'
-            rf-version: 'rf6'
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -51,19 +27,22 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r tests/rf_versions_matrix/requirements_${{ matrix.rf-version }}.txt
-          pip install .[dev]
+          pip install nox
 
       - name: Run unit tests with coverage
         run:
-          coverage run -m pytest
+          nox -s coverage
 
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:
-          name: ${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.rf-version }}
+          name: ${{ matrix.os }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 import nox
 
 UNIT_TEST_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+ROBOT_VERSIONS = ["3", "4", "5", "6", "7"]
 nox.options.sessions = [
     "unit",
 ]
@@ -17,29 +18,35 @@ def install_doc_deps(session, robot_major_ver):
 
 
 @nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
-@nox.parametrize("rf", ["3", "4", "5", "6"])
+@nox.parametrize("rf", ROBOT_VERSIONS)
 def unit(session, rf):
     install_dev_deps(session, rf)
     session.run("pytest", "tests")
 
 
-@nox.session()
-def coverage(session):
-    install_dev_deps(session, "5")
+@nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
+@nox.parametrize("rf", ROBOT_VERSIONS)
+def coverage(session, rf):
+    install_dev_deps(session, rf)
     session.install("coverage")
-    session.run("coverage", "run", "-m", "pytest")
+    session.run("coverage", "run", "-a", "-m", "pytest")
+    session.notify("coverage_report")
+
+
+@nox.session
+def coverage_report(session):
     session.run("coverage", "html")
 
 
 @nox.session()
 def docs(session):
-    install_doc_deps(session, "5")
+    install_doc_deps(session, ROBOT_VERSIONS[-1])
     session.run("sphinx-build", "-a", "-E", "-b", "html", "docs", "docs/_build/")
 
 
 @nox.session()
 def benchmark(session):
-    install_dev_deps(session, "5")
+    install_dev_deps(session, ROBOT_VERSIONS[-1])
     session.run(
         "pytest",
         "--benchmark-only",


### PR DESCRIPTION
This is test only so far - I came up with an idea how to run our tests on combination of all OS/Python/RF version without spending too much time (though it will take longer) and using too much of Github resources.

The major downside right now is logging - if the test fail for specific Python/RF version it may be harder to find it. I need to test if it's still okay.

Edit. It seems the builds are taking really long time..it's essentially running Py3.8-Py3.12 * RF3 - RF7 = 5 * 5 = 25 builds inside one docker * 3 OS. We could introduce it as separate action to run after the release/or on release branch before merging - long but covering all possible versions etc. And run current action for 'common' PRs. With that approach we could 'thin' the original run a bit (don't run on Windows, run on every RF version but do not cover all Py versions etc) - since those combinations rarely fail and take longer time. And we will run it anyway but just once before release.