### PR TITLE
Actually run pytest tests with configured RF version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run tests
-        run: uv run --with=robotframework==${{ matrix.rf-version }} coverage run --source src/robocop -m pytest
+        run: uv run --with=robotframework==${{ matrix.rf-version }} coverage run --source src/robocop -m pytest -v
 
       - name: Calculate coverage
         run: uv run coverage report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,10 +49,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: |
+          uv sync --all-extras --dev
+          uv add robotframework==${{ matrix.rf-version }}
 
       - name: Run tests
-        run: uv run --with=robotframework==${{ matrix.rf-version }} coverage run --source src/robocop -m pytest -v
+        run: |
+          uv run robot --version || true
+          uv run coverage run --source src/robocop -m pytest -v
 
       - name: Calculate coverage
         run: uv run coverage report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,12 +49,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
-        run: |
-          uv sync --all-extras --dev
-          uv pip install robotframework==${{ matrix.rf-version }}
+        run: uv sync --all-extras --dev
 
       - name: Run tests
-        run: uv run coverage run --source src/robocop -m pytest
+        run: |
+          uv run --with=robotframework==${{ matrix.rf-version }} robot --version
+          uv run --with=robotframework==${{ matrix.rf-version }} coverage run --source src/robocop -m pytest
 
       - name: Calculate coverage
         run: uv run coverage report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run tests
-        run: |
-          uv run --with=robotframework==${{ matrix.rf-version }} robot --version
-          uv run --with=robotframework==${{ matrix.rf-version }} coverage run --source src/robocop -m pytest
+        run: uv run --with=robotframework==${{ matrix.rf-version }} coverage run --source src/robocop -m pytest
 
       - name: Calculate coverage
         run: uv run coverage report


### PR DESCRIPTION
Using ~`uv run --with=...`~ `uv add` to explicitly install correct RF version for each test run. Also add sanity check before, that confirms the correct version (see [here](https://github.com/MarketSquare/robotframework-robocop/actions/runs/17534026091/job/49794716701?pr=1452#step:6:14)).