### PR TITLE
fix: Invalid Robocop disabler accepted as disabler for all rules

### DIFF
--- a/tests/linter/rules/misc/unused_disabler/expected_extended.txt
+++ b/tests/linter/rules/misc/unused_disabler/expected_extended.txt
@@ -1,7 +1,7 @@
-disabled_whole_no_violation.robot:1:2 MISC15 Disabler directive found for 'all' rule(s) but no violation found
+disabled_whole_no_violation.robot:1:3 MISC15 Disabler directive found for 'all' rule(s) but no violation found
    |
  1 | # robocop: off
-   |  ^^^^^^^^^^^^^ MISC15
+   |   ^^^^^^^^^^^^ MISC15
    |
 
 disabled_whole_rule.robot:1:3 MISC15 Disabler directive found for 'some-rule' rule(s) but no violation found
@@ -40,12 +40,12 @@ test.robot:5:41 MISC15 Disabler directive found for 'unused-variable' rule(s) bu
  7 |     END
    |
 
-test.robot:8:21 MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:8:22 MISC15 Disabler directive found for 'all' rule(s) but no violation found
    |
  6 |         Log    ${var}
  7 |     END
  8 |     Log    ${var}  # robocop: off
-   |                     ^^^^^^^^^^^^^ MISC15
+   |                      ^^^^^^^^^^^^ MISC15
    |
 
 test.robot:17:21 MISC15 Disabler directive found for 'NAME01' rule(s) but no violation found
@@ -157,12 +157,50 @@ test.robot:62:7 MISC15 Disabler directive found for 'unused-variable' rule(s) bu
  63 |     ${var}    Set Variable    value
     |
 
-test.robot:66:6 MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:66:7 MISC15 Disabler directive found for 'all' rule(s) but no violation found
     |
  64 |
  65 | Disabled All Unused
  66 |     # robocop: off
-    |      ^^^^^^^^^^^^^ MISC15
+    |       ^^^^^^^^^^^^ MISC15
  67 |     No Operation
+    |
+
+test.robot:75:28 MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+    |
+ 75 | Scoped disablers Unused  # robocop: off=unused-variable
+    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MISC15
+ 76 |     ${var}    Set Variable    value
+ 77 |     VAR    ${name}    # robocop: off=line-too-long
+    |
+
+test.robot:77:25 MISC15 Disabler directive found for 'line-too-long' rule(s) but no violation found
+    |
+ 75 | Scoped disablers Unused  # robocop: off=unused-variable
+ 76 |     ${var}    Set Variable    value
+ 77 |     VAR    ${name}    # robocop: off=line-too-long
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ MISC15
+ 78 |     ...    A value that is longer than configured minimal length of the line and will trigger the line-too-long rule
+ 79 |     Log    ${var}
+    |
+
+test.robot:83:7 MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+    |
+ 81 |
+ 82 | Block disablers Used
+ 83 |     # robocop: off=unused-variable
+    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MISC15
+ 84 |     ${var}    Set Variable    value
+ 85 |     # robocop: off=line-too-long
+    |
+
+test.robot:85:7 MISC15 Disabler directive found for 'line-too-long' rule(s) but no violation found
+    |
+ 83 |     # robocop: off=unused-variable
+ 84 |     ${var}    Set Variable    value
+ 85 |     # robocop: off=line-too-long
+    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^ MISC15
+ 86 |     VAR    ${name}
+ 87 |     ...    A value that is longer than configured minimal length of the line and will trigger the line-too-long rule
     |
 

--- a/tests/linter/rules/misc/unused_disabler/expected_output.txt
+++ b/tests/linter/rules/misc/unused_disabler/expected_output.txt
@@ -1,19 +1,23 @@
 test.robot:3:21 [I] MISC15 Disabler directive found for 'NAME01' rule(s) but no violation found
 test.robot:4:21 [I] MISC15 Disabler directive found for 'wrong-case-in-keyword-call' rule(s) but no violation found
 test.robot:5:41 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
