### PR TITLE
Fix `AlignKeywordsSection` and `AlignTestCasesSection` not aligning VAR variables

### DIFF
--- a/docs/formatter/formatters/AlignKeywordsSection.md
+++ b/docs/formatter/formatters/AlignKeywordsSection.md
@@ -439,6 +439,33 @@ Example:
         Perform Action And Wait For Result              ${argument_name}
     ```
 
+## Alignment of VAR variables
+
+VAR variables are aligned with the rest of the code. By default, ``VAR`` and variable name is fit into the same
+column:
+
+=== "Before"
+
+    ```robotframework
+    *** Keywords ***
+    Cancel Window
+        VAR    ${var_1}    My value 1
+        VAR    ${var_2}    My value 2
+        Navigate    ${URL}
+        Click    Cancel
+    ```
+
+=== "After (default settings)"
+
+    ```robotframework
+    *** Keywords ***
+    Cancel Window
+        VAR    ${var_1}       My value 1
+        VAR    ${var_2}       My value 2
+        Navigate              ${URL}
+        Click                 Cancel
+    ```
+
 ## Skip formatting
 
 It is possible to use the following arguments to skip formatting of the code:

--- a/docs/formatter/formatters/AlignTestCasesSection.md
+++ b/docs/formatter/formatters/AlignTestCasesSection.md
@@ -451,6 +451,33 @@ See example:
         Perform Action And Wait     ${argument_name}
     ```
 
+## Alignment of VAR variables
+
+VAR variables are aligned with the rest of the code. By default, ``VAR`` and variable name is fit into the same
+column:
+
+=== "Before"
+
+    ```robotframework
+    *** Test Cases ***
+    Test navigation
+        VAR    ${var_1}    My value 1
+        VAR    ${var_2}    My value 2
+        Navigate    ${URL}
+        Click    Cancel
+    ```
+
+=== "After (default settings)"
+
+    ```robotframework
+    *** Test Cases ***
+    Test navigation
+        VAR    ${var_1}       My value 1
+        VAR    ${var_2}       My value 2
+        Navigate              ${URL}
+        Click                 Cancel
+    ```
+
 ## Skip formatting
 
 It is possible to use the following arguments to skip formatting of the code:

