### PR TITLE
Update SplitTooLongLine.rst

### DIFF
--- a/docs/source/formatters/formatters_list/SplitTooLongLine.rst
+++ b/docs/source/formatters/formatters_list/SplitTooLongLine.rst
@@ -281,7 +281,7 @@ Ignore comments
 
 To not count length of the comment to line length use :ref:`skip option` option::
 
-    robocop format --configure SplitTooLongLine.skip=comments
+    robocop format --configure SplitTooLongLine.skip_comments=True
 
 This allows to accept and do not format lines that are longer than allowed length because of the added comment.
 


### PR DESCRIPTION
`robocop format --configure SplitTooLongLine.skip=comments`
InvalidParameterError: SplitTooLongLine: Failed to import. Verify if correct name or configuration was provided. This formatter accepts following arguments:...