### PR TITLE
Update community rules documentation

### DIFF
--- a/docs/community_rules.rst
+++ b/docs/community_rules.rst
@@ -1,32 +1,19 @@
-.. _rules list:
+.. _community rules:
 
-**********
-Rules list
-**********
+********************
+Community rules list
+********************
 
-This is the complete list of all Robocop rules grouped by categories.
-If you want to learn more about the rules and their features, see :ref:`rules`.
+Community rules are optional rules that may handle specific issues or offer particular utility with certain limitations.
+All community rules are disabled by default and can be enabled by configuring ``enabled`` parameter::
 
-There are over a 100 rules available in Robocop and they are organized into the following categories:
+    robocop --configure sleep-keyword-used:enabled:True
 
-* 01: Base
-* 02: :ref:`Documentation`
-* 03: :ref:`Naming`
-* 04: :ref:`Errors`
-* 05: :ref:`Lengths`
-* 06: :ref:`Tags`
-* 07: :ref:`Comments`
-* 08: :ref:`Duplications`
-* 09: :ref:`Misc`
-* 10: :ref:`Spacing`
+or by including rule in ``--include``::
 
-Each rule has a 4-digit ID that contains:
-- a 2-digit category ID (listed above), followed by
-- a 2-digit rule number.
+    robocop --include sleep-keyword-used
 
-Below is the list of all built-in Robocop rules. Enjoy |:sunglasses:|
-
-{% for checker_group in builtin_checkers %}
+{% for checker_group in community_checkers %}
 .. _{{ checker_group[0] }}:
 
 {{ checker_group[0] }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,12 +68,16 @@ def setup(app):
     app.add_css_file("css/custom.css")
 
 
-def get_checker_docs():
+def get_checker_docs(rule_type: str):
     """
     Load rules for dynamic docs generation
     """
     checker_docs = defaultdict(list)
-    for module_name, rule in robocop.checkers.get_builtin_rules():
+    if rule_type == "builtin":
+        rules = robocop.checkers.get_builtin_rules()
+    else:
+        rules = robocop.checkers.get_community_rules()
+    for module_name, rule in rules:
         module_name = module_name.title()
         severity_threshold = rule.config.get("severity_threshold", None)
         robocop_version = rule.added_in_version if rule.added_in_version else "\\-"
@@ -110,4 +114,4 @@ def get_checker_docs():
     return groups_sorted_by_id
 
 
-html_context = {"checker_groups": get_checker_docs()}
+html_context = {"builtin_checkers": get_checker_docs("builtin"), "community_checkers": get_checker_docs("community")}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Table of contents
 
    rule_basics
    rules_list
+   community_rules
    external_rules
 
 .. toctree::

--- a/docs/releasenotes/unreleased/most_important.1.rst
+++ b/docs/releasenotes/unreleased/most_important.1.rst
@@ -1,5 +1,29 @@
 New community rules
 -------------------
 
-<description here, together with first community rule (working as example)>
-<also describe somewhere robocop --list COMMUNITY and robocop --list ALL>
+Robocop now contains new type of rules: **community rules**. To put it simply, community rule is just rule disabled
+by default. However it allows us to add rules that handle specific problems or have certain limitations. Such rules
+will not be enabled by default and users will be able to choose to run them or not.
+
+``Community rule`` name originates from our purpose behind this feature - we want users (our community) to more actively
+contribute to Robocop rules. If you developed rule for your company that may benefit more people but is not fit for
+everyone feel free to add it in our repository.
+
+Existing community rules can be listed with ``COMMUNITY`` or ``ALL`` filters::
+
+    > robocop --list COMMUNITY
+    Rule - 10001 [W]: sleep-keyword-used: Sleep keyword with '{{ duration_time }}' sleep time found (disabled)
+
+Those rules can be enabled by configuring ``enabled`` parameter::
+
+    robocop --configure sleep-keyword-used:enabled:True
+
+or by including rule in ``--include``::
+
+    robocop --include sleep-keyword-used
+
+Community rules - or in other words rules disabled by default - are now part of our core code. It is now also
+possible to create custom disabled by default rule. If you want to contribute new community rule or create your own
+custom rule then <check out this doc page>. # TODO
+
+https://robocop.readthedocs.io/en/stable/external_rules.html#rules-disabled-by-default


### PR DESCRIPTION
Add missing release notes and list community rules in our documentation:

![image](https://github.com/MarketSquare/robotframework-robocop/assets/8532066/81db3f19-8d99-4afa-a7d3-cb8f56da0a7b)

It's related to #898 but does not implement it - since linked issue is for guides how to create community rule.