### PR TITLE
Fix EOL issue on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           uv pip install robotframework==${{ matrix.rf-version }}
 
       - name: Run tests
-        run: |
-          uv run coverage run --source src/robocop -m pytest
-          uv run coverage report
+        run: uv run coverage run --source src/robocop -m pytest
+
+      - name: Calculate coverage
+        run: uv run coverage report

--- a/tests/formatter/__init__.py
+++ b/tests/formatter/__init__.py
@@ -96,7 +96,7 @@ class FormatterAcceptanceTest:
                 overwrite=True,
                 check=not_modified,
                 output=output_path,
-                line_ending="unix",
+                # line_ending="unix",
                 **kwargs,
             )
         if exit_code is not None:

--- a/tests/formatter/__init__.py
+++ b/tests/formatter/__init__.py
@@ -96,7 +96,6 @@ class FormatterAcceptanceTest:
                 overwrite=True,
                 check=not_modified,
                 output=output_path,
-                # line_ending="unix",
                 **kwargs,
             )
         if exit_code is not None:

--- a/tests/migrate_config/test_migrate_config.py
+++ b/tests/migrate_config/test_migrate_config.py
@@ -12,19 +12,27 @@ from robocop.run import migrate_config
 TEST_DATA = Path(__file__).parent / "test_data"
 
 
-def display_file_diff(expected, actual):
+def display_file_diff(expected, actual) -> bool:
+    """
+    Display difference between files.
+
+    If files are only different with EOLs, return False. Return True otherwise.
+    """
     # TODO: copied over from formatter tests, make common method
     print("\nExpected file after formatting does not match actual")
     with open(expected, encoding="utf-8") as f, open(actual, encoding="utf-8") as f2:
         expected_lines = f.readlines()
-        actual_lines = f2.readlines()
+        actual_lines = [line.replace("\r\n", "\n") for line in f2.readlines()]
     lines = list(
         unified_diff(expected_lines, actual_lines, fromfile=f"expected: {expected}\t", tofile=f"actual: {actual}\t")
     )
+    if not lines:
+        return False
     colorized_output = decorate_diff_with_color(lines)
     console = Console(color_system="windows", width=400)
     for line in colorized_output:
         console.print(line, end="", highlight=False)
+    return True
 
 
 @pytest.mark.parametrize(
@@ -49,5 +57,6 @@ def test_migrate_config(source_config, expected_config, tmp_path):
     if not expected:
         assert not actual.exists()
     elif not filecmp.cmp(expected, actual):
-        display_file_diff(expected, actual)
+        if not display_file_diff(expected, actual):
+            return
         pytest.fail(f"File {actual} is not same as expected")


### PR DESCRIPTION
I have enforced unix formatting due to failing tests but the real cause was incorrectly working formatting settings which was fixed some time ago. This setting combined with autocrlf option caused Windows tests to fail.