### PR TITLE
Documentation fix: Changed `unused-keyword` introduction version to 5.3.0

### DIFF
--- a/robocop/checkers/community_rules/usage.py
+++ b/robocop/checkers/community_rules/usage.py
@@ -21,7 +21,7 @@ rules = {
         name="unused-keyword",
         msg="Keyword '{{ keyword_name }}' is not used",
         severity=RuleSeverity.INFO,
-        added_in_version="5.1.0",
+        added_in_version="5.3.0",
         enabled=False,
         docs="""
         Reports not used keywords.


### PR DESCRIPTION
The community rule `unused-keyword` claims to be added in 5.1.0, but it was actually added in 5.3.0.

This is a docs-only change