### PR TITLE
feat: Fix rule where it is being reported

### DIFF
--- a/src/robocop/linter/diagnostics.py
+++ b/src/robocop/linter/diagnostics.py
@@ -73,6 +73,7 @@ class Diagnostic:
         node=None,
         extended_disablers: tuple[int, int] | None = None,
         sev_threshold_value: int | None = None,
+        fix: Fix | None = None,
         **kwargs,
     ) -> None:
         self.rule = rule
@@ -82,14 +83,12 @@ class Diagnostic:
         self.extended_disablers = extended_disablers if extended_disablers else []
         self.reported_arguments = kwargs
         self.severity = rule.get_severity_with_threshold(sev_threshold_value)
+        self.fix = fix
         self._message = None
 
     @property
     def message(self) -> str:
         return self.rule.message.format(**self.reported_arguments)
-
-    def fix(self, source_lines: list[str]) -> Fix | None:
-        return self.rule.fix(self, source_lines)
 
     @staticmethod
     def get_range(

--- a/src/robocop/linter/fix.py
+++ b/src/robocop/linter/fix.py
@@ -160,8 +160,11 @@ class FixApplier:
         applicable_fixes = [
             fix
             for fix in fixes
-            if fix.applicability == FixApplicability.SAFE
-            or (fix.applicability == FixApplicability.UNSAFE and allow_unsafe)
+            if fix
+            and (
+                fix.applicability == FixApplicability.SAFE
+                or (fix.applicability == FixApplicability.UNSAFE and allow_unsafe)
+            )
         ]
 
         # Collect all edits from safe fixes

--- a/src/robocop/linter/rules/__init__.py
+++ b/src/robocop/linter/rules/__init__.py
@@ -28,7 +28,6 @@ import importlib.util
 import inspect
 import pkgutil
 import sys
-from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum
 from functools import total_ordering
@@ -40,7 +39,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from robocop import __version__, exceptions
 from robocop.linter.diagnostics import Diagnostic
-from robocop.linter.fix import FixAvailability
+from robocop.linter.fix import Fix, FixAvailability
 from robocop.version_handling import Version, VersionSpecifier
 
 try:
@@ -482,7 +481,7 @@ class Rule:
         return None
 
 
-class FixableRule(Rule, ABC):
+class FixableRule(Rule):
     """
     Abstract base class for rules that can automatically fix issues.
 
@@ -493,7 +492,6 @@ class FixableRule(Rule, ABC):
     fix_availability: FixAvailability
     fixable: bool = True
 
-    @abstractmethod
     def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
         """
         Generate TextEdit to fix the issue or return None if no fix available.
@@ -540,6 +538,7 @@ class BaseChecker:
         extended_disablers: tuple[int, int] | None = None,
         sev_threshold_value: int | None = None,
         source: SourceFile | None = None,
+        fix: Fix | None = None,
         **kwargs,
     ) -> None:
         if not rule.enabled:
@@ -561,6 +560,7 @@ class BaseChecker:
             source=source or self.source_file,
             extended_disablers=extended_disablers,
             sev_threshold_value=sev_threshold_value,
+            fix=fix,
             **kwargs,
         )
         self.issues.append(diagnostic)

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -184,7 +184,7 @@ class RobocopLinter:
             fix_applier.fix_stats.total_fixes += max(prev_fixable - len(fixable_diagnostics), 0)
             prev_fixable = len(fixable_diagnostics)
             # Collect fixes from diagnostics
-            fixes = [diag.fix(source_file) for diag in fixable_diagnostics]
+            fixes = [diag.fix or diag.rule.fix(diag, source_file) for diag in fixable_diagnostics]
             if not fix_applier.apply_fixes(source_file, fixes):
                 break
         if source_file.config.linter.fix and not source_file.config.linter.diff:

--- a/src/robocop/source_file.py
+++ b/src/robocop/source_file.py
@@ -69,6 +69,7 @@ class SourceFile:
             list[str]: A list of source code lines.
 
         """
+        # TODO: potential issue: robotcode send model with the updated code, but the file is not saved to disk yet
         if self._source_lines is None:
             try:
                 self._source_lines = self._read_lines()

--- a/tests/linter/rules/custom_tests/rules_with_fix/custom_rules.py
+++ b/tests/linter/rules/custom_tests/rules_with_fix/custom_rules.py
@@ -1,0 +1,43 @@
+from robot.parsing.model.statements import Error
+
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, RuleSeverity, VisitorChecker
+
+
+class CustomWithFix(FixableRule):
+    """
+    Custom rule that does have a fix.
+
+    The fix is available only when reporting the issue.
+    """
+
+    name = "fixable-rule"
+    rule_id = "FIX01"
+    message = "Custom rule message"
+    severity = RuleSeverity.INFO
+    added_in_version = "8.0.0"
+    fix_availability = FixAvailability.ALWAYS
+
+
+class CustomChecker(VisitorChecker):
+    fixable_rule: CustomWithFix
+
+    def visit_File(self, node):  # noqa: N802
+        if isinstance(node.sections[0].body[-1], Error):  # placeholder added in first run
+            return
+        fix = Fix(
+            edits=[
+                TextEdit(
+                    rule_id=self.fixable_rule.rule_id,
+                    rule_name=self.fixable_rule.name,
+                    start_line=node.end_lineno,
+                    end_line=node.end_lineno,
+                    start_col=node.end_col_offset + 1,
+                    end_col=node.end_col_offset + 1,
+                    replacement="PLACEHOLDER",
+                )
+            ],
+            message="Replace last character of file with 'PLACEHOLDER'",
+            applicability=FixApplicability.SAFE,
+        )
+        self.report(self.fixable_rule, lineno=node.lineno, col=node.col_offset + 1, fix=fix)

--- a/tests/linter/rules/custom_tests/rules_with_fix/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/custom_tests/rules_with_fix/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 1 issue:
+- actual_fixed${/}test.robot:
+    1 x FIX01 (fixable-rule)
+
+Found 1 issue (1 fixed, 0 remaining).

--- a/tests/linter/rules/custom_tests/rules_with_fix/expected_fixed/test.robot
+++ b/tests/linter/rules/custom_tests/rules_with_fix/expected_fixed/test.robot
@@ -1,0 +1,3 @@
+*** Settings ***
+Documentation    Last line should have PLACEHOLDER added.
+PLACEHOLDER

--- a/tests/linter/rules/custom_tests/rules_with_fix/test.robot
+++ b/tests/linter/rules/custom_tests/rules_with_fix/test.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Documentation    Last line should have PLACEHOLDER added.

--- a/tests/linter/rules/custom_tests/rules_with_fix/test_rule.py
+++ b/tests/linter/rules/custom_tests/rules_with_fix/test_rule.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from tests.linter.utils import RuleAcceptance
+
+CUR_DIR = Path(__file__).parent
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_fix(self):
+        self.check_rule_fix(
+            src_files=["test.robot"],
+            expected_dir="expected_fixed",
+            select=["fixable-rule"],
+            custom_rules=[f"{CUR_DIR}/custom_rules.py"],
+        )


### PR DESCRIPTION
Add another method for registering the fix for the rule - when reporting the issue itself. Is is better to use fix() method in rule (because it's lazily loaded) but in some cases we may need access to more data not available in diagnostic itself. For those sitations we can now pass Fix() instance when reporting the issue.