### PR TITLE
invalid-for-loop: Change test data to reflect a change in robot error message in RF7.3

### DIFF
--- a/tests/linter/rules/errors/invalid_for_loop/expected_extended.txt
+++ b/tests/linter/rules/errors/invalid_for_loop/expected_extended.txt
@@ -1,4 +1,4 @@
-test.robot:37:5 ERR12 Invalid for loop syntax: FOR loop has no loop variables
+test.robot:37:5 ERR12 Invalid for loop syntax: FOR loop has no variables
     |
  35 |
  36 | For Loop
@@ -18,7 +18,7 @@ test.robot:40:5 ERR12 Invalid for loop syntax: FOR loop cannot be empty
  42 |     FOR  ${var}  IN RANGE
     |
 
-test.robot:42:5 ERR12 Invalid for loop syntax: FOR loop has no loop values
+test.robot:42:5 ERR12 Invalid for loop syntax: FOR loop has no values
     |
  40 |     FOR  ${var}  IN  @{list}
  41 |     END
@@ -67,7 +67,7 @@ test.robot:51:9 ERR12 Invalid for loop syntax: FOR loop cannot be empty
  52 |     END
     |
 
-test.robot:51:9 ERR12 Invalid for loop syntax: FOR loop has no loop variables
+test.robot:51:9 ERR12 Invalid for loop syntax: FOR loop has no variables
     |
  49 |     END
  50 |     FOR  ${var}  IN  1  2  3
@@ -85,7 +85,7 @@ test.robot:51:9 ERR12 Invalid for loop syntax: FOR loop has no 'IN' or other val
  52 |     END
     |
 
-test.robot:56:9 ERR12 Invalid for loop syntax: FOR loop has no loop variables
+test.robot:56:9 ERR12 Invalid for loop syntax: FOR loop has no variables
     |
  54 | RF 5.0 syntax
  55 |     TRY
@@ -95,7 +95,7 @@ test.robot:56:9 ERR12 Invalid for loop syntax: FOR loop has no loop variables
  58 |         END
     |
 
-test.robot:64:9 ERR12 Invalid for loop syntax: FOR loop has no loop variables
+test.robot:64:9 ERR12 Invalid for loop syntax: FOR loop has no variables
     |
  62 |         Keyword
  63 |     FINALLY
@@ -105,7 +105,7 @@ test.robot:64:9 ERR12 Invalid for loop syntax: FOR loop has no loop variables
  66 |         END
     |
 
-test.robot:69:9 ERR12 Invalid for loop syntax: FOR loop has no loop variables
+test.robot:69:9 ERR12 Invalid for loop syntax: FOR loop has no variables
     |
  67 |     END
  68 |     WHILE    ${condition}

--- a/tests/linter/rules/errors/invalid_for_loop/expected_output_rf73.txt
+++ b/tests/linter/rules/errors/invalid_for_loop/expected_output_rf73.txt
@@ -1,0 +1,12 @@
+test.robot:37:5 [E] ERR12 Invalid for loop syntax: FOR loop has no variables
+test.robot:40:5 [E] ERR12 Invalid for loop syntax: FOR loop cannot be empty
+test.robot:42:5 [E] ERR12 Invalid for loop syntax: FOR loop has no values
+test.robot:45:5 [E] ERR12 Invalid for loop syntax: FOR loop must have closing END
+test.robot:47:5 [E] ERR12 Invalid for loop syntax: FOR loop has no 'IN' or other valid separator
+test.robot:50:5 [E] ERR12 Invalid for loop syntax: FOR loop must have closing END
+test.robot:51:9 [E] ERR12 Invalid for loop syntax: FOR loop cannot be empty
+test.robot:51:9 [E] ERR12 Invalid for loop syntax: FOR loop has no 'IN' or other valid separator
+test.robot:51:9 [E] ERR12 Invalid for loop syntax: FOR loop has no variables
+test.robot:56:9 [E] ERR12 Invalid for loop syntax: FOR loop has no variables
+test.robot:64:9 [E] ERR12 Invalid for loop syntax: FOR loop has no variables
+test.robot:69:9 [E] ERR12 Invalid for loop syntax: FOR loop has no variables

--- a/tests/linter/rules/errors/invalid_for_loop/test_rule.py
+++ b/tests/linter/rules/errors/invalid_for_loop/test_rule.py
@@ -3,15 +3,18 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", test_on_version=">=5")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", test_on_version=">=5;<7.3")
 
     def test_rf4(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version="==4.*")
+
+    def test_rf73(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf73.txt", test_on_version=">=7.3")
 
     def test_extended(self):
         self.check_rule(
             src_files=["test.robot"],
             expected_file="expected_extended.txt",
             output_format="extended",
-            test_on_version=">=5",
+            test_on_version=">=7.3",
         )


### PR DESCRIPTION
I just noticed that this test is failing with latest RF, very slight change in the error message. I wasn't sure about the extended output, if it should continue to be checked for `>=5.0;<7.3`.

robotframework/robotframework@448fb07