### PR TITLE
Rule/undefined argument value

### DIFF
--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -855,10 +855,10 @@ rules = {
         optionally overwrite this default.
 
         When you use an argument default, you should be as clear as possible. This improves the
-        readability of your code. The syntax `${argument}=` is unclear unless you happen to know
-        that it is technically equivalent to `${argument}=${EMPTY}`. To prevent people from
+        readability of your code. The syntax ``${argument}=`` is unclear unless you happen to know
+        that it is technically equivalent to ``${argument}=${EMPTY}``. To prevent people from
         misreading your keyword arguments, explicitly state that the value is empty using the
-        built-in `${EMPTY}` variable.
+        built-in ``${EMPTY}`` variable.
 
         Example of a rule violation::
 
@@ -874,7 +874,20 @@ rules = {
         severity=RuleSeverity.ERROR,
         added_in_version="5.7.0",
         docs="""
-        TODO
+        When calling a keyword, it can accept named arguments.
+
+        When you call a keyword, you should be as clear as possible. This improves the
+        readability of your code. The syntax ``argument=`` is unclear unless you happen to know
+        that it is technically equivalent to ``argument=${EMPTY}``. To prevent people from
+        misreading your keyword arguments, explicitly state that the value is empty using the
+        built-in ``${EMPTY}`` variable.
+
+        If your argument is falsly flagged by this rule, escape the ``=`` character in your argument
+        value by like so: ``\\=``.
+
+        Example of a rule violation::
+
+            My Amazing Keyword    argument_name=
         """,
     ),
 }

--- a/tests/atest/rules/misc/undefined_argument_value/expected_output.txt
+++ b/tests/atest/rules/misc/undefined_argument_value/expected_output.txt
@@ -1,0 +1,6 @@
+test.robot:3:12 [E] 0933 Undefined argument value, use message=${EMPTY} instead
+test.robot:4:12 [E] 0933 Undefined argument value, use message=${EMPTY} instead
+test.robot:4:24 [E] 0933 Undefined argument value, use level=${EMPTY} instead
+test.robot:5:27 [E] 0933 Undefined argument value, use level=${EMPTY} instead
+test.robot:6:12 [E] 0933 Undefined argument value, use A great log message=${EMPTY} instead
+test.robot:7:12 [E] 0933 Undefined argument value, use A great log message =${EMPTY} instead

--- a/tests/atest/rules/misc/undefined_argument_value/test.robot
+++ b/tests/atest/rules/misc/undefined_argument_value/test.robot
@@ -1,0 +1,20 @@
+*** Test Cases ***
+With undefined value
+    Log    message=
+    Log    message=    level=
+    Log    Hello world    level=    html=${True}
+    Log    A great log message=
+    Log    A great log message =
+
+With escaped equals sign
+    Log    A great log message \=
+    Log    A great log message\=
+    Log    Hello\=world
+    Log    mess\=age=foo
+
+With defined values
+    Log    Hello = world
+    Log    message=Hello world
+    Log    message==
+    Log    =
+    Log    = amazing!

--- a/tests/atest/rules/misc/undefined_argument_value/test_rule.py
+++ b/tests/atest/rules/misc/undefined_argument_value/test_rule.py
@@ -1,0 +1,6 @@
+from tests.atest.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")


### PR DESCRIPTION
Closes #1149 

I thought I'd quickly do the same thing I did for `undefined-argument-default`. There was some hidden complexity caused by this version using `arg_name` instead of `${arg_name}`.