### PR TITLE
Rename custom-formatters to extend-select

### DIFF
--- a/docs/configuration/configuration_reference.md
+++ b/docs/configuration/configuration_reference.md
@@ -422,6 +422,12 @@ option to select all rules except those you want to ignore:
 
 ---
 
+#### ``extend select``
+
+Fill it with linter feature.
+
+---
+
 #### ``ignore``
 
 Use ``--ignore`` option to ignore rules. You can use rule id or rule name. Glob patterns are supported.
@@ -748,7 +754,7 @@ Use ``--select`` option to select formatters to run. When this option is used, a
 ???+ note
 
     If you want to only enable additional formatters and do not disable default ones, use
-    ``--configure <formatter>.enabled=True`` configuration parameter instead.
+    ``--extend-select`` option instead.
 
 To only select and run ``NormalizeSeparators`` formatter:
 
@@ -787,23 +793,25 @@ You can select multiple formatters:
 
 ---
 
-#### ``custom formatters``
+#### ``extend select``
+
+``--extend-select`` option allows including formatters in addition to the ``--select`` ones. Since ``--select`` option
+by default enables all default formatters, this option is useful to run all default and selected non-default or custom
+formatters.
 
 Read more about custom formatters on the [Custom formatters](../formatter/custom_formatters.md) page.
-
-``--custom-formatters`` option allows including custom formatters.
 
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop format --custom-formatters my/own/Formatter.py --custom-formatters CustomFormatter.py
+    robocop format --extend-select my/own/Formatter.py --extend-select CustomFormatter.py
     ```
 
 === ":material-file-cog-outline: toml"
 
     ```toml
     [tool.robocop.format]
