### PR TITLE
fix: `wrong-case-in-keyword-name` rule false positive reports on `.` characters

### DIFF
--- a/docs/releasenotes/changelog.md
+++ b/docs/releasenotes/changelog.md
@@ -82,6 +82,8 @@
 ### Fixes
 
 - Fix ``unused-variable`` and ``variable-overwritten-before-usage`` rules not reporting violations in ``TRY`` blocks ([issue #1548](https://github.com/MarketSquare/robotframework-robocop/issues/1548))
+- Fix ``wrong-case-in-keyword-call`` rule false positive report on names with ``.`` character with first_word_capitalized = True ([issue #1555](https://github.com/MarketSquare/robotframework-robocop/issues/1555))
+- Fix ``wrong-case-in-keyword-name`` rule incorrectly handling names with ``.`` character ([issue #1555](https://github.com/MarketSquare/robotframework-robocop/issues/1555))
 
 ### Documentation
 

--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -793,7 +793,15 @@ class KeywordNamingChecker(VisitorChecker):
             case_naming_rule = self.wrong_case_in_keyword_call
         normalized = utils.remove_robot_vars(keyword_name)
         normalized = case_naming_rule.pattern.sub("", normalized)
-        normalized = normalized.split(".")[-1]  # remove any imports ie ExternalLib.SubLib.Log -> Log
+        if not is_keyword_definition and "." in normalized:
+            # remove potential library import
+            # Library.Keyword -> Keyword, Library.SubLibrary.Keyword -> Keyword
+            # Library Space.Keyword -> Library Space.Keyword
+            parts = normalized.split(".")
+            for i, part in enumerate(parts):
+                if " " in part:
+                    normalized = ".".join(parts[i:])
+                    break
         normalized = normalized.replace("'", "")  # replace ' apostrophes
         if "_" in normalized:
             self.report(

--- a/tests/linter/rules/naming/wrong_case_in_keyword_call/first_word/expected_output.txt
+++ b/tests/linter/rules/naming/wrong_case_in_keyword_call/first_word/expected_output.txt
@@ -5,3 +5,6 @@ first_word${/}test.robot:6:16 [W] NAME18 Keyword name 'keyword' does not follow 
 first_word${/}test.robot:14:14 [W] NAME18 Keyword name 'keyword' does not follow case convention
 first_word${/}test.robot:15:5 [W] NAME18 Keyword name 'pass' does not follow case convention
 first_word${/}test.robot:18:17 [W] NAME18 Keyword name 'keyword' does not follow case convention
+first_word${/}test.robot:107:5 [W] NAME18 Keyword name 'Process.txt with keyword' does not follow case convention
+first_word${/}test.robot:109:5 [W] NAME18 Keyword name 'Process.file test.txt with keyword' does not follow case convention
+first_word${/}test.robot:113:5 [W] NAME18 Keyword name '${VAR WITH SPACE}.txt with keyword' does not follow case convention

--- a/tests/linter/rules/naming/wrong_case_in_keyword_call/first_word/test.robot
+++ b/tests/linter/rules/naming/wrong_case_in_keyword_call/first_word/test.robot
@@ -100,3 +100,15 @@ Recognize Figure(s) (Math) From Picture
 
 Click 'Next' button
     No Operation
+
+Dot in keyword call
+    [Documentation]  Bug #1555
+    Process file test with keyword          # No warning
+    Process.txt with keyword                # Warning
+    Process file test.txt with keyword      # No warning
+    Process.file test.txt with keyword      # Warning
+    Process.File test.txt with keyword      # No warning
+    Process file test.Txt with keyword      # No warning
+    Process file ${TEST_FILE} with keyword  # No warning
+    ${VAR WITH SPACE}.txt with keyword      # Warning
+    ${VAR WITH SPACE}.Txt with keyword      # No warning

--- a/tests/linter/rules/naming/wrong_case_in_keyword_name/first_word/test.robot
+++ b/tests/linter/rules/naming/wrong_case_in_keyword_name/first_word/test.robot
@@ -100,3 +100,6 @@ Recognize Figure(s) (Math) From Picture
 
 Click 'Next' button
     No Operation
+
+Dot.in name
+    Should Be Ignored


### PR DESCRIPTION
FIxes #1555 