### PR TITLE
Add migrate config command for migrating old robocop & robotidy configuration files

### DIFF
--- a/docs/releasenotes/6.0.0dev1.rst
+++ b/docs/releasenotes/6.0.0dev1.rst
@@ -57,15 +57,15 @@ File inclusion changes:
 Previously, Robocop used ``paths`` argument and Robotidy ``src`` for selecting paths. It was then additionally
 configured using options for filtering based on directory names or file types.
 
-Now it is not possible to use ``paths / src`` in the configuration file. Paths can be configured only via cli,
-and then additionally filtered using new options listed below. The reason behind is that users always selected
-paths from the cli (``robocop src.robot`` or ``robotidy .``) and those arguments were overwritten anyway.
-Default path is ``.`` (current directory) and can be omitted (``robocop check`` / ``robocop format`` will start
-from the current directory).
+Now the role of ``paths`` was taken by ``include`` and ``--default--include`` (``*.robot`` and ``.resource``) options.
+It is recommended to use cli for selecting directory and leave it to robocop to find and filter out files.
+If nothing is configured (we only run ``robocop check`` / ``robocop format``) then it will start from the current
+directory. List of new or deprecated options:
 
+- ``paths`` became ``--include``
+- ``-ft/--filetypes`` is now deprecated in favour of using ``--include`` or ``--default-include`` option
 - ``-g/--ignore`` became ``-e/--exclude`` (additionally excluded paths)
 - ``-gd/--ignore-default`` became ``--default-exclude`` (paths excluded by default)
-- ``-ft/--filetypes`` is now deprecated in favour of using ``--include`` or ``--default-include`` option
 
 More on how to configure file paths in the X section in the documentation. # TODO
 
@@ -101,6 +101,7 @@ Issue format ``--format`` is now renamed to ``--issue-format``.
 Formatting options from Robotidy:
 
 - ``--lineseparator`` became ``--line-ending``
+- ``--spacecount`` became ``--space-count``
 - ``-sl/--startline`` became ``--start-line``
 - ``-el/--endline`` became ``--end-line``
 
@@ -373,8 +374,6 @@ id while ``01`` was unique rule number. This naming scheme wasn't clear and made
 glance. That's why we have switched to alphanumeric group names (for example ``DOC`` instead of ``02``).
 Various groups are also additionally split into smaller sub-groups. This change leads to backward incompatible
 changes to all rule ids.
-
-# TODO: LEN
 
 Documentation rules are now grouped under 'DOC' group:
 

