### PR TITLE
Add missing disabler directives to too-long-line rule

### DIFF
--- a/docs/releasenotes/6.8.0.rst
+++ b/docs/releasenotes/6.8.0.rst
@@ -91,3 +91,10 @@ Rules urls (such as SARIF helpUri, or diagnostic message urls) were pointing to 
 documentation refactor. URLs now correctly point to:
 
 https://robocop.readthedocs.io/en/v{version}/rules/rules_list.html#{rule-name} .
+
+Line too long rule reporting lines with new disablers
+-----------------------------------------------------
+
+New disabler directives (``robocop: fmt: off`` and ``fmt: off``) were not ignored by ``line-too-long`` rule.
+
+From now on, together with other disablers, comments with disablers will be ignored when checking line length.

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 from robot.api import Token
 from robot.parsing.model.blocks import Keyword, TestCase
 from robot.parsing.model.statements import Comment, EmptyLine, KeywordCall
-from robot.parsing.model.visitor import ModelVisitor
 
 from robocop.linter.utils.misc import ROBOT_VERSION
 
@@ -1146,7 +1145,7 @@ class UnevenIndentChecker(VisitorChecker):
     def visit_Statement(self, statement) -> None:  # noqa: N802
         if statement is None or isinstance(statement, EmptyLine) or not self.indents:
             return
-        # Ignore indent if current line is on the same line as parent, i.e. test case header or inline IFs
+        # Ignore indent if the current line is on the same line as a parent, i.e. test case header or inline IFs
         if self.parent_line == statement.lineno:
             return
         indent = get_indent(statement)
@@ -1171,7 +1170,7 @@ class UnevenIndentChecker(VisitorChecker):
         )
 
 
-class MisalignedContinuation(VisitorChecker, ModelVisitor):
+class MisalignedContinuation(VisitorChecker):
     """Checker for misaligned continuation line markers."""
 
     misaligned_continuation: MisalignedContinuationRule

--- a/src/robocop/linter/utils/misc.py
+++ b/src/robocop/linter/utils/misc.py
@@ -356,7 +356,9 @@ def find_robot_vars(name: str) -> list[tuple[int, int]]:
     return variables
 
 
-def pattern_type(value: str) -> re.Pattern:
+def pattern_type(value: str | None) -> re.Pattern | None:
+    if value is None:
+        return None
     try:
         pattern = re.compile(value)
     except re.error as err:

--- a/tests/linter/cli/test_rule.py
+++ b/tests/linter/cli/test_rule.py
@@ -44,13 +44,14 @@ class TestDescribeRule:
         Message: Line is too long ({line_length}/{allowed_length})
         Severity: W
 
-        Line is too long.
+        The line is too long.
 
-        It is possible to ignore lines that match regex pattern. Configure it using following option::
+        Comments with disabler directives (such as ``# robocop: off``) are ignored. Lines that contain URLs are also
+        ignored.
+
+        It is possible to ignore lines that match the regex pattern. Configure it using the following option::
 
             robocop check --configure line-too-long.ignore_pattern=pattern
-
-        The default pattern is ``https?://\\S+`` that ignores the lines that look like an URL.
 
 
         Configurables:
@@ -58,7 +59,7 @@ class TestDescribeRule:
             line_length = 120
                 type: int
                 info: number of characters allowed in line
-            ignore_pattern = re.compile('https?://\\S+')
+            ignore_pattern = None
                 type: pattern_type
                 info: ignore lines that contain configured pattern
 

--- a/tests/linter/rules/lengths/line_too_long/test_rule.py
+++ b/tests/linter/rules/lengths/line_too_long/test_rule.py
@@ -33,7 +33,7 @@ class TestRuleAcceptance(RuleAcceptance):
                 line_length = 120
                     type: int
                     info: number of characters allowed in line
-                ignore_pattern = re.compile('https?://\\\\S+')
+                ignore_pattern = None
                     type: pattern_type
                     info: ignore lines that contain configured pattern
             """  # noqa: E501


### PR DESCRIPTION
I have also refactored the rule code a bit so it early returns and do not use regex patterns for disablers or url detenction.