-test.robot:8:21 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:8:22 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 test.robot:17:21 [I] MISC15 Disabler directive found for 'NAME01' rule(s) but no violation found
 test.robot:17:21 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
 test.robot:20:40 [I] MISC15 Disabler directive found for 'some-rule' rule(s) but no violation found
 test.robot:23:7 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+test.robot:27:5 [I] VAR02 Variable '${var2}' is assigned but not used
 test.robot:29:11 [I] MISC15 Disabler directive found for 'SPC10' rule(s) but no violation found
+test.robot:37:5 [I] VAR02 Variable '${var2}' is assigned but not used
 test.robot:45:7 [I] MISC15 Disabler directive found for 'some-rule' rule(s) but no violation found
+test.robot:48:5 [I] VAR02 Variable '${var2}' is assigned but not used
 test.robot:51:38 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 test.robot:58:86 [I] MISC15 Disabler directive found for 'too-many-arguments' rule(s) but no violation found
 test.robot:62:7 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
-test.robot:66:6 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
-test.robot:27:5 [I] VAR02 Variable '${var2}' is assigned but not used
-test.robot:37:5 [I] VAR02 Variable '${var2}' is assigned but not used
-test.robot:48:5 [I] VAR02 Variable '${var2}' is assigned but not used
-disabled_whole_no_violation.robot:1:2 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:66:7 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:75:28 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+test.robot:77:25 [I] MISC15 Disabler directive found for 'line-too-long' rule(s) but no violation found
+test.robot:83:7 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+test.robot:85:7 [I] MISC15 Disabler directive found for 'line-too-long' rule(s) but no violation found
+disabled_whole_no_violation.robot:1:3 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 disabled_whole_rule.robot:1:3 [I] MISC15 Disabler directive found for 'some-rule' rule(s) but no violation found

--- a/tests/linter/rules/misc/unused_disabler/expected_output_rf4.txt
+++ b/tests/linter/rules/misc/unused_disabler/expected_output_rf4.txt
@@ -1,7 +1,7 @@
 test.robot:3:21 [I] MISC15 Disabler directive found for 'NAME01' rule(s) but no violation found
 test.robot:4:21 [I] MISC15 Disabler directive found for 'wrong-case-in-keyword-call' rule(s) but no violation found
 test.robot:5:41 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
-test.robot:8:21 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:8:22 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 test.robot:17:21 [I] MISC15 Disabler directive found for 'NAME01' rule(s) but no violation found
 test.robot:17:21 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
 test.robot:20:40 [I] MISC15 Disabler directive found for 'some-rule' rule(s) but no violation found
@@ -12,9 +12,13 @@ test.robot:45:7 [I] MISC15 Disabler directive found for 'some-rule' rule(s) but 
 test.robot:51:38 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 test.robot:58:86 [I] MISC15 Disabler directive found for 'too-many-arguments' rule(s) but no violation found
 test.robot:62:7 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
-test.robot:66:6 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:66:7 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 test.robot:27:5 [I] VAR02 Variable '${var2}' is assigned but not used
 test.robot:37:5 [I] VAR02 Variable '${var2}' is assigned but not used
 test.robot:48:5 [I] VAR02 Variable '${var2}' is assigned but not used
-disabled_whole_no_violation.robot:1:2 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
+test.robot:75:28 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+test.robot:77:25 [I] MISC15 Disabler directive found for 'line-too-long' rule(s) but no violation found
+test.robot:83:7 [I] MISC15 Disabler directive found for 'unused-variable' rule(s) but no violation found
+test.robot:85:7 [I] MISC15 Disabler directive found for 'line-too-long' rule(s) but no violation found
+disabled_whole_no_violation.robot:1:3 [I] MISC15 Disabler directive found for 'all' rule(s) but no violation found
 disabled_whole_rule.robot:1:3 [I] MISC15 Disabler directive found for 'some-rule' rule(s) but no violation found

--- a/tests/linter/rules/misc/unused_disabler/test.robot
+++ b/tests/linter/rules/misc/unused_disabler/test.robot
@@ -65,3 +65,35 @@ Disabled With All And Selected Rule
 Disabled All Unused
     # robocop: off
     No Operation
