### PR TITLE
Add paralleing testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ path = "src/robocop/__init__.py"
 dev = [
     "coverage>=7.6.4",
     "pytest>=8.3.3",
+    "pytest-xdist>=3.6.1",
     "ruff==0.9.7",
 ]
 doc = [

--- a/tests/formatter/__init__.py
+++ b/tests/formatter/__init__.py
@@ -82,7 +82,7 @@ class FormatterAcceptanceTest:
     ):
         if not self.enabled_in_version(test_on_version):
             pytest.skip(f"Test enabled only for RF {test_on_version}")
-        output_path = self.FORMATTERS_DIR / "actual" / source
+        output_path = self.FORMATTERS_DIR / self.FORMATTER_NAME / "actual" / source
         if source is None:
             source_path = self.FORMATTERS_DIR / self.FORMATTER_NAME / "source"
         else:
@@ -107,7 +107,7 @@ class FormatterAcceptanceTest:
         if expected_name is None:
             expected_name = actual_name
         expected = self.FORMATTERS_DIR / self.FORMATTER_NAME / "expected" / expected_name
-        actual = self.FORMATTERS_DIR / "actual" / actual_name
+        actual = self.FORMATTERS_DIR / self.FORMATTER_NAME / "actual" / actual_name
         if not filecmp.cmp(expected, actual):
             display_file_diff(expected, actual)
             pytest.fail(f"File {actual_name} is not same as expected")

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612 },
+]
+
+[[package]]
 name = "furo"
 version = "2024.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -392,6 +401,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
+]
+
+[[package]]
 name = "pytz"
 version = "2024.2"
 source = { registry = "https://pypi.org/simple" }
@@ -456,6 +478,7 @@ dependencies = [
 dev = [
     { name = "coverage" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 doc = [
@@ -483,6 +506,7 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = ">=7.6.4" },
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = "==0.9.7" },
 ]
 doc = [


### PR DESCRIPTION
Our tests are not fully prepared for it - for example some tests are trying to access the same file or use the same actual filename. It may leads to failing tests if too much workers are used at once. For that reason parallel testing it opt in feature until we adjust all tests for parallel testing.

To run tests in parallel simply add ``-n x`` option when running tests, where x is number of workers (recommended is 5).