--- a/docs/releasenotes/changelog.md
+++ b/docs/releasenotes/changelog.md
@@ -6,6 +6,11 @@
 
 - Change ``mixed-tabs-and-spaces`` (SPC06) rule behaviour to report all occurrences of mixed tabs and spaces in a file ([issue #848](https://github.com/MarketSquare/robotframework-robocop/issues/848))
 
+
+### Fixes
+
+- Fix ``AlignKeywordsSection`` and ``AlignTestCasesSection`` not aligning VAR variables ([issue #1493](https://github.com/MarketSquare/robotframework-robocop/issues/1493))
+
 ### Documentation
 
 - Add ``deprecated names`` section to all the rules that list previous names and ids of the rule

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+VAR with =
+    VAR    ${var_1}=        My value 1
+    VAR    ${var_2}=        My value 2
+    GoTo                    ${URL}
+    Click                   Cancel
+
+VAR without =
+    VAR    ${var_1}         My value 1
+    VAR    ${var_2}         My value 2
+    GoTo                    ${URL}
+    Click                   Cancel
+
+VAR with long variable names
+    VAR                     ${variable_name_that_affects_something}         My value 1
+    VAR    ${var_2}         My value 2
+    GoTo                    ${URL}
+    Click                   Cancel
+
+VAR with long variable names and long keyword name
+    VAR                     ${variable_name_that_affects_something}         My value 1
+    VAR    ${var_2}         My value 2
+    Click On The Button And Input Text Into Field                           ${URL}
+    Click                   Cancel
+
+VAR without value
+    VAR    ${var_1}
+    Should Be Equal         ${c}                    123
+
+VAR with errors
+    VAR
+    VAR    ${var
+    VAR    $var    value
+    Should Be Equal         ${c}                    123
+
+VAR multiline
+    VAR    ${var}
+    ...                     value
+    Should Be Equal         ${c}                    123
+
+Only VAR
+    VAR    ${a}             ${1}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_12.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_12.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+VAR with =
+    VAR         ${var_1}=               My value 1
+    VAR         ${var_2}=               My value 2
+    GoTo        ${URL}
+    Click       Cancel
+
+VAR without =
+    VAR         ${var_1}                My value 1
+    VAR         ${var_2}                My value 2
+    GoTo        ${URL}
+    Click       Cancel
+
+VAR with long variable names
+    VAR         ${variable_name_that_affects_something}                 My value 1
+    VAR         ${var_2}                My value 2
+    GoTo        ${URL}
+    Click       Cancel
+
+VAR with long variable names and long keyword name
+    VAR         ${variable_name_that_affects_something}                 My value 1
+    VAR         ${var_2}                My value 2
+    Click On The Button And Input Text Into Field       ${URL}
+    Click       Cancel
+
+VAR without value
+    VAR         ${var_1}
+    Should Be Equal                     ${c}            123
+
+VAR with errors
+    VAR
+    VAR    ${var
+    VAR    $var    value
+    Should Be Equal                     ${c}            123
+
+VAR multiline
+    VAR         ${var}
+    ...         value
+    Should Be Equal                     ${c}            123
+
+Only VAR
+    VAR    ${a}    ${1}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_24.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+VAR with =
+    VAR    ${var_1}=        My value 1
+    VAR    ${var_2}=        My value 2
+    GoTo                    ${URL}
+    Click                   Cancel
+
+VAR without =
+    VAR    ${var_1}         My value 1
+    VAR    ${var_2}         My value 2
+    GoTo                    ${URL}
+    Click                   Cancel
+
+VAR with long variable names
+    VAR                     ${variable_name_that_affects_something}                 My value 1
+    VAR    ${var_2}         My value 2
+    GoTo                    ${URL}
+    Click                   Cancel
+
+VAR with long variable names and long keyword name
+    VAR                     ${variable_name_that_affects_something}                 My value 1
+    VAR    ${var_2}         My value 2
+    Click On The Button And Input Text Into Field                   ${URL}
+    Click                   Cancel
+
+VAR without value
+    VAR    ${var_1}
+    Should Be Equal         ${c}                    123
+
+VAR with errors
+    VAR
+    VAR    ${var
+    VAR    $var    value
+    Should Be Equal         ${c}                    123
+
+VAR multiline
+    VAR    ${var}
+    ...                     value
+    Should Be Equal         ${c}                    123
+
+Only VAR
+    VAR    ${a}             ${1}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_auto.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_auto.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+VAR with =
+    VAR    ${var_1}=    My value 1
+    VAR    ${var_2}=    My value 2
+    GoTo                ${URL}
+    Click               Cancel
+
+VAR without =
+    VAR    ${var_1}    My value 1
+    VAR    ${var_2}    My value 2
+    GoTo               ${URL}
+    Click              Cancel
+
+VAR with long variable names
+    VAR                ${variable_name_that_affects_something}     My value 1
+    VAR    ${var_2}    My value 2
+    GoTo               ${URL}
+    Click              Cancel
+
+VAR with long variable names and long keyword name
+    VAR                ${variable_name_that_affects_something}     My value 1
+    VAR    ${var_2}    My value 2
+    Click On The Button And Input Text Into Field                  ${URL}
+    Click              Cancel
+
+VAR without value
+    VAR    ${var_1}
+    Should Be Equal     ${c}        123
+
+VAR with errors
+    VAR
+    VAR    ${var
+    VAR    $var    value
+    Should Be Equal     ${c}    123
+
+VAR multiline
+    VAR    ${var}
+    ...                 value
+    Should Be Equal     ${c}        123
+
+Only VAR
+    VAR    ${a}    ${1}

--- a/tests/formatter/formatters/AlignTestCasesSection/source/var_syntax.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/source/var_syntax.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+VAR with =
+    VAR    ${var_1}=    My value 1
+    VAR                    ${var_2}=    My value 2
+    GoTo                   ${URL}
+    Click                     Cancel
+
+VAR without =
+    VAR    ${var_1}    My value 1
+    VAR                    ${var_2}    My value 2
+    GoTo                   ${URL}
+    Click                     Cancel
+
+VAR with long variable names
+    VAR    ${variable_name_that_affects_something}    My value 1
+    VAR                    ${var_2}    My value 2
+    GoTo                   ${URL}
+    Click                     Cancel
+
+VAR with long variable names and long keyword name
+    VAR    ${variable_name_that_affects_something}    My value 1
+    VAR                    ${var_2}    My value 2
+    Click On The Button And Input Text Into Field                   ${URL}
+    Click                     Cancel
+
+VAR without value
+    VAR    ${var_1}
+    Should Be Equal    ${c}    123
+
+VAR with errors
+    VAR
+    VAR    ${var
+    VAR    $var    value
+    Should Be Equal    ${c}    123
+
+VAR multiline
+    VAR    ${var}
+    ...     value
+    Should Be Equal    ${c}    123
+
+Only VAR
+    VAR    ${a}    ${1}

--- a/tests/formatter/formatters/AlignTestCasesSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignTestCasesSection/test_formatter.py
@@ -190,3 +190,30 @@ class TestAlignTestCasesSection(FormatterAcceptanceTest):
 
     def test_groups(self):
         self.compare(source="groups.robot", test_on_version=">7.1.1")
+
+    def test_var_syntax(self):
+        self.compare(source="var_syntax.robot", test_on_version=">=7")
+
+    def test_var_syntax_auto(self):
+        self.compare(
+            source="var_syntax.robot",
+            expected="var_syntax_auto.robot",
+            configure=[f"{self.FORMATTER_NAME}.alignment_type=auto"],
+            test_on_version=">=7",
+        )
+
+    def test_var_syntax_configure_widths_12(self):
+        self.compare(
+            source="var_syntax.robot",
+            expected="var_syntax_12.robot",
+            configure=[f"{self.FORMATTER_NAME}.widths=12,24,16"],
+            test_on_version=">=7",
+        )
+
+    def test_var_syntax_configure_widths_24(self):
+        self.compare(
+            source="var_syntax.robot",
+            expected="var_syntax_24.robot",
+            configure=[f"{self.FORMATTER_NAME}.widths=24,24,16"],
+            test_on_version=">=7",
+        )


### PR DESCRIPTION
Fixes #1493