### PR TITLE
feat: Variable type conversion - support duplicated-assigned-var-name rule

### DIFF
--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -11,6 +11,7 @@ from robocop.linter.utils.misc import (
     normalize_robot_var_name,
     strip_equals_from_assignment,
 )
+from robocop.version_handling import TYPE_SUPPORTED
 
 
 class DuplicatedTestCaseRule(Rule):
@@ -347,7 +348,7 @@ class DuplicationsChecker(VisitorChecker):
         seen = set()
         for var in assign:
             var_name = strip_equals_from_assignment(var.value)
-            name = normalize_robot_var_name(var_name)
+            name = normalize_robot_var_name(var_name, strip_type=TYPE_SUPPORTED)
             if not name:  # i.e. "${_}" -> ""
                 return
             if name in seen:

--- a/src/robocop/linter/utils/misc.py
+++ b/src/robocop/linter/utils/misc.py
@@ -79,8 +79,13 @@ def normalize_robot_name(name: str, remove_prefix: str | None = None) -> str:
     return name
 
 
-def normalize_robot_var_name(name: str) -> str:
-    return normalize_robot_name(name)[2:-1] if name else ""
+def normalize_robot_var_name(name: str, strip_type: bool = False) -> str:
+    if not name:
+        return ""
+    no_braces = name[2:-1]
+    if strip_type:
+        no_braces, *_ = no_braces.split(": ", 1)
+    return normalize_robot_name(no_braces)
 
 
 def remove_nested_variables(var_name: str) -> str:

--- a/tests/linter/rules/variables/duplicated_assigned_var_name/expected_extended_rf7_3.txt
+++ b/tests/linter/rules/variables/duplicated_assigned_var_name/expected_extended_rf7_3.txt
@@ -1,0 +1,86 @@
+test.robot:3:15 VAR12 Assigned variable name '${var}' is already used
+   |
+ 1 | *** Test Cases ***
+ 2 | Test
+ 3 |     ${var}    ${var}    My Keyword
+   |               ^^^^^^ VAR12
+ 4 |     FOR  ${i}  IN RANGE  10
+ 5 |         ${var}    ${var}    My Keyword
+   |
+
+test.robot:5:19 VAR12 Assigned variable name '${var}' is already used
+   |
+ 3 |     ${var}    ${var}    My Keyword
+ 4 |     FOR  ${i}  IN RANGE  10
+ 5 |         ${var}    ${var}    My Keyword
+   |                   ^^^^^^ VAR12
+ 6 |     END
+ 7 |     IF    ${condition}
+   |
+
+test.robot:9:23 VAR12 Assigned variable name '${var}' is already used
+   |
+ 7 |     IF    ${condition}
+ 8 |         IF    ${condition}
+ 9 |             ${var}    ${var}    My Keyword
+   |                       ^^^^^^ VAR12
+10 |         ELSE IF
+11 |             ${var}    ${var}    My Keyword
+   |
+
+test.robot:11:23 VAR12 Assigned variable name '${var}' is already used
+    |
+  9 |             ${var}    ${var}    My Keyword
+ 10 |         ELSE IF
+ 11 |             ${var}    ${var}    My Keyword
+    |                       ^^^^^^ VAR12
+ 12 |         END
+ 13 |     END
+    |
+
+test.robot:21:26 VAR12 Assigned variable name '${var}' is already used
+    |
+ 19 |     ${var}    My Keyword
+ 20 |     ${var}    My Keyword    ${var}
+ 21 |     ${var}    ${var2}    ${var}    My Keyword    ${var}
+    |                          ^^^^^^ VAR12
+ 22 |     ${var}    ${Va r}    My Keyword    ${var}
+ 23 |     ${var}
+    |
+
+test.robot:22:15 VAR12 Assigned variable name '${Va r}' is already used
+    |
+ 20 |     ${var}    My Keyword    ${var}
+ 21 |     ${var}    ${var2}    ${var}    My Keyword    ${var}
+ 22 |     ${var}    ${Va r}    My Keyword    ${var}
+    |               ^^^^^^^ VAR12
+ 23 |     ${var}
+ 24 |     ...    ${var}    My Keyword    ${var}
+    |
+
+test.robot:24:12 VAR12 Assigned variable name '${var}' is already used
+    |
+ 22 |     ${var}    ${Va r}    My Keyword    ${var}
+ 23 |     ${var}
+ 24 |     ...    ${var}    My Keyword    ${var}
+    |            ^^^^^^ VAR12
+    |
+
+test.robot:42:21 VAR12 Assigned variable name '${duplicate}' is already used
+    |
+ 40 |
+ 41 | Duplicated With Equal Sign
+ 42 |     ${duplicate}    ${duplicate}=    Keyword
+    |                     ^^^^^^^^^^^^^ VAR12
+    |
+
+test.robot:49:15 VAR12 Assigned variable name '${var: int}' is already used
+    |
+ 47 |
+ 48 | Variable Type Conversion
+ 49 |     ${var}    ${var: int}    My Keyword  # should be reported in 7.3
+    |               ^^^^^^^^^^^ VAR12
+ 50 |     ${var}    ${var:int}    My Keyword  # ignore
+    |
+
+Found 9 issues.

--- a/tests/linter/rules/variables/duplicated_assigned_var_name/expected_output_rf7_3.txt
+++ b/tests/linter/rules/variables/duplicated_assigned_var_name/expected_output_rf7_3.txt
@@ -1,0 +1,11 @@
+test.robot:3:15 [I] VAR12 Assigned variable name '${var}' is already used
+test.robot:5:19 [I] VAR12 Assigned variable name '${var}' is already used
+test.robot:9:23 [I] VAR12 Assigned variable name '${var}' is already used
+test.robot:11:23 [I] VAR12 Assigned variable name '${var}' is already used
+test.robot:21:26 [I] VAR12 Assigned variable name '${var}' is already used
+test.robot:22:15 [I] VAR12 Assigned variable name '${Va r}' is already used
+test.robot:24:12 [I] VAR12 Assigned variable name '${var}' is already used
+test.robot:42:21 [I] VAR12 Assigned variable name '${duplicate}' is already used
+test.robot:49:15 [I] VAR12 Assigned variable name '${var: int}' is already used
+
+Found 9 issues.

--- a/tests/linter/rules/variables/duplicated_assigned_var_name/test.robot
+++ b/tests/linter/rules/variables/duplicated_assigned_var_name/test.robot
@@ -44,3 +44,7 @@ Duplicated With Equal Sign
 Non Important Variable
     ${_}    ${middle}    ${_}    Unpack Tuple
     ${_}    ${middle}    ${_}=    Unpack Tuple
+
+Variable Type Conversion
+    ${var}    ${var: int}    My Keyword  # should be reported in 7.3
+    ${var}    ${var:int}    My Keyword  # ignore

--- a/tests/linter/rules/variables/duplicated_assigned_var_name/test_rule.py
+++ b/tests/linter/rules/variables/duplicated_assigned_var_name/test_rule.py
@@ -3,7 +3,23 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf7_3.txt", test_on_version=">=7.3")
 
     def test_extended(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+        self.check_rule(
+            src_files=["test.robot"],
+            expected_file="expected_extended_rf7_3.txt",
+            output_format="extended",
+            test_on_version=">=7.3",
+        )
+
+    def test_rule_before_typing(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version="<7.3")
+
+    def test_extende_before_typingd(self):
+        self.check_rule(
+            src_files=["test.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version="<7.3",
+        )


### PR DESCRIPTION
Add support for variable type conversion for duplicated-assigned-var-name rule. Relates #1399