-    custom_formatters = [
+    extend-select = [
         "my/own/Formatter.py",
         "CustomFormatter.py"
     ]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -64,7 +64,7 @@ and options in TOML format.
 
     [tool.robocop.format]
     select = ["NormalizeNewLines"]
-    custom_formatters = ["CustomFormatter.py"]
+    extend-select = ["CustomFormatter.py"]
     configure = [
         "NormalizeNewLines.section_lines=1"
     ]

--- a/docs/formatter/custom_formatters.md
+++ b/docs/formatter/custom_formatters.md
@@ -2,29 +2,28 @@
 
 ## How to include custom formatters
 
-``--custom-formatters`` option allows including custom formatters. It can point to a single file (named the same as
-the formatter class) or to a module containing multiple formatters. Each formatter must be a class that inherits from
-`robocop.formatter.formatters.Formatter` class.
+Both [``--select``](../configuration/configuration_reference.md#select_1) and [``--extend-select``](../configuration/configuration_reference.md#extend-select_1)
+options allow including custom rules. Use the ``select`` option to only run custom formatter and ``extend-select``
+to run both default and custom formatters.
+
+You can point to a single file (named the same as the formatter class) or to a module containing multiple formatters.
+Each formatter must be a class that inherits from `robocop.formatter.formatters.Formatter` class.
 
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop format --custom-formatters CustomFormatters --custom-formatters CustomFormatter.py
+    robocop format --extend-select CustomFormatters --extend-select CustomFormatter.py
     ```
 
 === ":material-file-cog-outline: toml"
 
     ```toml
     [tool.robocop.format]
-    custom_formatters = [
+    extend-select = [
         "CustomFormatters",
         "CustomFormatter.py"
     ]
     ```
-
-It is also possible to include custom formatters using [select](../configuration/configuration_reference.md#select_1)
-option. Select loads only selected formatters, while ``--custom-formatters`` load custom formatters after loading
-default formatters.
 
 ## How to write custom formatters
 
@@ -56,7 +55,7 @@ Importing formatters from a module works similarly to how custom libraries are i
 If the file has the same name as the formatter, it will be auto-imported. For example, the following import:
 
 ```bash
-robocop format --custom-formatters CustomFormatter.py
+robocop format --extend-select CustomFormatter.py
 ```
 
 will auto import class ``CustomFormatter`` from the file.

--- a/docs/formatter/formatter.md
+++ b/docs/formatter/formatter.md
@@ -28,7 +28,7 @@ robocop list formatters
 The following options can be used to select rules:
 
 - ``--select`` (see [configuration reference](../configuration/configuration_reference.md#select_1)) to only run selected formatters
-- ``--custom-formatters`` (see [configuration reference](../configuration/configuration_reference.md#custom-formatters)) to load custom formatters
+- ``--extend-select`` (see [configuration reference](../configuration/configuration_reference.md#extend-select_1)) to load default and selected formatters
 
 It is also possible to disable rules not available in the selected Robot Framework version using [target version](../configuration/configuration_reference.md#target-version).
 

--- a/docs/formatter/formatters/enable_hint.md.jinja
+++ b/docs/formatter/formatters/enable_hint.md.jinja
@@ -1,14 +1,13 @@
 ??? info "Enabling the formatter"
 
-    {{ formatter }} is not included in default formatters. To enabled it, you need to call it with ``--select``
-    explicitly:
+    {{ formatter }} is not included in default formatters.
+
+    You can enable it by using [``--select``](../../configuration/configuration_reference.md#select_1) and [``--extend-select``](../../configuration/configuration_reference.md#extend-select_1) options.
 
     ```bash
     robocop format --select {{ formatter }}
     ```
 
-    Or configure ``enabled`` parameter:
-
     ```bash
-    robocop format --configure {{ formatter }}.enabled=True
+    robocop format --extend-select {{ formatter }}
     ```

--- a/docs/releasenotes/changelog.md
+++ b/docs/releasenotes/changelog.md
@@ -4,6 +4,21 @@
 
 ### Features
 
+- **Breaking change** Add option ``--extend-select`` for linter and formatter ([issue #1546](https://github.com/MarketSquare/robotframework-robocop/issues/1546))
+
+``extend--select`` allows to enable rules and formatters on top of the ``select`` configuration. It can be used to
+retain all default rules or formatters and only add additional ones:
+
+```
+robocop check --extend-select no-embedded-keyword-arguments
+robocop check --extend-select AlignKeywordsSection --extend-select CustomFormatter
+```
+
+Because previous ``--custom-formatters`` formatter option already behaved like a ``--extend-select`` option (which was
+not documented), it is now deprecated and renamed to ``--extend-select`` instead.
+
+It is also recommended to use ``--extend-select`` over ``--configue name.enabled=True``.
+
 - **Breaking change** Split ``wrong-case-in-keyword-name`` rule into two separate rules ([issue #1471](https://github.com/MarketSquare/robotframework-robocop/issues/1471)):
 
 ``wrong-case-in-keyword-name`` which checks case convention in keyword definition name

--- a/docs/user_guide/migrate_to_robocop6.md
+++ b/docs/user_guide/migrate_to_robocop6.md
@@ -110,10 +110,11 @@ Formatting options from Robotidy:
 
 ``-rules / --ext-rules`` can be now only used under ``--custom-rules`` name.
 
-``--load-transformers / --custom-transformers`` is now renamed to ``--custom-formatters``.
+``--load-transformers / --custom-transformers`` is now renamed to ``--custom-formatters``. In Robocop 7.0 it is
+renamed to ``--extend-select``.
 
 ---
-
+ 
 ``-nr / --no-recursive`` is now deprecated. Similar behaviour can be reached by passing file paths to robocop or
 configuring ``--exclude`` option.
 

--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -93,7 +93,7 @@ class WrongCaseInKeywordNameRule(Rule):
 
         Go To robocop.readthedocs.io Page
 
-    See the sibling rule [wrong-case-in-keyword-call](#wrong-case-in-keyword-call) that checks keyword call
+    See the sibling rule [wrong-case-in-keyword-call](#name18-wrong-case-in-keyword-call) that checks keyword call
     naming convention.
     """
 
@@ -600,7 +600,7 @@ class WrongCaseInKeywordCallRule(Rule):
 
         Go To robocop.readthedocs.io Page
 
-    See the sibling rule [wrong-case-in-keyword-name](#wrong-case-in-keyword-name) that checks keyword definition
+    See the sibling rule [wrong-case-in-keyword-name](#name02-wrong-case-in-keyword-name) that checks keyword definition
     naming convention.
     """
 

--- a/src/robocop/migrate_config.py
+++ b/src/robocop/migrate_config.py
@@ -368,14 +368,15 @@ def migrate_deprecated_configs(config_path: Path) -> None:
             migrated["lint"]["configure"] = [f"text_file.output_path={robocop_config['output']}"]
     robotidy_config = drop_formatters_with_enabled_config(robotidy_config)
     migrated["format"] = copy_keys(
-        robotidy_config,  # load-transformers / --custom-transformers
+        robotidy_config,
         {
             "transform": "select",
+            "load_transformers": "extend-select",
+            "custom_transformers": "extend-select",
+            "custom_formatters": "extend-select",
             "check": "check",
             "diff": "diff",
             "overwrite": "overwrite",
-            "load_transformers": "custom_formatters",
-            "custom_transformers": "custom_formatters",
             "line_length": "line_length",
             "separator": "separator",
             "spacecount": "space_count",
@@ -389,12 +390,13 @@ def migrate_deprecated_configs(config_path: Path) -> None:
             "configure": ("configure", convert_robotidy_configure),
         },
     )
-    if "select" in migrated["format"]:
-        migrated["format"]["select"], new_configure = split_config_from_select(
-            migrated["format"]["select"], migrated["format"].get("configure", [])
-        )
-        if new_configure:
-            migrated["format"]["configure"] = new_configure
+    for select_option in ("select", "extend-select"):
+        if select_option in migrated["format"]:
+            migrated["format"][select_option], new_configure = split_config_from_select(
+                migrated["format"][select_option], migrated["format"].get("configure", [])
+            )
+            if new_configure:
+                migrated["format"]["configure"] = new_configure
     if skips := convert_skips(robotidy_config):
         migrated["format"]["skip"] = skips
     split_multiline_config(migrated)

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -331,12 +331,12 @@ def format_files(
             rich_help_panel="Selecting formatters",
         ),
     ] = None,
-    custom_formatters: Annotated[
+    extend_select: Annotated[
         list[str],
         typer.Option(
             show_default=False,
             metavar="FORMATTER",
-            help="Run custom formatters.",
+            help="Select additional formatters to run.",
             rich_help_panel="Selecting formatters",
         ),
     ] = None,
@@ -508,7 +508,7 @@ def format_files(
     )
     formatter_config = config.FormatterConfig(
         select=select,
-        custom_formatters=custom_formatters,
+        extend_select=extend_select,
         force_order=force_order,
         whitespace_config=whitespace_config,
         skip_config=skip_config,
@@ -678,7 +678,7 @@ def list_formatters(
     console = Console(soft_wrap=True)
     formatter_config = config.FormatterConfig(
         select=None,
-        custom_formatters=None,
+        extend_select=None,
         force_order=None,
         whitespace_config=config.WhitespaceConfig(),
         skip_config=config.SkipConfig(),

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -113,7 +113,7 @@ class TestConfigFinder:
         config.linter.exit_zero = True
 
         config.formatter.select = ["NormalizeNewLines"]
-        config.formatter.custom_formatters = ["CustomFormatter.py"]
+        config.formatter.extend_select = ["CustomFormatter.py"]
         config.formatter.configure = ["NormalizeNewLines.flatten_lines=True"]
         config.formatter.force_order = True
         config.formatter.diff = True
@@ -281,7 +281,7 @@ class TestConfigFinder:
             == (relative_parent / "custom_rules/CustomRules.py").resolve()
         )
         assert (
-            Path(config_manager.default_config.formatter.custom_formatters[0]).resolve()
+            Path(config_manager.default_config.formatter.extend_select[0]).resolve()
             == (relative_parent / "custom_formatters").resolve()
         )
 

--- a/tests/config/test_data/config_with_all_options/pyproject.toml
+++ b/tests/config/test_data/config_with_all_options/pyproject.toml
@@ -32,7 +32,7 @@ configure = [
 
 [tool.robocop.format]
 select = ["NormalizeNewLines"]
-custom_formatters = ["CustomFormatter.py"]
+extend-select = ["CustomFormatter.py"]
 configure = [
     "NormalizeNewLines.flatten_lines=True"
 ]

--- a/tests/config/test_data/config_with_all_options_hyphens/pyproject.toml
+++ b/tests/config/test_data/config_with_all_options_hyphens/pyproject.toml
@@ -32,7 +32,7 @@ configure = [
 
 [tool.robocop.format]
 select = ["NormalizeNewLines"]
-custom-formatters = ["CustomFormatter.py"]
+extend-select = ["CustomFormatter.py"]
 configure = [
     "NormalizeNewLines.flatten_lines=True"
 ]

--- a/tests/config/test_data/relative_paths/pyproject.toml
+++ b/tests/config/test_data/relative_paths/pyproject.toml
@@ -2,4 +2,4 @@
 custom_rules = ["custom_rules/CustomRules.py"]
 
 [tool.robocop.format]
-custom_formatters = ["custom_formatters/"]
+extend-select = ["custom_formatters/"]

--- a/tests/config/test_formatter_config.py
+++ b/tests/config/test_formatter_config.py
@@ -30,3 +30,31 @@ def test_unordered_select(select: list[str]):
 def test_ordered_select(select: list[str]):
     config = FormatterConfig(select=select, force_order=True)
     assert select == config.selected_formatters()
+
+
+@pytest.mark.parametrize(
+    ("select", "extend_select", "expected", "not_expected"),
+    [
+        # --select with 2, --extend-select with 1; finally we have all 3
+        (
+            ["NormalizeSeparators", "CustomFormatter"],
+            ["NormalizeNewLines"],
+            ["NormalizeSeparators", "CustomFormatter", "NormalizeNewLines"],
+            ["AlignVariablesSection"],
+        ),
+        # --select and --extend-select have the same formatter
+        (
+            ["NormalizeSeparators", "CustomFormatter"],
+            ["NormalizeNewLines", "NormalizeSeparators"],
+            ["NormalizeSeparators", "CustomFormatter", "NormalizeNewLines"],
+            ["AlignVariablesSection"],
+        ),
+        # no --select, only --extend-select
+        ([], ["CustomFormatter"], ["NormalizeSeparators", "CustomFormatter", "AlignVariablesSection"], []),
+    ],
+)
+def test_extend_select(select: list[str], extend_select: list[str], expected: list[str], not_expected: list[str]):
+    config = FormatterConfig(select=select, extend_select=extend_select)
+    selected_formatters = config.selected_formatters()
+    assert all(item in selected_formatters for item in expected)
+    assert all(item not in selected_formatters for item in not_expected)

--- a/tests/documentation/test_toml_config.py
+++ b/tests/documentation/test_toml_config.py
@@ -151,7 +151,7 @@ def test_cli_config(tmp_robot_dir):
                         continue
                     if "--install-completion" in conf:  # TODO: not supported in subprocess
                         continue
-                    if "--custom-formatters CustomFormatters" in conf:  # TODO: need to prepare the whole test module
+                    if "--extend-select CustomFormatters" in conf:  # TODO: need to prepare the whole test module
                         continue
                     if "GenerateDocumentation.doc_template" in conf:
                         continue

--- a/tests/formatter/formatters/ExternalTransformer/test_formatter.py
+++ b/tests/formatter/formatters/ExternalTransformer/test_formatter.py
@@ -33,7 +33,7 @@ class TestExternalTransformer(FormatterAcceptanceTest):
     @pytest.mark.parametrize("external_transformer", [EXTERNAL_TRANSFORMER, EXTERNAL_TRANSFORMER_REL])
     def test_load_external_transformer(self, external_transformer):
         self.run_tidy(
-            custom_formatters=[str(external_transformer)],
+            extend_select=[str(external_transformer)],
             configure=[f"{self.FORMATTER_NAME}.param=2"],
             source="tests.robot",
         )
@@ -46,12 +46,12 @@ class TestExternalTransformer(FormatterAcceptanceTest):
 
     @pytest.mark.parametrize("disabled_transformer", [DISABLED_TRANSFORMER, DISABLED_TRANSFORMER_REL])
     def test_load_disabled(self, disabled_transformer):
-        self.run_tidy(custom_formatters=[str(disabled_transformer)], source="tests.robot")
+        self.run_tidy(extend_select=[str(disabled_transformer)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_only_defaults.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     def test_load_from_module(self, module_path):
-        self.run_tidy(custom_formatters=[str(module_path)], source="tests.robot")
+        self.run_tidy(extend_select=[str(module_path)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_load.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
@@ -63,7 +63,7 @@ class TestExternalTransformer(FormatterAcceptanceTest):
     # @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     # def test_load_from_module_and_configure(self, module_path):
     #     self.run_tidy(
-    #         custom_formatters=[str(module_path)], configure=["CustomClass2.extra_param=True"], source="tests.robot"
+    #         extend_select=[str(module_path)], configure=["CustomClass2.extra_param=True"], source="tests.robot"
     #     )
     #     self.compare_file("tests.robot", expected_name="tests_module_load_configure.robot")
 
@@ -77,5 +77,5 @@ class TestExternalTransformer(FormatterAcceptanceTest):
         self.compare_file("tests.robot", expected_name="tests_module_transform.robot")
 
     def test_load_ordered(self):
-        self.run_tidy(custom_formatters=[str(MODULE_ORDERED_TRANFORMERS)], source="tests.robot")
+        self.run_tidy(extend_select=[str(MODULE_ORDERED_TRANFORMERS)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_load.robot")

--- a/tests/migrate_config/test_data/common.toml
+++ b/tests/migrate_config/test_data/common.toml
@@ -36,6 +36,7 @@ verbose = false
 # comment that will be discarded
 [tool.robotidy]
 transform = ["AlignKeywordsSection", "SplitTooLongLine:split_on_every_arg=False"]
+custom_formatters = ["CustomFormatter"]
 skip_return_values = true
 skip_tags = false
 diff = false

--- a/tests/migrate_config/test_data/common_hyphens.toml
+++ b/tests/migrate_config/test_data/common_hyphens.toml
@@ -36,6 +36,9 @@ verbose = false
 # comment that will be discarded
 [tool.robotidy]
 transform = ["AlignKeywordsSection", "SplitTooLongLine:split_on_every_arg=False"]
+custom-formatters = [
+    "CustomFormatter",
+]
 skip-return-values = true
 skip-tags = false
 diff = false

--- a/tests/migrate_config/test_data/common_migrated.toml
+++ b/tests/migrate_config/test_data/common_migrated.toml
@@ -47,6 +47,9 @@ select = [
     "AlignKeywordsSection",
     "SplitTooLongLine",
 ]
+extend-select = [
+    "CustomFormatter",
+]
 diff = false
 overwrite = true
 line_length = 120


### PR DESCRIPTION
It implements formatter part of #1546 feature: rename custom formatter to reflect actual behaviour of the option and update the documentation and tests.