+
+Scoped disablers Used  # robocop: off=unused-variable
+    ${var}    Set Variable    value
+    VAR    ${name}    # robocop: off=line-too-long
+    ...    A value that is longer than configured minimal length of the line and will trigger the line-too-long rule and we don't want that
+    Log    ${name}
+
+Scoped disablers Unused  # robocop: off=unused-variable
+    ${var}    Set Variable    value
+    VAR    ${name}    # robocop: off=line-too-long
+    ...    A value that is longer than configured minimal length of the line and will trigger the line-too-long rule
+    Log    ${var}
+    Log    ${name}
+
+Block disablers Used
+    # robocop: off=unused-variable
+    ${var}    Set Variable    value
+    # robocop: off=line-too-long
+    VAR    ${name}
+    ...    A value that is longer than configured minimal length of the line and will trigger the line-too-long rule
+    Log    ${var}
+    Log    ${name}
+    # robocop: on=line-too-long
+
+Block disablers Unused
+    # robocop: off=unused-variable
+    ${var}    Set Variable    value
+    # robocop: off=line-too-long
+    VAR    ${name}
+    ...    A value that is longer than configured minimal length of the line and will trigger the line-too-long rule and we don't want that
+    Log    ${name}
+    # robocop: on=line-too-long

--- a/tests/linter/rules/misc/unused_disabler/test_rule.py
+++ b/tests/linter/rules/misc/unused_disabler/test_rule.py
@@ -2,6 +2,7 @@ from tests.linter.utils import RuleAcceptance
 
 SELECT = [
     "unused-disabler",
+    "line-too-long",
     "multiline-inline-if",
     "duplicated-variable",
     "NAME01",

--- a/tests/linter/test_data/disablers/disabled.robot
+++ b/tests/linter/test_data/disablers/disabled.robot
@@ -16,6 +16,10 @@ Multiline
     ...    ${ARG}    # robocop: off=disable-whole-keyword
     No Operation
 
+Invalid disabler  # robocop: off:some-rule
+    Keyword
+
+
 *** Keywords ***  # robocop: off=whole-section
 Keyword
     No Operation

--- a/tests/linter/test_data/disablers/scopes.robot
+++ b/tests/linter/test_data/disablers/scopes.robot
@@ -72,3 +72,7 @@ Disablers in blocks
             # robocop: off=rule1
         END
     END
+
+Invalid disabler
+    # robocop: off:rule1
+    Log    Invalid disabler

--- a/tests/linter/test_disablers.py
+++ b/tests/linter/test_disablers.py
@@ -38,10 +38,12 @@ class TestDisablers:
         assert disabler.is_line_disabled(15, "disable-whole-keyword")
         assert disabler.is_line_disabled(16, "disable-whole-keyword")
         assert not disabler.is_line_disabled(17, "disable-whole-keyword")
-        assert disabler.is_line_disabled(19, "whole-section")
-        assert disabler.is_line_disabled(20, "whole-section")
-        assert disabler.is_line_disabled(21, "whole-section")
-        assert not disabler.is_line_disabled(10, "otherule")
+        assert disabler.is_line_disabled(23, "whole-section")
+        assert disabler.is_line_disabled(24, "whole-section")
+        assert disabler.is_line_disabled(25, "whole-section")
+        assert not disabler.is_line_disabled(19, "all")
+        assert not disabler.is_line_disabled(19, "some-rule")
+        assert not disabler.is_line_disabled(20, "all")
         model = get_model(DISABLED_TEST_DIR / "disabled_whole.robot")
         disabler = DisablersFinder(model)
         for i in range(1, 11):
@@ -71,7 +73,7 @@ class TestDisablers:
         exp_disabled_rules = {
             "all": [(8, 9)],
             "rule1": [(4, 9), (39, 39), (72, 72)],
-            "rule2": [(14, 42), (32, 41), (47, 74), (65, 74)],
+            "rule2": [(14, 42), (32, 41), (47, 78), (65, 74)],
             "rule3": [(22, 29), (55, 62)],
             "rule4": [(24, 25), (57, 58)],
         }


### PR DESCRIPTION
Fixed an issue where invalid Robocop disabler ('# robocop: off:rulename') was parsed as all rules disabler instead of disabler for the selected rule.