### PR TITLE
test: add test with single large file

### DIFF
--- a/tests/performance/generate_reports.py
+++ b/tests/performance/generate_reports.py
@@ -7,9 +7,12 @@ Each report is run multiple times and calculates a trimmed mean by excluding the
 """
 
 import json
+import tempfile
 import time
 from functools import wraps
 from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
 
 from robocop import __version__, config
 from robocop.formatter.formatters import FORMATTERS
@@ -17,6 +20,7 @@ from robocop.run import check_files, format_files
 from tests import working_directory
 
 LINTER_TESTS_DIR = Path(__file__).parent.parent / "linter"
+TEST_DATA = Path(__file__).parent / "test_data"
 REPORTS = {}
 
 
@@ -26,7 +30,8 @@ def performance_report(runs: int = 100):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            report_name = kwargs.get("report_name")
+            report_name = kwargs.get("report_name", "")
+            print(report_name)
             run_times = []
             counter = 0
             for run in range(runs):
@@ -41,7 +46,10 @@ def performance_report(runs: int = 100):
             cut_off = int(runs * 0.1)
             if cut_off + 2 > runs:
                 cut_off = 0
-            avg_time = sum(run_times[cut_off:-cut_off]) / (len(run_times) - 2 * cut_off)
+            if len(run_times) > 2:
+                avg_time = sum(run_times[cut_off:-cut_off]) / (len(run_times) - 2 * cut_off)
+            else:
+                avg_time = sum(run_times) / len(run_times)
             print(f"Mean average execution time over {runs} runs: {avg_time:.6f} seconds")
             if report_name:
                 if func.__name__ not in REPORTS:
@@ -55,7 +63,7 @@ def performance_report(runs: int = 100):
     return decorator
 
 
-@performance_report(runs=100)
+@performance_report(runs=50)
 def project_traversing_report() -> int:
     """
     Measure how long it takes to traverse Robocop repository files.
@@ -82,24 +90,32 @@ def project_traversing_report() -> int:
     return files_count
 
 
-@performance_report(runs=100)
-def formatter_report(report_name: str):
+@performance_report(runs=50)
+def formatter_report(formatter: str, report_name: str, cache: bool = True) -> int:  # noqa: ARG001
     main_dir = Path(__file__).parent.parent.parent
-    formatter_dir = main_dir / "tests" / "formatter" / "formatters" / report_name
+    formatter_dir = main_dir / "tests" / "formatter" / "formatters" / formatter
     with working_directory(formatter_dir):
-        format_files(["source"], select=[report_name], overwrite=False, return_result=True, silent=True)
+        format_files(
+            ["source"], select=[formatter], overwrite=False, return_result=True, silent=True, no_cache=not cache
+        )
     source_dir = formatter_dir / "source"
     return len(list(source_dir.iterdir()))
 
 
 @performance_report(runs=10)
-def linter_report(report_name: str, **kwargs):
-    print(report_name)
+def linter_report(report_name: str, **kwargs) -> int:  # noqa: ARG001
     main_dir = Path(__file__).parent.parent.parent
     linter_dir = main_dir / "tests" / "linter"
     with working_directory(linter_dir):
         check_files(return_result=True, select=["ALL"], **kwargs)
     return len(list(linter_dir.glob("**/*.robot")))
+
+
+@performance_report(runs=2)
+def lint_large_file(report_name: str, lint_dir: Path, **kwargs) -> int:  # noqa: ARG001
+    with working_directory(lint_dir):
+        check_files(return_result=True, select=["ALL"], no_cache=True, **kwargs)
+    return 1
 
 
 def merge_dictionaries(d1: dict, d2: dict) -> dict:
@@ -111,12 +127,34 @@ def merge_dictionaries(d1: dict, d2: dict) -> dict:
     return d1
 
 
+def generate_large_file(template_path: Path, output_dir: Path) -> None:
+    env = Environment(loader=FileSystemLoader(template_path.parent), autoescape=True)
+    template = env.get_template(template_path.name)
+
+    rendered_content = template.render()
+
+    with open(f"{output_dir}/{template_path.name}", "w", encoding="utf-8") as f:
+        f.write(rendered_content)
+
+
 if __name__ == "__main__":