--- a/docs/source/overview/linter.rst
+++ b/docs/source/overview/linter.rst
@@ -49,7 +49,7 @@ Use ``--select`` and ``--ignore`` to select only rules to run or run all default
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             select = [
                 "rule1",
                 "rule2",
@@ -137,7 +137,7 @@ it is properly configured. You can supply language code or name in the configura
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             language = [
                 "fi"
             ]
@@ -157,7 +157,7 @@ Support multiple languages by either using ``language`` option multiple times:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             language = [
                 "pl",
                 "pt"

--- a/docs/source/reports.rst
+++ b/docs/source/reports.rst
@@ -26,7 +26,7 @@ You can use multiple reports with separate arguments (``-r report1 -r report2``)
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             reports = [
                 "rules_by_id",
                 "some_other_report"
@@ -54,7 +54,7 @@ other reports, you can use the following configuration:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             reports = [
                 "timestamp",
                 "all"
@@ -95,7 +95,7 @@ For example:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             reports = [
                 "sarif"
             ]
@@ -151,7 +151,7 @@ Saving the results is disabled by default and can be enabled with ``--persistent
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             persistent = true
 
 Only the previous run for the current working directory is saved.
@@ -170,7 +170,7 @@ To used stored results to compare with current run, enable ``compare_runs`` repo
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             reports = [
                 "all",
                 "compare_runs"

--- a/docs/source/rules/external_rules.rst
+++ b/docs/source/rules/external_rules.rst
@@ -18,7 +18,7 @@ It accepts comma-separated list of paths to files, directories or name of the Py
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             ext_rules = [
                 "my/own/rule.py",
                 "external_rules.py"
@@ -181,7 +181,7 @@ Configurable parameter can be referred by its ``name`` in command line options:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             ext_rules = [
                 "my/own/rule.py"
             ]

--- a/docs/source/rules/rules_basics.rst
+++ b/docs/source/rules/rules_basics.rst
@@ -96,7 +96,7 @@ We can use ``severity_threshold`` for this purpose:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             configure = [
                 "line-too-long.severity_threshold=warning=120:error=200"
             ]
@@ -124,7 +124,7 @@ info message if the line is longer than 80 characters, we need to configure ``li
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             configure = [
                 "line-too-long.line_length=80",
                 "line-too-long.severity_threshold=info=80:warning=120:error=200"
@@ -161,7 +161,7 @@ To only select and run ``missing-doc-keyword`` rule:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             select = [
                 "missing-doc-keyword"
             ]
@@ -180,7 +180,7 @@ To run all rules except ``missing-doc-keyword`` rule:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             ignore = [
                 "missing-doc-keyword"
             ]
@@ -199,7 +199,7 @@ Robocop supports glob patterns:
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             select = [
                 "*doc*"
             ]
@@ -220,7 +220,7 @@ To configure multiple rules you can repeat option / or add more to array (config
 
         .. code:: toml
 
-            [robocop.linter]
+            [robocop.lint]
             select = [
                 "rule1",
                 "rule2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "robotframework>=4.0,<7.3",
     "typer>=0.12.5,<0.13",
     "tomli==2.0.2; python_version < '3.11'",
+    "tomli-w==1.2.0",
     "pathspec>=0.12,<0.13",
     "platformdirs>=4.3,<4.4",
     "pytz>=2022.7,<2024.3",

--- a/src/robocop/cli.py
+++ b/src/robocop/cli.py
@@ -13,6 +13,7 @@ from robocop.linter.reports import load_reports, print_reports
 from robocop.linter.rules import RuleFilter, RuleSeverity, filter_rules_by_category, filter_rules_by_pattern
 from robocop.linter.runner import RobocopLinter
 from robocop.linter.utils.misc import ROBOCOP_RULES_URL, compile_rule_pattern, get_plural_form  # TODO: move higher up
+from robocop.migrate_config import migrate_deprecated_configs
 
 
 class CliWithVersion(typer.core.TyperGroup):
@@ -559,6 +560,17 @@ def print_resource_documentation(name: Annotated[str, typer.Argument(help="Rule 
     else:
         console.print(f"There is no rule, formatter or a report with a '{name}' name.")
         raise typer.Exit(code=2)
+
+
+@app.command("migrate")
+def migrate_config(
+    config_path: Annotated[
+        Path, typer.Argument(help="Path to the configuration file to be migrated.", show_default=False)
+    ],
+) -> None:
+    """Migrate Robocop and Robotidy old configuration files to new format."""
+    # TODO: ask user to proceed, list warning with possible issues
+    migrate_deprecated_configs(config_path)
 
 
 def main() -> None:

--- a/src/robocop/linter/reports/text_file.py
+++ b/src/robocop/linter/reports/text_file.py
@@ -13,7 +13,7 @@ class TextFile(robocop.linter.reports.Report):
 
     You can configure output path::
 
-        robocop linter --configure json_report.output_path output/robocop.txt
+        robocop linter --configure text_file.output_path=output/robocop.txt
 
     ``text_file`` report supports only ``simple`` issue output format.
     """

--- a/src/robocop/linter/rules/__init__.py
+++ b/src/robocop/linter/rules/__init__.py
@@ -81,7 +81,7 @@ class RuleSeverity(Enum):
 
             .. code:: toml
 
-                [robocop.linter]
+                [robocop.lint]
                 configure = [
                     "line-too-long.severity=e"
                 ]
@@ -106,7 +106,7 @@ class RuleSeverity(Enum):
 
             .. code:: toml
 
-                [robocop.linter]
+                [robocop.lint]
                 threshold = "W"
 
     """

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -175,7 +175,7 @@ class InconsistentAssignmentRule(Rule):
 
             .. code:: toml
 
-                [robocop.linter]
+                [robocop.lint]
                 configure = [
                     "inconsistent-assignment.assignment_sign_type=none"
                 ]

--- a/src/robocop/migrate_config.py
+++ b/src/robocop/migrate_config.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import tomli_w
+
+from robocop.files import load_toml_file
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+RENAMED_RULES = {
+    "0201": "DOC01",
+    "0202": "DOC02",
+    "0203": "DOC03",
+    "0204": "DOC04",
+    "0601": "TAG01",
+    "0602": "TAG02",
+    "0603": "TAG03",
+    "0605": "TAG05",
+    "0606": "TAG06",
+    "0607": "TAG07",
+    "0608": "TAG08",
+    "0609": "TAG09",
+    "0610": "TAG10",
+    "0611": "TAG11",
+    "0701": "COM01",
+    "0702": "COM02",
+    "0703": "COM03",
+    "0704": "COM04",
+    "0705": "COM05",
+    "0911": "IMP01",
+    "0926": "IMP02",
+    # "10101": "IMP03", # we had one rule id for two rules
+    "10102": "IMP04",
+    "1001": "SPC01",
+    "1002": "SPC02",
+    "1003": "SPC03",
+    "1004": "SPC04",
+    "1005": "SPC05",
+    "1006": "SPC06",
+    "1008": "SPC08",
+    "1009": "SPC09",
+    "1010": "SPC10",
+    "1011": "SPC11",
+    "1012": "SPC12",
+    "1013": "SPC13",
+    "1014": "SPC14",
+    "variable-should-be-left-aligned": "variable-not-left-aligned",
+    "1015": "SPC15",
+    "1016": "SPC16",
+    "suite-setting-should-be-left-aligned": "suite-setting-not-left-aligned",
+    "1017": "SPC17",
+    "1018": "SPC18",
+    "0402": "SPC19",
+    "0406": "SPC20",
+    "0410": "SPC21",
+    "0411": "SPC22",
+    "0801": "DUP01",
+    "0802": "DUP02",
+    "0803": "DUP03",
+    "0804": "DUP04",
+    "0805": "DUP05",
+    "0806": "DUP06",
+    "0807": "DUP07",
+    "0808": "DUP08",
+    "0810": "DUP09",
+    "0813": "DUP10",
+    "0501": "LEN01",
+    "0502": "LEN02",
+    "0503": "LEN03",
+    "0504": "LEN04",
+    "0528": "LEN05",
+    "0505": "LEN06",
+    "0507": "LEN07",
+    "0508": "LEN08",
+    "0509": "LEN09",
+    "0510": "LEN10",
+    "0511": "LEN11",
+    "0512": "LEN12",
+    "0513": "LEN13",
+    "0514": "LEN14",
+    "0515": "LEN15",
+    "0516": "LEN16",
+    "0517": "LEN17",
+    "0518": "LEN18",
+    "0519": "LEN19",
+    "0520": "LEN20",
+    "0521": "LEN21",
+    "0522": "LEN22",
+    "0523": "LEN23",
+    "0524": "LEN24",
+    "0525": "LEN25",
+    "0526": "LEN26",
+    "0527": "LEN27",
+    "0506": "LEN28",
+    "0529": "LEN29",
+    "0530": "LEN30",
+    "0531": "LEN31",
+    "0912": "VAR01",
+    "0920": "VAR02",
+    "0922": "VAR03",
+    "0929": "VAR04",
+    "0930": "VAR05",
+    "0931": "VAR06",
+    "0310": "VAR07",
+    "0316": "VAR08",
+    "0317": "VAR09",
+    "0323": "VAR10",
+    "0324": "VAR11",
+    "0812": "VAR12",
+    "0919": "ARG01",
+    "0921": "ARG02",
+    "0932": "ARG03",
+    "0933": "ARG04",
+    "0407": "ARG05",
+    "0811": "ARG06",
+    "0532": "ARG07",
+    "0908": "DEPR01",
+    "0319": "DEPR02",
+    "0321": "DEPR03",
+    "0322": "DEPR04",
+    "0327": "DEPR05",
+    "0328": "DEPR06",
+    "0301": "NAME01",
+    "0302": "NAME02",
+    "0303": "NAME03",
+    "0305": "NAME04",
+    "0306": "NAME05",
+    "0307": "NAME06",
+    "0308": "NAME07",
+    "0309": "NAME08",
+    "0311": "NAME09",
+    "0312": "NAME10",
+    "0313": "NAME11",
+    "0314": "NAME12",
+    "0315": "NAME13",
+    "0318": "NAME14",
+    "0320": "NAME15",
+    "0325": "NAME16",
+    "0326": "NAME17",
+    "0901": "MISC01",
+    "0903": "MISC02",
+    "0907": "MISC03",
+    "0909": "MISC04",
+    "0910": "MISC05",
+    "0913": "MISC06",
+    "0914": "MISC07",
+    "0915": "MISC08",
+    "0916": "MISC09",
+    "0917": "MISC10",
+    "0918": "MISC11",
+    "0923": "MISC12",
+    "0924": "MISC13",
+    "0925": "MISC14",
+    "10001": "KW01",
+    "10002": "KW02",
+    "10003": "KW03",
+    "10101": "KW04",
+    "0927": "ORD01",
+    "0928": "ORD02",
+}
+
+
+def replace_severity_values(rule_name: str) -> str:
+    if re.match("[IWE][0-9]{4,}", rule_name):
+        for char in "IWE":
+            rule_name = rule_name.replace(char, "")
+    return rule_name
+
+
+def convert_rule_list(rules: list[str]) -> list[str]:
+    """
+    Convert rule names and ids to new ones.
+
+    Removes optional severity. Rule patterns (``name*``) are ignored.
+    """
+    no_sev = [replace_severity_values(rule) for rule in rules]
+    return [RENAMED_RULES.get(rule, rule) for rule in no_sev]
+
+
+def convert_robocop_configure(configure: list[str]) -> list[str]:
+    configure = [replace_severity_values(config) for config in configure]
+    new_configure = []
+    for config in configure:
+        try:
+            name, param_and_value = config.split(":", maxsplit=1)
+            name = RENAMED_RULES.get(name, name)
+            param, value = param_and_value.split(":", maxsplit=1)
+            new_configure.append(f"{name.strip()}.{param.strip()}={value.strip()}")
+        except ValueError:
+            continue
+    return new_configure
+
+
+def convert_robotidy_configure(configure: list[str]) -> list[str]:
+    new_configure = []
+    for config in configure:
+        try:
+            name, param_and_value = config.split(":", maxsplit=1)
+            param, value = param_and_value.split("=", maxsplit=1)
+            new_configure.append(f"{name.strip()}.{param.strip()}={value.strip()}")
+        except ValueError:
+            continue
+    return new_configure
+
+
+def convert_skips(old_config: dict) -> list[str]:
+    old_skips = [
+        "documentation",
+        "return_values",
+        "settings",
+        "arguments",
+        "setup",
+        "teardown",
+        "timeout",
+        "template",
+        "return",
+        "tags",
+        "comments",
+        "block_comments",
+    ]
+    return [name for name in old_skips if old_config.get(f"skip_{name}", False)]
+
+
+def copy_keys(src_dict: dict, keys: dict[str, str | tuple[str, Callable]]) -> dict:
+    """
+    Copy values from one dict to another.
+
+    Keys are in old_key: new_key format. new_key may be a tuple in (new_key, convert_fn) format.
+    """
+    dst_dict = {}
+    for old_key, new_key in keys.items():
+        if old_key in src_dict:
+            if isinstance(new_key, tuple):
+                dst_dict[new_key[0]] = new_key[1](src_dict[old_key])
+            else:
+                dst_dict[new_key] = src_dict[old_key]
+    return dst_dict
+
+
+def migrate_deprecated_configs(config_path: Path) -> None:
+    # TODO: Warn that file should have [tool.robocop] and [tool.robotidy] sections
+    config = load_toml_file(config_path)
+    tool_config = config.get("tool", {})
+    if not tool_config:
+        print("No [tool] section found.")
+        return
+    robotidy_config = tool_config.get("robotidy", {})
+    robocop_config = tool_config.get("robocop", {})
+    if not robotidy_config and not robocop_config:
+        print("No [tool.robocop] or [tool.robotidy] section found.")
+        return
+    migrated = copy_keys(
+        robocop_config,
+        {
+            "paths": "include",
+            "ignore": "exclude",
+            "ignore_default": "exclude_default",
+            # "filetypes": "", TODO
+        },
+    )
+    migrated["lint"] = copy_keys(
+        robocop_config,
+        {
+            "include": ("select", convert_rule_list),
+            "exclude": ("ignore", convert_rule_list),
+            "reports": "reports",
+            "format": ("issue_format", lambda x: x.replace("{source_rel}", "{source}")),
+            "threshold": "threshold",
+            "verbose": "verbose",
+            "persistent": "persistent",
+            "language": "language",
+            "ignore_git_dir": "ignore_git_dir",
+            "ext_rules": "ext_rules",
+            "rules": "ext_rules",
+            "configure": ("configure", convert_robocop_configure),
+        },
+    )
+    if "output" in robocop_config:
+        if "reports" in migrated["lint"]:
+            migrated["lint"]["reports"].append("text_file")
+        else:
+            migrated["lint"]["reports"] = ["text_file"]
+        if "configure" in migrated["lint"]:
+            migrated["lint"]["configure"].append(f"text_file.output_path={robocop_config['output']}")
+        else:
+            migrated["lint"]["configure"] = [f"text_file.output_path={robocop_config['output']}"]
+    migrated["format"] = copy_keys(
+        robotidy_config,
+        {
+            "diff": "diff",
+            "overwrite": "overwrite",
+            "verbose": "verbose",
+            "line_length": "line_length",
+            "separator": "separator",
+            "spacecount": "space_count",
+            "continuation_indent": "continuation_indent",
+            "lineseparator": "line_separator",
+            "skip_sections": "skip_sections",
+            "skip_keyword_call": "skip_keyword_call",
+            "skip_keyword_call_pattern": "skip_keyword_call_pattern",
+            "configure": ("configure", convert_robotidy_configure),
+        },
+    )
+    if skips := convert_skips(robotidy_config):
+        migrated["format"]["skip"] = skips
+    if not migrated["lint"]:
+        migrated.pop("lint")
+    if not migrated["format"]:
+        migrated.pop("format")
+    if not migrated:
+        print("Nothing to migrate.")
+        return
+    config["tool"]["robocop"] = migrated
+    config["tool"].pop("robotidy", None)
+    dest = config_path.parent / f"{config_path.stem}_migrated.toml"
+    with open(dest, "wb") as fp:
+        tomli_w.dump(config, fp)

--- a/tests/migrate_config/test_data/common.toml
+++ b/tests/migrate_config/test_data/common.toml
@@ -1,0 +1,55 @@
+[tool.other_tool]
+flag = true
+
+[other_section]
+# empty
+
+[tool.robocop]
+paths = [
+    "tests\\atest\\rules\\bad-indent",
+    "tests\\atest\\rules\\duplicated-library"
+]
+include = ['W0504', '*doc*']
+exclude = ["0203", "too-many-arguments"]
+reports = [
+    "rules_by_id",
+    "scan_timer"
+]
+ignore = ["ignore_me.robot"]
+ext_rules = ["path_to_external\\dir"]
+filetypes = [".txt", ".tsv"]
+threshold = "E"
+format = "{source}:{line}:{col} [{severity}] {rule_id} {desc} (name)1{source_rel}"
+output = "robocop.log"
+configure = [
+    "line-too-long:line_length:150",
+    "0201:severity:E"
+]
+persistent = true
+no_recursive = true
+language = [
+    "pt",
+    "fi"
+]
+
+# comment that will be discarded
+[tool.robotidy]
+skip_return_values = true
+skip_tags = false
+diff = false
+overwrite = true
+verbose = false
+separator = "space"
+spacecount = 4
+continuation_indent = 2
+exclude = "Regex\\s"
+line_length = 120
+lineseparator = "native"
+skip_gitignore = false
+ignore_git_dir = false
+configure = [
+    "OrderSettings:keyword_before=documentation,tags,timeout,arguments:keyword_after=return",
+    "OrderSettingsSection:group_order=documentation,imports,settings,tags",
+    "OrderSettingsSection:imports_order=library,resource,variables",
+    "AlignKeywordsSection : skip_return_values = False"
+]

--- a/tests/migrate_config/test_data/common_migrated.toml
+++ b/tests/migrate_config/test_data/common_migrated.toml
@@ -1,0 +1,62 @@
+[tool.other_tool]
+flag = true
+
+[tool.robocop]
+include = [
+    "tests\\atest\\rules\\bad-indent",
+    "tests\\atest\\rules\\duplicated-library",
+]
+exclude = [
+    "ignore_me.robot",
+]
+
+[tool.robocop.lint]
+select = [
+    "LEN04",
+    "*doc*",
+]
+ignore = [
+    "DOC03",
+    "too-many-arguments",
+]
+reports = [
+    "rules_by_id",
+    "scan_timer",
+    "text_file",
+]
+issue_format = "{source}:{line}:{col} [{severity}] {rule_id} {desc} (name)1{source}"
+threshold = "E"
+persistent = true
+language = [
+    "pt",
+    "fi",
+]
+ext_rules = [
+    "path_to_external\\dir",
+]
+configure = [
+    "line-too-long.line_length=150",
+    "DOC01.severity=E",
+    "text_file.output_path=robocop.log",
+]
+
+[tool.robocop.format]
+diff = false
+overwrite = true
+verbose = false
+line_length = 120
+separator = "space"
+space_count = 4
+continuation_indent = 2
+line_separator = "native"
+configure = [
+    "OrderSettings.keyword_before=documentation,tags,timeout,arguments:keyword_after=return",
+    "OrderSettingsSection.group_order=documentation,imports,settings,tags",
+    "OrderSettingsSection.imports_order=library,resource,variables",
+    "AlignKeywordsSection.skip_return_values=False",
+]
+skip = [
+    "return_values",
+]
+
+[other_section]

--- a/tests/migrate_config/test_migrate_config.py
+++ b/tests/migrate_config/test_migrate_config.py
@@ -1,0 +1,40 @@
+import filecmp
+import shutil
+from difflib import unified_diff
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from robocop.cli import migrate_config
+from robocop.formatter.utils.misc import decorate_diff_with_color
+
+TEST_DATA = Path(__file__).parent / "test_data"
+
+
+def display_file_diff(expected, actual):
+    # TODO: copied over from formatter tests, make common method
+    print("\nExpected file after formatting does not match actual")
+    with open(expected, encoding="utf-8") as f, open(actual, encoding="utf-8") as f2:
+        expected_lines = f.readlines()
+        actual_lines = f2.readlines()
+    lines = list(
+        unified_diff(expected_lines, actual_lines, fromfile=f"expected: {expected}\t", tofile=f"actual: {actual}\t")
+    )
+    colorized_output = decorate_diff_with_color(lines)
+    console = Console(color_system="windows", width=400)
+    for line in colorized_output:
+        console.print(line, end="", highlight=False)
+
+
+def test_migrate_config(tmp_path):
+    config_path = TEST_DATA / "common.toml"
+    expected = TEST_DATA / "common_migrated.toml"
+    actual = tmp_path / "common_migrated.toml"
+    shutil.copy(config_path, tmp_path)
+
+    migrate_config(tmp_path / "common.toml")
+
+    if not filecmp.cmp(expected, actual):
+        display_file_diff(expected, actual)
+        pytest.fail(f"File {actual} is not same as expected")

--- a/uv.lock
+++ b/uv.lock
@@ -471,6 +471,7 @@ dependencies = [
     { name = "pytz" },
     { name = "robotframework" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
     { name = "typer" },
 ]
 
@@ -499,6 +500,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2022.7,<2024.3" },
     { name = "robotframework", specifier = ">=4.0,<7.3" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = "==2.0.2" },
+    { name = "tomli-w", specifier = "==1.2.0" },
     { name = "typer", specifier = ">=0.12.5,<0.13" },
 ]
 
@@ -746,6 +748,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]


### PR DESCRIPTION
It still needs to be added to the release notes and documentation needs to be updated. I am adding it now so it can help users with testing alpha release.