### PR TITLE
Ignore templates suites in bad-indent rule

### DIFF
--- a/docs/releasenotes/6.0.0a3.rst
+++ b/docs/releasenotes/6.0.0a3.rst
@@ -955,3 +955,10 @@ Project-level rules were previous reported after other runs. Sorting them by lin
 files to mix up.
 
 Now project-level rules are grouped and sorted together with other rules which fixes this issue.
+
+bad-indent raised for templates suites (#808)
+---------------------------------------------
+
+Templated suites (with the use of ``Test Template`` setting) allows to use different styles of alignment. It doesn't
+work well with ``bad-indent`` rule and caused false positive warnings. It is now disabled for templated suites.
+Instead we will implement separate rule for templated suites alignment.

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -999,7 +999,7 @@ def block_indent(checker: type[BaseChecker], node: type[Node]):
 def index_of_first_standalone_comment(node: type[Node]) -> int:
     """
     Get index of first standalone comment.
-    Comment can be standalone only if there are not other data statements in the node.
+    Comment can be standalone only if there are not the other data statements in the node.
     """
     last_standalone_comment = len(node.body)
     for index, child in enumerate(node.body[::-1], start=-(len(node.body) - 1)):
@@ -1043,6 +1043,8 @@ class UnevenIndentChecker(VisitorChecker):
     visit_Keyword = visit_TestCase  # noqa: N815
 
     def visit_TestCaseSection(self, node) -> None:  # noqa: N802
+        if self.templated_suite:
+            return
         self.check_standalone_comments_indent(node)
 
     def visit_KeywordSection(self, node) -> None:  # noqa: N802

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -56,8 +56,6 @@ class RobocopLinter:
             diagnostics = self.run_check(model, source, config)
             issues_no += len(diagnostics)
             self.diagnostics.extend(diagnostics)
-        # several configs, each can have or have not project checkers..
-        # so we would need to first gather info, and then "mamy
         self.diagnostics.extend(self.run_project_checks())
         if not files:
             print("No Robot files were found with the existing configuration.")

--- a/tests/linter/rules/spacing/bad_indent/bug758/expected_output.txt
+++ b/tests/linter/rules/spacing/bad_indent/bug758/expected_output.txt
@@ -1,3 +1,0 @@
-bug758${/}templated_suite.robot:21:1 [W] SPC08 Line is under-indented
-bug758${/}templated_suite.robot:26:1 [W] SPC08 Line is under-indented
-bug758${/}templated_suite.robot:30:1 [W] SPC08 Line is under-indented

--- a/tests/linter/rules/spacing/bad_indent/template_suite_with_settings.robot
+++ b/tests/linter/rules/spacing/bad_indent/template_suite_with_settings.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Test Template  Example
+
+
+*** Test Cases ***
+Example  argument=abc
+    [Documentation]  Documentation text
+Second test  argument=abc
+    [Documentation]  Documentation text
+
+
+*** Test Cases ***    ARG1    ARG2    [Documentation]           [Tags]
+TestA                 aaa     AAA     Prints some message       tagA
+TestB                 bbb     BBB     Prints another message    tagB
+
+
+*** Keywords ***
+Example
+  [Arguments]  ${argument}
+  Log  ${argument}

--- a/tests/linter/rules/spacing/bad_indent/test_rule.py
+++ b/tests/linter/rules/spacing/bad_indent/test_rule.py
@@ -4,6 +4,9 @@ from tests.linter.utils import RuleAcceptance
 
 
 class TestRuleAcceptance(RuleAcceptance):
+    def test_template_suite_with_settings(self):
+        self.check_rule(src_files=["template_suite_with_settings.robot"], expected_file=None)
+
     @pytest.mark.parametrize("config", [None, ["bad-indent.indent=3"]])
     def test_templated_suite(self, config):
         self.check_rule(configure=config, src_files=["templated_suite.robot"], expected_file=None)
@@ -38,7 +41,7 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(
             configure=["bad-indent.indent=-1"],
             src_files=["bug758/templated_suite.robot"],
-            expected_file="bug758/expected_output.txt",
+            expected_file=None,
         )
 
     def test_groups(self):


### PR DESCRIPTION
Templates suites can have different alignment styles, which leads to false positive bad-indent reports. I have disabled this rule for such suites. In the future we will have separate rule for alignments of such suites.

Fixes #808 