### PR TITLE
Remove dynamic version from lock file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.13"
+          version: "0.7.2"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Development environment
 To setup your local development environment, use install uv first:
 
 ```commandline
-pip install uv
+pip install uv==0.7.2
 ```
 
 You can now run our tests with:

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,6 @@ wheels = [
 
 [[package]]
 name = "robotframework-robocop"
-version = "6.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
uv automatically removes Robocop version from the lock file (following this and similiar changes: https://github.com/astral-sh/uv/pull/10622). It leads to failing CI, while tests work locally. I'm opening the PR to find source of the problem on our side and fix it (for example correcting run command).