### PR TITLE
fix: Fix #1422 - ReplaceWithVAR formatter replacing variables with item access

### DIFF
--- a/tests/formatter/formatters/ReplaceWithVAR/source/item_access.robot
+++ b/tests/formatter/formatters/ReplaceWithVAR/source/item_access.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+Variables with item access should be ignored
+    VAR    &{dict}=    a=1    b=2    c=3
+    ${dict}[a]=    Set Variable    0
+    ${container}    Get Container
+    ${container.item}    Set Variable    0
+    ${list}[0] =       Set Variable     first
+    ${list}[${1}] =    Set Variable     second
+    ${list}[2:3] =     Create List      third
+    ${container.item}    ${container.item2}    Set Variable    4    5
+    ${var}    ${container.item2}    Set Variable    4    5

--- a/tests/formatter/formatters/ReplaceWithVAR/test_formatter.py
+++ b/tests/formatter/formatters/ReplaceWithVAR/test_formatter.py
@@ -50,3 +50,6 @@ class TestReplaceWithVAR(FormatterAcceptanceTest):
 
     def test_match_assignment(self):
         self.compare(source="assignment_char.robot")
+
+    def test_item_access(self):
+        self.compare(source="item_access.robot", not_modified=True)


### PR DESCRIPTION
Fixes #1422

VAR can be only used for creating the variable, not updating the part of it. For that reason Robocop incorrectly replace   Set Variable to VAR . Now such code will be ignored.