### PR TITLE
Temporarily disable project-level checks

### DIFF
--- a/docs/releasenotes/6.0.0a3.rst
+++ b/docs/releasenotes/6.0.0a3.rst
@@ -788,6 +788,15 @@ Following code will not warn anymore that builtin tag (robot:private) should be 
         [Tags]  robot:flatten    robot:private
         No Operation
 
+Known issues
+============
+
+Project-level checks
+--------------------
+
+Project-level checks are temporarily disabled. It will be later migrated to separate command that will scan whole
+project.
+
 Fixes
 =====
 
@@ -947,14 +956,6 @@ Following code will now not raise an issue::
 
 Since we don't track variable values in linting, we do not check if ``${name}`` use upper case or not - such cases
 are ignored.
-
-ProjectChecker rules sorted by line number (#1121)
---------------------------------------------------
-
-Project-level rules were previous reported after other runs. Sorting them by line numbers caused issues from several
-files to mix up.
-
-Now project-level rules are grouped and sorted together with other rules which fixes this issue.
 
 bad-indent raised for templates suites (#808)
 ---------------------------------------------

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -46,6 +46,7 @@ class UnusedKeywordRule(Rule):
     rule_id = "KW04"
     message = "Keyword '{keyword_name}' is not used"
     severity = RuleSeverity.INFO
+    deprecated = True  # TODO: temporary deprecation
     enabled = False
     added_in_version = "5.3.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -57,7 +57,6 @@ class RobocopLinter:
             diagnostics = self.run_check(model, source, config)
             issues_no += len(diagnostics)
             self.diagnostics.extend(diagnostics)
-        self.diagnostics.extend(self.run_project_checks())
         if not files:
             print("No Robot files were found with the existing configuration.")
         if "file_stats" in self.reports:
@@ -96,6 +95,7 @@ class RobocopLinter:
         return found_diagnostics
 
     def run_project_checks(self) -> list[Diagnostic]:
+        # TODO: use in a separate command
         found_diagnostics = []
         for checker in self.config_manager.default_config.linter.project_checkers:
             found_diagnostics.extend(

--- a/tests/linter/rules/keywords/unused_keyword/test_rule.py
+++ b/tests/linter/rules/keywords/unused_keyword/test_rule.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.linter.utils import RuleAcceptance
 
 
+@pytest.mark.skip("Skipped: unused-keyword is temporarily disabled")
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(src_files=["."], expected_file="expected_output.txt", issue_format="end_col")


### PR DESCRIPTION
It was decided to move project-level checks into separate command. For now I have disabled such rules from normal runs.

#1108