### PR TITLE
Fix consecutive-empty-lines reporting column position in SonarQube report

### DIFF
--- a/docs/releasenotes/6.5.1.rst
+++ b/docs/releasenotes/6.5.1.rst
@@ -9,3 +9,4 @@ Additional fixes to our rule locations. Following rule(s) have their location ad
 
 - NAME04 ``underscore-in-keyword-name`` (which used last line in keyword for end column instead of keyword name)
 - ARG07 ``arguments-per-line`` (which was offset by 1)
+- SPC12 ``consecutive-empty-lines`` (which reported start/end column positions in SonarQube report)

--- a/src/robocop/linter/reports/sonarqube.py
+++ b/src/robocop/linter/reports/sonarqube.py
@@ -85,7 +85,7 @@ class SonarQubeGenerator:
     def get_sonar_qube_range(diagnostic: Diagnostic) -> dict:
         text_range = diagnostic.range
         # reports on empty lines
-        if diagnostic.rule.rule_id in {"SPC03", "SPC04", "SPC05", "SPC09"}:
+        if diagnostic.rule.rule_id in {"SPC03", "SPC04", "SPC05", "SPC09", "SPC12"}:
             return {"startLine": text_range.start.line, "endLine": text_range.end.line}
         if text_range.start == text_range.end:
             return {"startLine": text_range.start.line}


### PR DESCRIPTION
#1417 