### PR TITLE
feat: Add case_normalization parameter to enforce case by RenameKeywords

### DIFF
--- a/docs/formatter/formatters/RenameKeywords.md
+++ b/docs/formatter/formatters/RenameKeywords.md
@@ -65,6 +65,49 @@ By default, each word in the keyword case is capitalized. It can be configured u
         perform Action
     ```
 
+## Case normalization
+
+When converting the case, only the affected letter (first in sentence or first of each word) is affect. This is
+controled by ``case_normalization`` parameter (default "first_letter"):
+
+=== "Before"
+
+    ```robotframework
+    *** Keywords ***
+    keyword name
+        Keyword Call
+        EXECUTE actioN
+    ```
+
+=== "case_normalization = first_letter (default) | keyword_case = capitalize_words (default)"
+
+    ```robotframework
+    *** Keywords ***
+    Keyword Name
+        Keyword Call
+        EXECUTE ActioN
+    ```
+
+=== "case_normalization = full | keyword_case = capitalize_words (default)"
+
+    ```robotframework
+    *** Keywords ***
+    Keyword Name
+        Keyword Call
+        Execute Action
+    ```
+
+=== "case_normalization = full | keyword_case = capitalize_first"
+
+    ```robotframework
+    *** Keywords ***
+    Keyword name
+        Keyword call
+        Execute action
+    ```
+
+Use ``skip_keyword_call`` to ignore case normalization on selected keyword calls.
+
 ## Library name
 
 By default, the library name in the keyword name is ignored. Anything before the last dot in the name is considered as

--- a/src/robocop/formatter/skip.py
+++ b/src/robocop/formatter/skip.py
@@ -50,12 +50,17 @@ class Skip:
         return bool(self.keyword_call_names or self.keyword_call_pattern)
 
     def keyword_call(self, node: KeywordCall) -> bool:
-        if not getattr(node, "keyword", None) or not self.any_keword_call:
+        if not getattr(node, "keyword", None):
             return False
-        normalized = normalize_name(node.keyword)
+        return self.keyword_call_name(node.keyword)
+
+    def keyword_call_name(self, name: str) -> bool:
+        if not self.any_keword_call:
+            return False
+        normalized = normalize_name(name)
         if normalized in self.keyword_call_names:
             return True
-        return any(pattern.search(node.keyword) for pattern in self.keyword_call_pattern)
+        return any(pattern.search(name) for pattern in self.keyword_call_pattern)
 
     def setting(self, name: str) -> bool:
         if not self.skip_settings:

--- a/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full.robot
@@ -1,0 +1,52 @@
+*** Test Cases ***
+test
+    Keyword
+
+Rename Me
+    No Operation
+
+*** Keywords ***
+Rename Me
+   Also Rename This
+
+Rename Me 2
+    No Operation
+
+I Am Fine
+    But I Am Not
+
+Underscores Are Bad
+    Looks Like Python
+    library_with_underscore.Looks Like Python
+
+Keyword With Unicode And Non Latin
+    Eäi Saa Peittää
+    日本語
+    _
+    __
+
+Ignore ${var} Embedded
+    Also Ignore ${variable}['key'] Syntax
+
+Structures
+    FOR  ${var}  IN  1  2  3
+        IF  condition
+            Keyword
+        ELSE IF
+            Keyword
+        ELSE
+            Keyword
+        END
+            Keyword
+    END
+
+Double Underscores
+    No Operation
+
+All Upper Case
+    Connect To System Abc
+    Create Product DFG
+
+Underscores And. Dots
+    Foo. Bar Baz A B C
+    Foo Bar Baz

--- a/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full_first_letter.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full_first_letter.robot
@@ -1,0 +1,52 @@
+*** Test Cases ***
+test
+    Keyword
+
+Rename Me
+    No operation
+
+*** Keywords ***
+Rename me
+   Also rename this
+
+Rename me 2
+    No operation
+
+I am fine
+    But i am not
+
+Underscores are bad
+    Looks like python
+    library_with_underscore.Looks like python
+
+Keyword with unicode and non latin
+    Eäi saa peittää
+    日本語
+    _
+    __
+
+Ignore ${var} embedded
+    Also ignore ${variable}['key'] syntax
+
+Structures
+    FOR  ${var}  IN  1  2  3
+        IF  condition
+            Keyword
+        ELSE IF
+            Keyword
+        ELSE
+            Keyword
+        END
+            Keyword
+    END
+
+Double underscores
+    No operation
+
+All upper case
+    Connect to system abc
+    Create product dfg
+
+Underscores and. dots
+    Foo. bar baz a b c
+    foo bar baz

--- a/tests/formatter/formatters/RenameKeywords/test_formatter.py
+++ b/tests/formatter/formatters/RenameKeywords/test_formatter.py
@@ -92,3 +92,23 @@ class TestRenameKeywords(FormatterAcceptanceTest):
             expected="capitalize_first.robot",
             configure=[f"{self.FORMATTER_NAME}.keyword_case=capitalize_first"],
         )
+
+    def test_normalize_case_full(self):
+        self.compare(
+            source="test.robot",
+            expected="case_normalization_full.robot",
+            configure=[
+                f"{self.FORMATTER_NAME}.case_normalization=full",
+                f"{self.FORMATTER_NAME}.skip_keyword_call=CreateProductDFG",
+            ],
+        )
+
+    def test_normalize_case_full_first_letter(self):
+        self.compare(
+            source="test.robot",
+            expected="case_normalization_full_first_letter.robot",
+            configure=[
+                f"{self.FORMATTER_NAME}.case_normalization=full",
+                f"{self.FORMATTER_NAME}.keyword_case=capitalize_first",
+            ],
+        )


### PR DESCRIPTION
RenameKeywords renames the case according to keyword_case parameter. It only affected first letter of word, leaving rest untouched. Added new parameter case_normalization to control whether remaining letters should be normalized to lower case as well. Also added skip_keyword_call functionality to RenameKeywords formatter.

Closes #1418