### PR TITLE
Fix rules url missing v prefix

### DIFF
--- a/src/robocop/linter/reports/sarif.py
+++ b/src/robocop/linter/reports/sarif.py
@@ -43,10 +43,11 @@ class SarifReport(robocop.linter.reports.JsonFileReport):
         return {"WARNING": "warning", "ERROR": "error", "INFO": "note"}[severity.name]
 
     def get_rule_desc(self, rule):
+        version = f"v{__version__}"
         return {
             "id": rule.rule_id,
             "name": rule.name,
-            "helpUri": f"{ROBOCOP_RULES_URL.format(version=__version__)}#{rule.name}",
+            "helpUri": f"{ROBOCOP_RULES_URL.format(version=version)}#{rule.name}",
             "shortDescription": {"text": rule.message},
             "fullDescription": {"text": rule.docs},
             "defaultConfiguration": {"level": self.map_severity_to_level(rule.default_severity)},

--- a/src/robocop/linter/utils/misc.py
+++ b/src/robocop/linter/utils/misc.py
@@ -140,6 +140,7 @@ def token_col(node: type[Node], *token_type) -> int:
 
 
 def issues_to_lsp_diagnostic(issues: list[Diagnostic]) -> list[dict]:
+    version = f"v{__version__}"
     return [
         {
             "range": {
@@ -156,7 +157,7 @@ def issues_to_lsp_diagnostic(issues: list[Diagnostic]) -> list[dict]:
             "code": issue.rule.rule_id,
             "source": "robocop",
             "message": issue.rule.message,
-            "codeDescription": {"href": f"{ROBOCOP_RULES_URL.format(version=__version__)}#{issue.rule.name}"},
+            "codeDescription": {"href": f"{ROBOCOP_RULES_URL.format(version=version)}#{issue.rule.name}"},
         }
         for issue in issues
     ]

--- a/tests/linter/reports/test_sarif_report.py
+++ b/tests/linter/reports/test_sarif_report.py
@@ -60,7 +60,7 @@ class TestSarifReport:
                                 {
                                     "id": r.rule_id,
                                     "name": r.name,
-                                    "helpUri": f"https://robocop.readthedocs.io/en/{__version__}/rules/rules_list.html#{r.name}",
+                                    "helpUri": f"https://robocop.readthedocs.io/en/v{__version__}/rules/rules_list.html#{r.name}",
                                     "shortDescription": {"text": r.message},
                                     "fullDescription": {"text": r.docs},
                                     "defaultConfiguration": {"level": r.default_severity.name.lower()},


### PR DESCRIPTION
Relates #1484

Since version can be prefixed by v (v6.1.0 etc) or 'stable', 'latest' the v prefix is added separetely, not in the url template.