### PR TITLE
Count VAR as keyword call in length rules

### DIFF
--- a/docs/releasenotes/unreleased/rules.1.rst
+++ b/docs/releasenotes/unreleased/rules.1.rst
@@ -6,3 +6,8 @@ Following rules now support ``VAR`` syntax:
 - W0310 ``non-local-variables-should-be-uppercase``
 - I0317 ``hyphen-in-variable-name``
 - W0324 ``overwriting-reserved-variable``
+- W0501 ``too-long-keyword``
+- W0502 ``too-few-calls-in-keyword``
+- W0503 ``too-many-calls-in-keyword``
+- W0504 ``too-long-test-case``
+- W0505 ``too-many-calls-in-test-case``

--- a/robocop/utils/misc.py
+++ b/robocop/utils/misc.py
@@ -3,7 +3,7 @@ import difflib
 import re
 import token as python_token
 import tokenize
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, namedtuple
 from io import StringIO
 from pathlib import Path
 from tokenize import generate_tokens
@@ -27,6 +27,35 @@ from robocop.version import __version__
 ROBOT_VERSION = Version(RF_VERSION)
 ROBOT_WITH_LANG = Version("6.0")
 ROBOCOP_RULES_URL = "https://robocop.readthedocs.io/en/{version}/rules_list.html"
+
+
+ReturnClasses = namedtuple("ReturnClasses", ["return_class", "return_setting_class"])
+
+
+def get_return_classes() -> ReturnClasses:
+    """
+    Robot Framework change model names for [Return] and RETURN depending on the RF version. To achieve backward
+    compatibility we need to define mapping.
+    """
+    from robot.parsing.model.statements import Return
+
+    if ROBOT_VERSION.major < 5:
+        return_class = Return  # it does not exist, but we define it for backward compatibility
+        return_setting_class = Return
+    elif ROBOT_VERSION.major < 7:
+        from robot.api.parsing import ReturnStatement
+
+        return_class = ReturnStatement
+        return_setting_class = Return
+    else:
+        from robot.api.parsing import ReturnSetting
+
+        return_class = Return
+        return_setting_class = ReturnSetting
+    return ReturnClasses(return_class, return_setting_class)
+
+
+RETURN_CLASSES = get_return_classes()
 
 
 def rf_supports_lang():

--- a/tests/atest/rules/lengths/too_few_calls_in_keyword/expected_output.txt
+++ b/tests/atest/rules/lengths/too_few_calls_in_keyword/expected_output.txt
@@ -1,2 +1,2 @@
-test.robot:25:1 [W] 0502 Keyword 'Empty Keyword' has too few keywords inside (0/1)
-test.robot:27:1 [W] 0502 Keyword 'Keyword' has too few keywords inside (0/1)
+test.robot:30:1 [W] 0502 Keyword 'Empty Keyword' has too few keywords inside (0/1)
+test.robot:32:1 [W] 0502 Keyword 'Keyword' has too few keywords inside (0/1)

--- a/tests/atest/rules/lengths/too_few_calls_in_keyword/expected_output_severity.txt
+++ b/tests/atest/rules/lengths/too_few_calls_in_keyword/expected_output_severity.txt
@@ -1,3 +1,3 @@
-test.robot:22:1 [W] 0502 Keyword 'Short Keyword' has too few keywords inside (1/1)
-test.robot:25:1 [E] 0502 Keyword 'Empty Keyword' has too few keywords inside (0/0)
-test.robot:27:1 [E] 0502 Keyword 'Keyword' has too few keywords inside (0/0)
+test.robot:27:1 [W] 0502 Keyword 'Short Keyword' has too few keywords inside (1/1)
+test.robot:30:1 [E] 0502 Keyword 'Empty Keyword' has too few keywords inside (0/0)
+test.robot:32:1 [E] 0502 Keyword 'Keyword' has too few keywords inside (0/0)

--- a/tests/atest/rules/lengths/too_few_calls_in_keyword/test.robot
+++ b/tests/atest/rules/lengths/too_few_calls_in_keyword/test.robot
@@ -19,6 +19,11 @@ Keyword
     No Operation
     Fail
 
+Only VAR
+    VAR    ${variable}
+    VAR    ${variable}
+    VAR    ${variable}
+
 Short Keyword
     Keyword
 

--- a/tests/atest/rules/lengths/too_few_calls_in_test_case/test.robot
+++ b/tests/atest/rules/lengths/too_few_calls_in_test_case/test.robot
@@ -32,6 +32,11 @@ Test case with settings and no keyword calls
     [Timeout]    1 min
     [Documentation]    doc
 
+Test only with VAR
+    VAR    ${variable}
+    VAR    ${variable}
+    VAR    ${variable}
+
 
 *** Keywords ***
 Keyword

--- a/tests/atest/rules/lengths/too_long_keyword/expected_output.txt
+++ b/tests/atest/rules/lengths/too_long_keyword/expected_output.txt
@@ -1,1 +1,1 @@
-test.robot:15:1 [W] 0501 Keyword 'Some Keyword' is too long (45/40)
+test.robot:15:1 [W] 0501 Keyword 'Some Keyword' is too long (46/40)

--- a/tests/atest/rules/lengths/too_long_keyword/test.robot
+++ b/tests/atest/rules/lengths/too_long_keyword/test.robot
@@ -58,6 +58,7 @@ Some Keyword
     ...   ${var}
     ...   ${var}
     ...   ${var}
+    VAR    ${variable}
 
 
 Keyword with comments at the end

--- a/tests/atest/rules/lengths/too_long_test_case/test.robot
+++ b/tests/atest/rules/lengths/too_long_test_case/test.robot
@@ -24,7 +24,7 @@ Test
     ...  ${var}
     ...  ${var}
     ...  ${var}
-    One More
+    VAR    ${variable}    value
 
 Test with comments at the end
     Pass

--- a/tests/atest/rules/lengths/too_many_calls_in_keyword/test.robot
+++ b/tests/atest/rules/lengths/too_many_calls_in_keyword/test.robot
@@ -19,7 +19,7 @@ Some Keyword
     No Operation
     Fail
     No Operation
-    No Operation
+    VAR    ${variable}    value
     No Operation
     No Operation
     No Operation

--- a/tests/atest/rules/lengths/too_many_calls_in_test_case/test.robot
+++ b/tests/atest/rules/lengths/too_many_calls_in_test_case/test.robot
@@ -17,7 +17,7 @@ Test
     Keyword
     Keyword
     Keyword
-    Keyword
+    VAR    ${variable}    value    scope=GLOBAL
     One More
 
 


### PR DESCRIPTION
Relates #973 

Also introduced new way of handling ``RETURN`` and ``[Return]`` mess (why, just why change class name to one that was assigned for different model just for sake changing it.. ;))