### PR TITLE
Make could-be-test/keyword-tags output deterministic by sorting common tags

### DIFF
--- a/docs/releasenotes/6.1.0.rst
+++ b/docs/releasenotes/6.1.0.rst
@@ -7,6 +7,12 @@ Robocop 6.1.0
 Fixes
 =====
 
+could-be-test-tags and could-be-keyword-tags are not deterministic (#1377)
+--------------------------------------------------------------------------
+
+Output of TAG5 ``could-be-test-tags`` and TAG10 ``could-be-keyword-tags`` should be now deterministic and print
+tags in alphabetical order.
+
 Some options are not recognized when used with hyphens (#1378)
 ---------------------------------------------------------------
 

--- a/src/robocop/linter/rules/tags.py
+++ b/src/robocop/linter/rules/tags.py
@@ -484,6 +484,7 @@ class TagScopeChecker(VisitorChecker):
         common_tags = set.intersection(*[set(tags) for tags in self.tags])
         common_tags = common_tags - self.test_tags
         if common_tags:
+            common_tags = sorted(common_tags)
             report_node = node if self.test_tags_node is None else self.test_tags_node
             self.report(
                 self.could_be_test_tags,
@@ -564,6 +565,7 @@ class KeywordTagsChecker(VisitorChecker):
         common_keyword_tags = set.intersection(*[set(tags) for tags in self.tags_in_keywords])
         common_keyword_tags = common_keyword_tags - self.keyword_tags
         if common_keyword_tags:
+            common_keyword_tags = sorted(common_keyword_tags)
             report_node = node if self.keyword_tags_node is None else self.keyword_tags_node
             self.report(
                 self.could_be_keyword_tags,

--- a/tests/linter/rules/tags/could_be_keyword_tags/expected_extended.txt
+++ b/tests/linter/rules/tags/could_be_keyword_tags/expected_extended.txt
@@ -1,2 +1,3 @@
 keywords_with_tests.robot:1:1 TAG10 All keywords in suite share these tags: 'tag'
 only_keywords.robot:1:1 TAG10 All keywords in suite share these tags: 'tag'
+two_tags.robot:2:1 TAG10 All keywords in suite share these tags: 'tag, tag2'

--- a/tests/linter/rules/tags/could_be_keyword_tags/expected_output.txt
+++ b/tests/linter/rules/tags/could_be_keyword_tags/expected_output.txt
@@ -1,2 +1,3 @@
 only_keywords.robot:1:1 [I] TAG10 All keywords in suite share these tags: 'tag'
 keywords_with_tests.robot:1:1 [I] TAG10 All keywords in suite share these tags: 'tag'
+two_tags.robot:2:1 [I] TAG10 All keywords in suite share these tags: 'tag, tag2'

--- a/tests/linter/rules/tags/could_be_keyword_tags/two_tags.robot
+++ b/tests/linter/rules/tags/could_be_keyword_tags/two_tags.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Keyword Tags    tag3
+
+
+*** Keywords ***
+Keyword
+    [Tags]  tag    tag2    tag3
+    No Operation
+
+Keyword 2
+    [Tags]  tag   tag2    tag3
+    No Operation

--- a/tests/linter/rules/tags/could_be_test_tags/expected_extended.txt
+++ b/tests/linter/rules/tags/could_be_test_tags/expected_extended.txt
@@ -1,2 +1,3 @@
 test.robot:1:1 TAG05 All tests in suite share these tags: 'sometag'
 tests_with_keywords.robot:1:1 TAG05 All tests in suite share these tags: 'sometag'
+two_tags.robot:1:1 TAG05 All tests in suite share these tags: 'first, second'

--- a/tests/linter/rules/tags/could_be_test_tags/expected_output.txt
+++ b/tests/linter/rules/tags/could_be_test_tags/expected_output.txt
@@ -1,2 +1,3 @@
 test.robot:1:1 [I] TAG05 All tests in suite share these tags: 'sometag'
 tests_with_keywords.robot:1:1 [I] TAG05 All tests in suite share these tags: 'sometag'
+two_tags.robot:1:1 [I] TAG05 All tests in suite share these tags: 'first, second'

--- a/tests/linter/rules/tags/could_be_test_tags/one_test.robot
+++ b/tests/linter/rules/tags/could_be_test_tags/one_test.robot
@@ -1,0 +1,4 @@
+*** Test Cases ***
+Test
+    [Tags]    single
+    No Operation

--- a/tests/linter/rules/tags/could_be_test_tags/two_tags.robot
+++ b/tests/linter/rules/tags/could_be_test_tags/two_tags.robot
@@ -1,0 +1,8 @@
+*** Test Cases ***
+Test
+    [Tags]    first    second
+    No Operation
+
+Test 2
+    [Tags]    first    second
+    No Operation


### PR DESCRIPTION
Fixes #1377 