### PR TITLE
New Robocop: Add --force-order option to formatter

### DIFF
--- a/tests/config/test_formatter_config.py
+++ b/tests/config/test_formatter_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+from robocop.config import FormatterConfig
+
+
+@pytest.mark.parametrize(
+    "select",
+    [
+        ["NormalizeSeparators", "CustomFormatter", "NormalizeNewLines"],
+        ["NormalizeSeparators", "NormalizeNewLines", "CustomFormatter"],
+        ["NormalizeNewLines", "CustomFormatter", "NormalizeSeparators"],
+        ["CustomFormatter", "NormalizeNewLines", "NormalizeSeparators"],
+    ],
+)
+def test_unordered_select(select: list[str]):
+    expected_order = ["NormalizeSeparators", "NormalizeNewLines", "CustomFormatter"]
+    config = FormatterConfig(select=select)
+    assert expected_order == config.selected_formatters()
+
+
+@pytest.mark.parametrize(
+    "select",
+    [
+        ["NormalizeSeparators", "CustomFormatter", "NormalizeNewLines"],
+        ["NormalizeSeparators", "NormalizeNewLines", "CustomFormatter"],
+        ["NormalizeNewLines", "CustomFormatter", "NormalizeSeparators"],
+        ["CustomFormatter", "NormalizeNewLines", "NormalizeSeparators"],
+    ],
+)
+def test_ordered_select(select: list[str]):
+    config = FormatterConfig(select=select, force_order=True)
+    assert select == config.selected_formatters()


### PR DESCRIPTION
Mirrored from bhirsz/robotframework-cop-academy PR #92