### PR TITLE
Ignore robot builtin tags in 'common tag should be set once' rules

### DIFF
--- a/docs/releasenotes/6.0.0a1.rst
+++ b/docs/releasenotes/6.0.0a1.rst
@@ -642,6 +642,24 @@ You can now use shell autocompletion by installing it for the current shell::
 
     robocop --install-completion
 
+New rules and rule updates
+===========================
+
+Ignore built in tags in tag rules (#1166)
+-----------------------------------------
+
+TAG05 ``could-be-test-tags`` and TAG10 ``could-be-keyword-tags`` will now ignore builtin tags.
+Following code will not warn anymore that builtin tag (robot:private) should be set in Keyword or Test Tags::
+
+    *** Keywords ***
+    Keyword
+        [Tags]  robot:flatten    robot:private
+        No Operation
+
+    Keyword 2
+        [Tags]  robot:flatten    robot:private
+        No Operation
+
 Fixes
 =====
 

--- a/src/robocop/linter/rules/tags.py
+++ b/src/robocop/linter/rules/tags.py
@@ -112,6 +112,7 @@ class CouldBeTestTagsRule(Rule):
     or ``Task Tags``.
     This rule was renamed from ``could-be-force-tags`` to ``could-be-test-tags`` in Robocop 2.6.0.
 
+    Will ignore `robot:*` tags.
     """
 
     name = "could-be-test-tags"
@@ -234,6 +235,7 @@ class CouldBeKeywordTagsRule(Rule):
     In this example all keywords share one common tag ``featureX``.It can be declared just once using
     ``Keyword Tags``.
 
+    Will ignore `robot:*` tags.
     """
 
     name = "could-be-keyword-tags"
@@ -486,7 +488,7 @@ class TagScopeChecker(VisitorChecker):
                 end_col=node.end_col_offset,
             )
         if not self.in_keywords:
-            self.tags.append([tag.value for tag in node.data_tokens[1:]])
+            self.tags.append([tag.value for tag in node.data_tokens[1:] if not tag.value.startswith("robot:")])
         for tag in node.data_tokens[1:]:
             if self.in_keywords or tag.value not in self.test_tags:
                 continue
@@ -553,7 +555,9 @@ class KeywordTagsChecker(VisitorChecker):
 
     def visit_Tags(self, node: type[Node]) -> None:  # noqa: N802
         if self.in_keywords:
-            self.tags_in_keywords.append([tag.value for tag in node.data_tokens[1:]])
+            self.tags_in_keywords.append(
+                [tag.value for tag in node.data_tokens[1:] if not tag.value.startswith("robot:")]
+            )
         for tag in node.data_tokens[1:]:
             if not self.in_keywords or tag.value not in self.keyword_tags:
                 continue

--- a/tests/linter/rules/tags/could_be_keyword_tags/builtin_tags.robot
+++ b/tests/linter/rules/tags/could_be_keyword_tags/builtin_tags.robot
@@ -1,0 +1,11 @@
+*** Settings ***
+Documentation  docs
+
+*** Keywords ***
+Keyword
+    [Tags]  robot:flatten    robot:private
+    No Operation
+
+Keyword 2
+    [Tags]  robot:flatten    robot:private
+    No Operation

--- a/tests/linter/rules/tags/could_be_test_tags/builtin_tags.robot
+++ b/tests/linter/rules/tags/could_be_test_tags/builtin_tags.robot
@@ -1,0 +1,11 @@
+*** Settings ***
+Documentation  docs
+
+*** Keywords ***
+Keyword
+    [Tags]  robot:flatten    robot:private
+    No Operation
+
+Keyword 2
+    [Tags]  robot:flatten    robot:private
+    No Operation


### PR DESCRIPTION
This is copied from #1166 as my Robocop migration overwrote this change.

@Lakitna This will go together with 6.0. Apologies for all recent confusions as the whole merge of two projects is bit chaoic by its nature 