### PR TITLE
chore: remove trailing comma in release-please config file name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "package-name": "robotframework-robocop",
       "changelog-path": "docs/releasenotes/changelog.md",
       "extra-files": ["src/robocop/__init__.py"]
-    },
+    }
   },
   "changelog-sections": [
     {"type": "feat", "section": "Features"},


### PR DESCRIPTION
Trailing commas are causing syntax errors. It may affected release-please workflow.