### PR TITLE
Fix get_formatter_short_name

### DIFF
--- a/src/robocop/formatter/formatters/__init__.py
+++ b/src/robocop/formatter/formatters/__init__.py
@@ -133,7 +133,9 @@ def get_formatter_short_name(name: str):
        C://path/to/formatter.py -> formatter
 
     """
-    return pathlib.Path(name).stem
+    if name.endswith(".py"):
+        return pathlib.Path(name).stem
+    return name.rsplit(".")[-1]
 
 
 def get_absolute_path_to_formatter(name):


### PR DESCRIPTION
I noticed there is a bug with the way robocop parses custom formatter paths. This error originates from the `get_formatter_short_name` function since the short name is used in resolving arguments for that formatter. 

Before:

```python
Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from robocop.config import FormatterConfig
>>> config = FormatterConfig(custom_formatters=["path.to.my.CustomFormatter"], configure=["CustomFormatter.enabled=True"])
>>> config.load_formatters()
>>> print(config.formatters["CustomFormatter"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'CustomFormatter'
>>> from robocop.formatter.formatters.__init__ import get_formatter_short_name
>>> get_formatter_short_name("path.to.my.CustomFormatter")
'path.to.my'
```

After:

```python
Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from robocop.config import FormatterConfig
>>> config = FormatterConfig(custom_formatters=["path.to.my.CustomFormatter"], configure=["CustomFormatter.enabled=True"])
>>> config.load_formatters()
>>> print(config.formatters["CustomFormatter"])
<path.to.my.CustomFormatter.CustomFormatter object at 0x7b903b33f460>
>>> from robocop.formatter.formatters.__init__ import get_formatter_short_name
>>> get_formatter_short_name("path.to.my.CustomFormatter")
'CustomFormatter'
```

