### PR TITLE
fix(release): fix triggering Github workflows from automated scripts (#1567)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Robocop
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Tests
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   pull_request_target:
     branches: [main]
 


### PR DESCRIPTION
Closes #1567 

 When another action triggers release or create pull request, there is different kind of event than when done manually. For example, creating release goes directly into published state, skipping 'created' state.