### PR TITLE
[Rule] Add ignore_templated option to LEN04 (too-long-test-case)

### DIFF
--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -743,8 +743,7 @@ class LengthChecker(VisitorChecker):
         return any(isinstance(statement, Template) for statement in node.body)
 
     def visit_TestCase(self, node) -> None:  # noqa: N802
-        # LEN04: skip if ignore_templated is set and test is templated
-        if self.too_long_test_case.ignore_templated and self. h(node):
+        if self.too_long_test_case.ignore_templated and self.test_is_templated(node):
             return
         length, node_end_line = check_node_length(node, ignore_docs=self.too_long_test_case.ignore_docs)
         if length > self.too_long_test_case.max_len:

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -133,7 +133,9 @@ class TooLongTestCaseRule(Rule):
     parameters = [
         RuleParam(name="max_len", default=20, converter=int, desc="number of lines allowed in a test case"),
         RuleParam(name="ignore_docs", default=False, converter=str2bool, show_type="bool", desc="Ignore documentation"),
-        RuleParam(name="ignore_templated", default=False, converter=str2bool, show_type="bool", desc="Ignore templated tests"),
+        RuleParam(
+            name="ignore_templated", default=False, converter=str2bool, show_type="bool", desc="Ignore templated tests"
+        ),
     ]
     severity_threshold = SeverityThreshold("max_len", compare_method="greater", substitute_value="allowed_length")
     added_in_version = "1.0.0"

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -133,6 +133,7 @@ class TooLongTestCaseRule(Rule):
     parameters = [
         RuleParam(name="max_len", default=20, converter=int, desc="number of lines allowed in a test case"),
         RuleParam(name="ignore_docs", default=False, converter=str2bool, show_type="bool", desc="Ignore documentation"),
+        RuleParam(name="ignore_templated", default=False, converter=str2bool, show_type="bool", desc="Ignore templated tests"),
     ]
     severity_threshold = SeverityThreshold("max_len", compare_method="greater", substitute_value="allowed_length")
     added_in_version = "1.0.0"
@@ -742,6 +743,9 @@ class LengthChecker(VisitorChecker):
         return any(isinstance(statement, Template) for statement in node.body)
 
     def visit_TestCase(self, node) -> None:  # noqa: N802
+        # LEN04: skip if ignore_templated is set and test is templated
+        if self.too_long_test_case.ignore_templated and self. h(node):
+            return
         length, node_end_line = check_node_length(node, ignore_docs=self.too_long_test_case.ignore_docs)
         if length > self.too_long_test_case.max_len:
             self.report(

--- a/tests/linter/rules/lengths/too_long_test_case/ignore_templated/expected_output.txt
+++ b/tests/linter/rules/lengths/too_long_test_case/ignore_templated/expected_output.txt
@@ -1,0 +1,1 @@
+ignore_templated${/}test.robot:6:1 [W] LEN04: Test case 'Templated Test' is too long (21/20)

--- a/tests/linter/rules/lengths/too_long_test_case/ignore_templated/expected_output.txt
+++ b/tests/linter/rules/lengths/too_long_test_case/ignore_templated/expected_output.txt
@@ -1,1 +1,1 @@
-ignore_templated${/}test.robot:6:1 [W] LEN04: Test case 'Templated Test' is too long (21/20)
+ignore_templated${/}test.robot:6:1 [W] LEN04 Test case 'Test' is too long (24/20)

--- a/tests/linter/rules/lengths/too_long_test_case/ignore_templated/templated_suite.robot
+++ b/tests/linter/rules/lengths/too_long_test_case/ignore_templated/templated_suite.robot
@@ -28,6 +28,7 @@ Template Case
     ${EMPTY}     ${EMPTY}
     ${EMPTY}     ${EMPTY}
     ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
 
 
 *** Keywords ***

--- a/tests/linter/rules/lengths/too_long_test_case/ignore_templated/templated_suite.robot
+++ b/tests/linter/rules/lengths/too_long_test_case/ignore_templated/templated_suite.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation    Suite Documentation
+Test Template    Do Stuff
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Tags]    Tags
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/linter/rules/lengths/too_long_test_case/ignore_templated/templated_test.robot
+++ b/tests/linter/rules/lengths/too_long_test_case/ignore_templated/templated_test.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation    Suite Documentation
+
+
+*** Test Cases ***
+Template Case
+    [Documentation]    Documentation
+    [Template]    Do Stuff
+    [Tags]    Tags
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+    ${EMPTY}     ${EMPTY}
+
+
+*** Keywords ***
+Do Stuff
+    [Documentation]    Filler keyword
+    [Arguments]    ${arg}    ${arg2}
+    Log    ${arg}

--- a/tests/linter/rules/lengths/too_long_test_case/ignore_templated/test.robot
+++ b/tests/linter/rules/lengths/too_long_test_case/ignore_templated/test.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/too_long_test_case/test_rule.py
+++ b/tests/linter/rules/lengths/too_long_test_case/test_rule.py
@@ -8,6 +8,13 @@ class TestRuleAcceptance(RuleAcceptance):
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
 
+    def test_ignore_templated(self):
+        self.check_rule(
+            configure=["too-long-test-case.ignore_templated=True"],
+            src_files=["ignore_templated"],
+            expected_file="ignore_templated/expected_output.txt",
+        )
+
     def test_ignore_docs(self):
         self.check_rule(
             configure=["too-long-test-case.ignore_docs=True"],


### PR DESCRIPTION
I also created an issue here: https://github.com/MarketSquare/robotframework-robocop/issues/1429

I would like the ignore_templated parameter for rule LEN04 in the same way rule LEN06 already has it