-    linter_report(report_name="with_print")
-    linter_report(report_name="without_print", silent=True)
+    # TODO: prepare i.e. nox script to install external robocops and run this script
+    # So we can generate reports for multiple past versions. It is important since the actual seconds change depending
+    # on where we run the script from, but the % change between version should be comparable. Also we can use new tests
+    # on old versions
+    linter_report(report_name="with_print_cache", no_cache=False)
+    linter_report(report_name="with_print_no_cache", no_cache=True)
+    linter_report(report_name="without_print_cache", silent=True, no_cache=False)
+    linter_report(report_name="without_print_no_cache", silent=True, no_cache=True)
     for formatter in FORMATTERS:
-        formatter_report(report_name=formatter)
+        formatter_report(formatter=formatter, report_name=formatter)
+        formatter_report(formatter=formatter, report_name=f"{formatter}_no_cache", cache=False)
     project_traversing_report()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir = Path(temp_dir)
+        generate_large_file(TEST_DATA / "large_file.robot", temp_dir)
+        lint_large_file(report_name="large_file_with_print", lint_dir=temp_dir)
+        lint_large_file(report_name="large_file_without_print", lint_dir=temp_dir, silent=True)
 
     report_path = Path(__file__).parent / "reports" / f"robocop_{__version__.replace('.', '_')}.json"
     if report_path.exists():

