### PR TITLE
fix: Fix format --extend-select not enabling formatters

### DIFF
--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -473,10 +473,11 @@ class FormattersLoader:
         return list(dict.fromkeys(selected))  # remove duplicates, order is preserved
 
     def load_formatters(self) -> None:
+        explicit_select: set[str] = set(self.select + self.extend_select)
         for formatter in self.selected_formatters():
             # formatter may be a single class or whole file / directory, so we need additional iterate
             for container in import_formatter(formatter, self.configurables, self.skip_config):
-                overwritten = container.name in self.select or formatter in self.select
+                overwritten = container.name in explicit_select or formatter in explicit_select
                 if overwritten:
                     enabled = True
                 elif "enabled" in container.args:

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -558,6 +558,20 @@ class TestConfigFinder:
             "It should be 'true' or 'false'" in normalized_error
         )
 
+    def test_extend_select_formatter(self, tmp_path, overwrite_config):
+        # Arrange
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("[tool.robocop.format]\nextend-select = ['IndentNestedKeywords']\n", encoding="utf-8")
+        resolver = ConfigResolver(load_formatters=True)
+
+        # Act
+        with working_directory(tmp_path):
+            config_manager = ConfigManager(overwrite_config=overwrite_config)
+            resolved_config = resolver.resolve_config(config_manager.default_config)
+
+        # Assert
+        assert "IndentNestedKeywords" in resolved_config.formatters
+
 
 class TestCacheConfigOverride:
     """Test that CLI cache options properly override config file cache settings."""

--- a/tests/formatter/formatters/ExternalTransformer/test_formatter.py
+++ b/tests/formatter/formatters/ExternalTransformer/test_formatter.py
@@ -47,7 +47,7 @@ class TestExternalTransformer(FormatterAcceptanceTest):
     @pytest.mark.parametrize("disabled_transformer", [DISABLED_TRANSFORMER, DISABLED_TRANSFORMER_REL])
     def test_load_disabled(self, disabled_transformer):
         self.run_tidy(extend_select=[str(disabled_transformer)], source="tests.robot")
-        self.compare_file("tests.robot", expected_name="tests_only_defaults.robot")
+        self.compare_file("tests.robot", expected_name="tests_with_defaults_lowercase.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     def test_load_from_module(self, module_path):


### PR DESCRIPTION
robocop check format --extend-select and robocop list formatters will now correctly take extend-select configuration into account.

Fixes #1666