### PR TITLE
feat: emit warning when select/extend-select/ignore use non existing rule

### DIFF
--- a/tests/linter/utils/__init__.py
+++ b/tests/linter/utils/__init__.py
@@ -233,8 +233,7 @@ class RuleAcceptance:
         expected = load_expected_file(test_data, expected_file, sort_lines=sort_lines)
         actual = normalize_result(parsed_results, test_data, sort_lines=sort_lines)
         if deprecated:
-            assert actual
-            assert "No rule selected" in actual[-1]
+            assert any("No rule selected" in line for line in actual)
             return
         if actual != expected:
             error = "Actual issues are different than expected.\n"


### PR DESCRIPTION
It should help debug incorrect configuration files and also catch possible Robocop bugs (if something is disabled but it shouldn't).

Also if someone uses "ALL" with other selects (unnecessary), uses rule both in select and extend-select, or in ignore and select (ignore takes precedence). If there is existing select/extend-select/ignore configuration and additional filtering is used (target version or threshold) it will also catch unnecessary filters.

Closes #1665 