### PR TITLE
Fix/rename variables template

### DIFF
--- a/docs/releasenotes/6.0.0a3.rst
+++ b/docs/releasenotes/6.0.0a3.rst
@@ -1083,3 +1083,13 @@ bad-indent raised for templates suites (#808)
 Templated suites (with the use of ``Test Template`` setting) allows to use different styles of alignment. It doesn't
 work well with ``bad-indent`` rule and caused false positive warnings. It is now disabled for templated suites.
 Instead we will implement separate rule for templated suites alignment.
+
+RenameVariables capitalized arguments in [Template]
+---------------------------------------------------
+
+``RenameVariables`` formatter from now on will rename arguments in ``[Template]`` to lower-case instead of upper-case::
+
+    Template arguments are local scope
+        [Template]    My Keyword ${embedded_arg}
+        value1
+        value2

--- a/docs/releasenotes/6.0.0a3.rst
+++ b/docs/releasenotes/6.0.0a3.rst
@@ -203,7 +203,7 @@ Linter or formatter specific settings are avaiable under ``lint`` or ``format`` 
     [tool.robocop.format]
     skip = ["documentation"]
     configure = [
-        "NormalizeSeparators.skip=documentation"
+        "NormalizeSeparators.skip_documentation=False"
     ]
 
 Documentation describes with examples where particular options should be configured.
@@ -243,8 +243,8 @@ Instead, ``text_file`` report can be used::
 
 ``text_file`` report supports only ``simple`` issue output format.
 
-Deprecated singular skip options in formatter (Robotidy)
---------------------------------------------------------
+Deprecated singular global skip options in formatter (Robotidy)
+---------------------------------------------------------------
 
 Robotidy offered multiple options to skip formatting of different statement types, if the formatter allows it::
 
@@ -283,7 +283,10 @@ Several options were combined under single option named ``skip``::
     --skip-keyword-call-pattern
 
 ``skip`` accept multiple values from the cli or the configuration files.
-When configuring skip options for the particular formatter, you can also use comma separated list.
+
+Overriding skip on the formatter level still uses previous syntax::
+
+    robocop format --configure AlignKeywordsSection.skip_arguments=True
 
 return_status report is now optional
 -------------------------------------

--- a/docs/source/formatters/skip_formatting.rst
+++ b/docs/source/formatters/skip_formatting.rst
@@ -33,13 +33,11 @@ Example usage:
 
 .. code:: shell
 
-    robocop format -c NormalizeSeparators.skip=documentation
-
-It is possible to use global option to skip formatting for every formatter that supports it:
-
-.. code:: shell
-
     robocop format --skip documentation
+
+To configure it on formatter level, or overwrite global setting use ``skip_<name>=True/False`` syntax:
+
+    robocop format --skip documentation --configure NormalizeSeparators.skip_documentation=False
 
 Both options are configurable using configuration file (:ref:`config-file`).
 
@@ -48,7 +46,7 @@ Both options are configurable using configuration file (:ref:`config-file`).
     [tool.robocop.format]
     skip = ["documentation"]
     configure = [
-        "NormalizeSeparators.skip=documentation"
+        "NormalizeSeparators.skip_documentation=False"
     ]
 
 .. _skip keyword call:

--- a/src/robocop/formatter/formatters/RenameVariables.py
+++ b/src/robocop/formatter/formatters/RenameVariables.py
@@ -291,9 +291,15 @@ class RenameVariables(Formatter):
             data_token.value = self.rename_value(data_token.value, variable_case=VariableCase.AUTO, is_var=False)
         return self.generic_visit(node)
 
-    visit_Teardown = visit_Timeout = visit_Template = visit_Return = visit_ReturnStatement = visit_ReturnSetting = (  # noqa: N815
+    visit_Teardown = visit_Timeout = visit_Return = visit_ReturnStatement = visit_ReturnSetting = (  # noqa: N815
         visit_Setup
     )
+
+    @skip_if_disabled
+    def visit_Template(self, node):  # noqa: N802
+        for data_token in node.data_tokens[1:]:
+            data_token.value = self.rename_value(data_token.value, variable_case=VariableCase.LOWER, is_var=False)
+        return self.generic_visit(node)
 
     @skip_if_disabled
     def visit_Variable(self, node):  # noqa: N802

--- a/tests/formatter/formatters/RenameVariables/expected/template_arguments.robot
+++ b/tests/formatter/formatters/RenameVariables/expected/template_arguments.robot
@@ -1,0 +1,15 @@
+*** Test Cases ***
+Template arguments are local scope
+    [Template]    My Keyword ${embedded_arg}
+    value1
+    value2
+
+Upper Case argument will be converted to lower case
+    [Template]    My Keyword ${arg}
+    value1
+    value2
+
+
+*** Keywords ***
+Keyword Argument Is Also ${embedded_arg} Local Scope
+    Log To Console    embedded arg: ${embedded_arg}

--- a/tests/formatter/formatters/RenameVariables/source/template_arguments.robot
+++ b/tests/formatter/formatters/RenameVariables/source/template_arguments.robot
@@ -1,0 +1,15 @@
+*** Test Cases ***
+Template arguments are local scope
+    [Template]    My Keyword ${embedded arg}
+    value1
+    value2
+
+Upper Case argument will be converted to lower case
+    [Template]    My Keyword ${ARG}
+    value1
+    value2
+
+
+*** Keywords ***
+Keyword Argument Is Also ${embedded arg} Local Scope
+    Log To Console    embedded arg: ${embedded arg}

--- a/tests/formatter/formatters/RenameVariables/test_formatter.py
+++ b/tests/formatter/formatters/RenameVariables/test_formatter.py
@@ -138,3 +138,6 @@ class TestRenameVariables(FormatterAcceptanceTest):
 
     def test_equal_sign_in_section(self):
         self.compare(source="equal_sign_in_section.robot")
+
+    def test_template_arguments(self):
+        self.compare(source="template_arguments.robot")


### PR DESCRIPTION
Fixes https://github.com/MarketSquare/robotframework-tidy/issues/713

I have also improved documentation for --skip / skip_name=