### PR TITLE
chore(release): fix release-please not updating version file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,13 @@
   "packages": {
     ".": {
       "package-name": "robocop",
-      "changelog-path": "docs/releasenotes/changelog.md"
+      "changelog-path": "docs/releasenotes/changelog.md",
+      "extra-files": [
+        {
+          "path": "src/robocop/__init__.py",
+          "type": "generic"
+        }
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Fix remaining issue with release-please not updating the version file. It is looking for roboframework-robocop/__init__.py instead of robocop/__init__.py