--- a/tests/performance/reports/robocop_7_1_0.json
+++ b/tests/performance/reports/robocop_7_1_0.json
@@ -1,0 +1,300 @@
+{
+    "linter_report": {
+        "with_print_cache": {
+            "avg_time": 2.96985698750359,
+            "counter": 388
+        },
+        "with_print_no_cache": {
+            "avg_time": 4.098235049954383,
+            "counter": 388
+        },
+        "without_print_cache": {
+            "avg_time": 0.856108075066004,
+            "counter": 388
+        },
+        "without_print_no_cache": {
+            "avg_time": 1.9954930499952752,
+            "counter": 388
+        }
+    },
+    "formatter_report": {
+        "AddMissingEnd": {
+            "avg_time": 0.0025422399980016054,
+            "counter": 3
+        },
+        "AddMissingEnd_no_cache": {
+            "avg_time": 0.008688030007760972,
+            "counter": 3
+        },
+        "NormalizeSeparators": {
+            "avg_time": 0.005260780022945255,
+            "counter": 13
+        },
+        "NormalizeSeparators_no_cache": {
+            "avg_time": 0.015568304993212222,
+            "counter": 13
+        },
+        "DiscardEmptySections": {
+            "avg_time": 0.0022869924956467,
+            "counter": 2
+        },
+        "DiscardEmptySections_no_cache": {
+            "avg_time": 0.0031895949970930813,
+            "counter": 2
+        },
+        "MergeAndOrderSections": {
+            "avg_time": 0.00548124251072295,
+            "counter": 14
+        },
+        "MergeAndOrderSections_no_cache": {
+            "avg_time": 0.011248849995899946,
+            "counter": 14
+        },
+        "RemoveEmptySettings": {
+            "avg_time": 0.002625014999648556,
+            "counter": 3
+        },
+        "RemoveEmptySettings_no_cache": {
+            "avg_time": 0.004889295011525974,
+            "counter": 3
+        },
+        "ReplaceEmptyValues": {
+            "avg_time": 0.0020431125070899726,
+            "counter": 1
+        },
+        "ReplaceEmptyValues_no_cache": {
+            "avg_time": 0.0025288450182415546,
+            "counter": 1
+        },
+        "ReplaceWithVAR": {
+            "avg_time": 0.002859552501467988,
+            "counter": 4
+        },
+        "ReplaceWithVAR_no_cache": {
+            "avg_time": 0.015055382519494741,
+            "counter": 4
+        },
+        "NormalizeAssignments": {
+            "avg_time": 0.003809087473200634,
+            "counter": 7
+        },
+        "NormalizeAssignments_no_cache": {
+            "avg_time": 0.00619702750700526,
+            "counter": 7
+        },
+        "GenerateDocumentation": {
+            "avg_time": 0.0023699625162407756,
+            "counter": 3
+        },
+        "GenerateDocumentation_no_cache": {
+            "avg_time": 0.005489615007536486,
+            "counter": 3
+        },
+        "OrderSettings": {
+            "avg_time": 0.0029902800160925835,
+            "counter": 4
+        },
+        "OrderSettings_no_cache": {
+            "avg_time": 0.006835065002087503,
+            "counter": 4
+        },
+        "OrderSettingsSection": {
+            "avg_time": 0.003953872487181797,
+            "counter": 8
+        },
+        "OrderSettingsSection_no_cache": {
+            "avg_time": 0.005790704995160922,
+            "counter": 8
+        },
+        "NormalizeTags": {
+            "avg_time": 0.0044895200291648505,
+            "counter": 10
+        },
+        "NormalizeTags_no_cache": {
+            "avg_time": 0.008566337503725662,
+            "counter": 10
+        },
+        "OrderTags": {
+            "avg_time": 0.0026960799877997488,
+            "counter": 3
+        },
+        "OrderTags_no_cache": {
+            "avg_time": 0.004152962501393631,
+            "counter": 3
+        },
+        "RenameVariables": {
+            "avg_time": 0.005505839997204021,
+            "counter": 14
+        },
+        "RenameVariables_no_cache": {
+            "avg_time": 0.023607444996014238,
+            "counter": 14
+        },
+        "IndentNestedKeywords": {
+            "avg_time": 0.0029322425019927324,
+            "counter": 4
+        },
+        "IndentNestedKeywords_no_cache": {
+            "avg_time": 0.0072910449875053015,
+            "counter": 4
+        },
+        "AlignSettingsSection": {
+            "avg_time": 0.0037672625039704144,
+            "counter": 7
+        },
+        "AlignSettingsSection_no_cache": {
+            "avg_time": 0.005970677523873746,
+            "counter": 7
+        },
+        "AlignVariablesSection": {
+            "avg_time": 0.003904082515509799,
+            "counter": 8
+        },
+        "AlignVariablesSection_no_cache": {
+            "avg_time": 0.006162447488168255,
+            "counter": 8
+        },
+        "AlignTemplatedTestCases": {
+            "avg_time": 0.004810090007958933,
+            "counter": 11
+        },
+        "AlignTemplatedTestCases_no_cache": {
+            "avg_time": 0.009894734976114705,
+            "counter": 11
+        },
+        "AlignTestCasesSection": {
+            "avg_time": 0.006912297487724572,
+            "counter": 19
+        },
+        "AlignTestCasesSection_no_cache": {
+            "avg_time": 0.018717997503699735,
+            "counter": 19
+        },
+        "AlignKeywordsSection": {
+            "avg_time": 0.006435322499601171,
+            "counter": 17
+        },
+        "AlignKeywordsSection_no_cache": {
+            "avg_time": 0.015787184989312662,
+            "counter": 17
+        },
+        "NormalizeNewLines": {
+            "avg_time": 0.0060056299960706385,
+            "counter": 16
+        },
+        "NormalizeNewLines_no_cache": {
+            "avg_time": 0.013009855011478066,
+            "counter": 16
+        },
+        "NormalizeSectionHeaderName": {
+            "avg_time": 0.0032612950017210096,
+            "counter": 5
+        },
+        "NormalizeSectionHeaderName_no_cache": {
+            "avg_time": 0.004263177519896999,
+            "counter": 5
+        },
+        "NormalizeSettingName": {
+            "avg_time": 0.0028721575101371853,
+            "counter": 4
+        },
+        "NormalizeSettingName_no_cache": {
+            "avg_time": 0.004713697504485026,
+            "counter": 4
+        },
+        "ReplaceRunKeywordIf": {
+            "avg_time": 0.003786032507196069,
+            "counter": 7
+        },
+        "ReplaceRunKeywordIf_no_cache": {
+            "avg_time": 0.01122040250338614,
+            "counter": 7
+        },
+        "SplitTooLongLine": {
+            "avg_time": 0.004489754984388128,
+            "counter": 10
+        },
+        "SplitTooLongLine_no_cache": {
+            "avg_time": 0.013641817501047626,
+            "counter": 10
+        },
+        "SmartSortKeywords": {
+            "avg_time": 0.0029111399839166553,
+            "counter": 4
+        },
+        "SmartSortKeywords_no_cache": {
+            "avg_time": 0.004348337522242218,
+            "counter": 4
+        },
+        "RenameTestCases": {
+            "avg_time": 0.002649882505647838,
+            "counter": 3
+        },
+        "RenameTestCases_no_cache": {
+            "avg_time": 0.0038951999915298073,
+            "counter": 3
+        },
+        "RenameKeywords": {
+            "avg_time": 0.004020485037472099,
+            "counter": 8
+        },
+        "RenameKeywords_no_cache": {
+            "avg_time": 0.008320510003250093,
+            "counter": 8
+        },
+        "ReplaceReturns": {
+            "avg_time": 0.0037000624870415777,
+            "counter": 7
+        },
+        "ReplaceReturns_no_cache": {
+            "avg_time": 0.006773599999723956,
+            "counter": 7
+        },
+        "ReplaceBreakContinue": {
+            "avg_time": 0.002707739995094016,
+            "counter": 3
+        },
+        "ReplaceBreakContinue_no_cache": {
+            "avg_time": 0.0054833325208164755,
+            "counter": 3
+        },
+        "InlineIf": {
+            "avg_time": 0.0031843150209169835,
+            "counter": 5
+        },
+        "InlineIf_no_cache": {
+            "avg_time": 0.02126073998515494,
+            "counter": 5
+        },
+        "Translate": {
+            "avg_time": 0.005078997503733263,
+            "counter": 6
+        },
+        "Translate_no_cache": {
+            "avg_time": 0.008630877465475351,
+            "counter": 6
+        },
+        "NormalizeComments": {
+            "avg_time": 0.0020914200227707624,
+            "counter": 1
+        },
+        "NormalizeComments_no_cache": {
+            "avg_time": 0.003166107484139502,
+            "counter": 1
+        }
+    },
+    "project_traversing_report": {
+        "avg_time": 0.37915756499860437,
+        "counter": 403
+    },
+    "lint_large_file": {
+        "large_file_with_print": {
+            "avg_time": 39.73930364998523,
+            "counter": 1
+        },
+        "large_file_without_print": {
+            "avg_time": 3.1198093499988317,
+            "counter": 1
+        }
+    }
+}

