### PR TITLE
Fix RenameVariables not recognizing variables in EXCEPT and WHILE limit

### DIFF
--- a/docs/releasenotes/6.0.0a3.rst
+++ b/docs/releasenotes/6.0.0a3.rst
@@ -1095,6 +1095,25 @@ RenameVariables capitalized arguments in [Template]
         value1
         value2
 
+RenameVariables ignores variables in EXCEPT and WHILE
+-----------------------------------------------------
+
+``RenameVariables`` will no longer ignore variables in TRY EXCEPT header and WHILE limit option::
+
+    EXCEPT With Dynamic Error
+    [Arguments]  ${expected_error}
+    TRY
+        No Operation
+    EXCEPT  ${expected_error}
+        No Operation
+    END
+
+    WHILE With Limit
+        [Arguments]    ${limit}
+        WHILE    ${CONDITION}    limit=${limit}
+            No Operation
+        END
+
 Comments section header is preserved when merging multiple sections
 -------------------------------------------------------------------
 

--- a/src/robocop/formatter/formatters/RenameVariables.py
+++ b/src/robocop/formatter/formatters/RenameVariables.py
@@ -420,15 +420,11 @@ class RenameVariables(Formatter):
 
     @skip_if_disabled
     def visit_Try(self, node):  # noqa: N802
-        if misc.ROBOT_VERSION.major < 7:
-            try_variable = node.variable
-        else:
-            try_variable = node.assign
-        if try_variable is not None:
-            error_var = node.header.get_token(Token.VARIABLE)
-            if error_var is not None:
-                self.variables_scope.add_local(error_var.value)
-                error_var.value = self.rename_value(error_var.value, variable_case=VariableCase.LOWER, is_var=True)
+        for token in node.header.get_tokens(Token.ARGUMENT):
+            token.value = self.rename_value(token.value, variable_case=VariableCase.AUTO, is_var=False)
+        for token in node.header.get_tokens(Token.VARIABLE):
+            self.variables_scope.add_local(token.value)
+            token.value = self.rename_value(token.value, variable_case=VariableCase.AUTO, is_var=True)
         return self.generic_visit(node)
 
     @skip_if_disabled
@@ -445,7 +441,7 @@ class RenameVariables(Formatter):
 
     @skip_if_disabled
     def visit_While(self, node):  # noqa: N802
-        for arg in node.header.get_tokens(Token.ARGUMENT):
+        for arg in node.header.get_tokens(Token.ARGUMENT, Token.OPTION):
             arg.value = self.rename_value(arg.value, variable_case=VariableCase.AUTO, is_var=False)
         return self.generic_visit(node)
 

--- a/tests/formatter/formatters/RenameVariables/expected/try_except.robot
+++ b/tests/formatter/formatters/RenameVariables/expected/try_except.robot
@@ -1,8 +1,21 @@
 *** Keywords ***
 Keyword With Try
-     ${local} =    Keyword
-     TRY
-         Do Stuff    ${local}    ${GLOBAL}
-     EXCEPT    Error    AS    ${error}
-         Log    ${error}
-     END
+    [Arguments]    ${expected_error}
+    ${local} =    Keyword
+    TRY
+        Do Stuff    ${local}    ${GLOBAL}
+    EXCEPT    Error    AS    ${error}
+        Log    ${error}
+    END
+
+    TRY
+        No Operation
+    EXCEPT    ${expected_error}
+        No Operation
+    END
+
+WHILE with limit
+    [Arguments]    ${ar_gument}
+    WHILE    ${True}    limit=${ar_gument}
+        No Operation
+    END

--- a/tests/formatter/formatters/RenameVariables/source/try_except.robot
+++ b/tests/formatter/formatters/RenameVariables/source/try_except.robot
@@ -1,8 +1,21 @@
 *** Keywords ***
 Keyword With Try
-     ${local} =    Keyword
-     TRY
-         Do Stuff    ${local}    ${global}
-     EXCEPT    Error    AS    ${ERROR}
-         Log    ${ERROR}
-     END
+    [Arguments]    ${expected_error}
+    ${local} =    Keyword
+    TRY
+        Do Stuff    ${local}    ${global}
+    EXCEPT    Error    AS    ${ERROR}
+        Log    ${ERROR}
+    END
+
+    TRY
+        No Operation
+    EXCEPT    ${expected error}
+        No Operation
+    END
+
+WHILE with limit
+    [Arguments]    ${ar_gument}
+    WHILE    ${True}    limit=${AR GUMENT}
+        No Operation
+    END


### PR DESCRIPTION
Fixes #https://github.com/MarketSquare/robotframework-tidy/issues/711