### PR TITLE
Handle RF development version as final version

### DIFF
--- a/docs/releasenotes/unreleased/other.2.rst
+++ b/docs/releasenotes/unreleased/other.2.rst
@@ -1,0 +1,19 @@
+Consider Robot Framework development version as final version in rule version matching
+---------------------------------------------------------------------------------------
+
+Robot Framework development version (for example 7.0rc1) is considered as final version (for example 7.0) in our
+version matcher. Thanks to this change it is easier to test rules with not released version - it's not required
+to define exact version specifier anymore (for example '==7.0rc1').
+
+It's internal change but can have effect on your custom rules if you have rule version specifier using development
+version:
+
+```
+"XYZ": Rule(
+    rule_id="XYZ",
+    name="custom-rule",
+    msg="custom-message",
+    severity=RuleSeverity.WARNING,
+    version=">=4.0alpha",  # it is not allowed anymore, use >=4.0 instead
+    )
+```

--- a/tests/atest/rules/errors/parsing_error/expected_output_rf7.txt
+++ b/tests/atest/rules/errors/parsing_error/expected_output_rf7.txt
@@ -14,8 +14,8 @@ invalid_try_except.robot:36:1 [E] 0401 Robot Framework syntax error: TRY does no
 invalid_try_except.robot:48:1 [E] 0401 Robot Framework syntax error: EXCEPT branch cannot be empty.
 invalid_try_except.robot:57:1 [E] 0401 Robot Framework syntax error: EXCEPT without patterns must be last.
 invalid_try_except.robot:69:1 [E] 0401 Robot Framework syntax error: Only one EXCEPT without patterns allowed.
-invalid_try_except.robot:83:1 [E] 0401 Robot Framework syntax error: EXCEPT AS requires variable.
-invalid_try_except.robot:91:1 [E] 0401 Robot Framework syntax error: EXCEPT AS accepts only one variable.
+invalid_try_except.robot:83:1 [E] 0401 Robot Framework syntax error: EXCEPT AS requires a value.
+invalid_try_except.robot:91:1 [E] 0401 Robot Framework syntax error: EXCEPT AS accepts only one value.
 invalid_try_except.robot:99:1 [E] 0401 Robot Framework syntax error: EXCEPT AS variable 'foo' is invalid.
 invalid_try_except.robot:109:1 [E] 0401 Robot Framework syntax error: ELSE does not accept arguments, got 'I should not be here'.
 invalid_try_except.robot:121:1 [E] 0401 Robot Framework syntax error: ELSE branch cannot be empty.

--- a/tests/atest/rules/errors/parsing_error/test_rule.py
+++ b/tests/atest/rules/errors/parsing_error/test_rule.py
@@ -3,7 +3,7 @@ from tests.atest.utils import RuleAcceptance
 
 class TestRule(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=7")
+        self.check_rule(expected_file="expected_output_rf7.txt", target_version=">=7")
 
     def test_rule_rf61(self):
         self.check_rule(expected_file="expected_output.txt", target_version="==6.1.*")

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -219,17 +219,14 @@ class TestMisc:
     [
         ("6.0.2", ">=6", True),
         ("6.1a2.dev1", ">=6", True),
-        ("6.0rc2.dev1", ">=6", False),
-        ("6.0pre2.dev1", ">=6", False),
+        ("6.0rc2.dev1", ">=6", True),
+        ("6.0pre2.dev1", ">=6", True),
         ("6.0.2", "<5", False),
         ("6.1a2.dev1", "<=5", False),
         ("6.1a2.dev1", "~=5.0", False),
         ("6.0rc2.dev1", "<=6", True),
         ("6.0rc2.dev", "<=6", True),
-        ("5.0", "<=5dev1", False),
-        ("5.0", ">5dev1", False),
-        ("5.0", ">5.0.dev1", False),
-        ("6.0dev0", ">=6", False),
+        ("6.0dev0", ">=6", True),
         ("6.0", ">=6", True),
         ("6", ">=6", True),
         ("5.0.2", ">=6", False),
@@ -261,12 +258,8 @@ def test_version_parsing_and_comparison():
     lower_version = Version("3")
     for version in versions:
         assert (version.major, version.minor, version.micro) == (4, 0, 0)
-        if version.dev is None:
-            assert version == equal_version
-            assert version >= equal_version
-        else:
-            assert version != equal_version
-            assert not version >= equal_version
+        assert version == equal_version
+        assert version >= equal_version
         assert version <= equal_version
         assert version < higher_version
         assert not version > higher_version


### PR DESCRIPTION
With previous implementation there was problem where some of our tests didn't run at all. For example if we used ">=7" version specifier, RF "7.0a1" didn't match it. I have decided to just drop support for development versions in version specifier and handle those as 'final' versions. Parsed version (the one from RF) can have development suffix (dev1, rc1..) but it will be ignored.