--- a/tests/performance/test_data/large_file.robot
+++ b/tests/performance/test_data/large_file.robot
@@ -1,0 +1,188 @@
+{% for n in range(5) %}
+*** Comments ***
+
+{% for n in range(50) %}
+Multiple comments here.
+{% endfor %}
+{% endfor %}
+*** Settings ***
+Resource     library.py
+Library      Collections    WITH NAME  Collections
+Library      Collections    AS  Collections
+Library      other_library.py    WITH NAME  PrettyName
+Library      WITH NAME
+Library      Collections    WITH NAME    Coll ections
+Library      Collections    AS    Coll ections
+
+Documentation   doc
+library         Library
+resource        resource.robot
+variablES       variables.py
+suite setup     Keyword
+suite Teardown  Keyword
+test seTup      Keyword
+Test teardown   Keyword
+test tags      tag
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2
+...             tag2    tag3    tag3    tag3    tag3    tag3    tag3    tag3    tag3    tag3    tag3    tag3    tag3    tag3
+...             tag2
+default tags    defaulttag
+
+*** Test Cases ***
+{% for n in range(50) %}
+Test{{ n }}
+    [Setup]    Keyword
+    [Documentation]    doc
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    [Tags]    tagname    tagname2    tagname3    tagname4    tagname5    tagname6    tagname7    tagname8    tagname9    tagname10
+    ...    tagname11
+    ${assign}=  Keyword Call
+    Keyword Call
+    ${assign1}    ${assign2}    Keyword Call
+    IF    ${assign}    Inline If
+    IF    True
+        IF    True
+            IF    True
+                IF    True
+                    IF    True
+                        IF    True
+                        IF    True
+                        IF    True
+                        IF    True
+                            No Operation
+                        END
+                        END
+                        END
+                        END
+                    END
+                END
+            ELSE IF    False
+                No Operation
+            ELSE
+                No Operation
+            END
+        END
+    END
+    FOR    ${var}    IN    @{list}
+        FOR    ${var2}    IN    @{list}
+            FOR    ${var3}    IN    @{list}
+                FOR    ${var4}    IN    @{list}
+                    FOR    ${var5}    IN RANGE  1
+                            Log    ${var}
+                        WHILE    ${condition}
+                            No Operation
+                        END
+                    END
+                END
+            END
+        END
+    END
+    {% for n in range(50) %}
+    Call Method With Some Parameters    ${arg1}    ${arg2}    ${long_argument_name3}    name=${value}    long_name=${long_value}
+    ...    multi_value=${multi_value1}    multi_value=${multi_value2}    multi_value=${multi_value3}
+    {% endfor %}
+    [Teardown]    Keyword
+{% endfor %}
+{% for n in range(50) %}
+Templated Test {{ n }}
+    [Template]    Test Template
+    arg1    arg2
+    arg3    arg4
+    arg5    arg6
+{% endfor %}
+*** Keywords ***
+{% for n in range(50) %}
+Keyword{{ n }}
+    [Documentation]    doc
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    ...    multi
+    [Tags]    tagname    tagname2    tagname3    tagname4    tagname5    tagname6    tagname7    tagname8    tagname9    tagname10
+    ...    tagname11
+    [Arguments]    ${arg1}    ${arg2}    ${arg3}    ${arg4}    ${arg5}    ${arg6}    ${arg7}    ${arg8}    ${arg9}    ${arg10}=default
+    ...    ${multi_argument}=
+    ${assign}=  Keyword Call
+    Keyword Call
+    ${assign1}    ${assign2}    Keyword Call
+    IF    ${assign}    Inline If
+    IF    True
+        IF    True
+            IF    True
+                IF    True
+                    IF    True
+                        IF    True
+                        IF    True
+                        IF    True
+                        IF    True
+                            No Operation
+                        END
+                        END
+                        END
+                        END
+                    END
+                END
+            ELSE IF    False
+                No Operation
+            ELSE
+                No Operation
+            END
+        END
+    END
+    FOR    ${var}    IN    @{list}
+        FOR    ${var2}    IN    @{list}
+            FOR    ${var3}    IN    @{list}
+                FOR    ${var4}    IN    @{list}
+                    FOR    ${var5}    IN RANGE  1
+                            Log    ${var}
+                        WHILE    ${condition}
+                            No Operation
+                        END
+                    END
+                END
+            END
+        END
+    END
+    {% for n in range(50) %}
+    Call Method With Some Parameters    ${arg1}    ${arg2}    ${long_argument_name3}    name=${value}    long_name=${long_value}
+    ...    multi_value=${multi_value1}    multi_value=${multi_value2}    multi_value=${multi_value3}
+    VAR    ${variable}    value
+    VAR    @{list_variable}    value    other_value    scope=SUITE
+    TRY
+        Do Dangerous Thing
+    EXCEPT
+        Ignore Error
+    END
+    {% endfor %}
+    [Teardown]    Keyword
+{% endfor %}


### PR DESCRIPTION
The file under test is generated from the jinja template and should have around 40k lines after generating.

Interesting is how bad printing scales with large amount of issues:

"large_file_with_print": {
    "avg_time": **39.73930364998523**,
    "counter": 1
},
"large_file_without_print": {
    "avg_time": **3.1198093499988317**,
    
Hopefully incoming refactors in printing will help a little.