### PR TITLE
feat: Ignore quoted parts when renaming or linting keyword name

### DIFF
--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -16,6 +16,7 @@ from robocop.linter import sonar_qube
 from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker, deprecated, variables
 from robocop.linter.utils import misc as utils
 from robocop.parsing.run_keywords import iterate_keyword_names
+from robocop.parsing.string_operations import get_unmasked_string
 from robocop.version_handling import ROBOT_VERSION, TYPE_SUPPORTED
 
 if TYPE_CHECKING:
@@ -813,7 +814,7 @@ class KeywordNamingChecker(VisitorChecker):
             case_naming_rule = self.wrong_case_in_keyword_name
         else:
             case_naming_rule = self.wrong_case_in_keyword_call
-        normalized = utils.remove_robot_vars(keyword_name)
+        normalized = get_unmasked_string(keyword_name)
         normalized = case_naming_rule.pattern.sub("", normalized)
         if not is_keyword_definition and "." in normalized:
             # remove potential library import

--- a/src/robocop/linter/utils/misc.py
+++ b/src/robocop/linter/utils/misc.py
@@ -288,35 +288,6 @@ def next_char_is(string: str, i: int, char: str) -> bool:
     return string[i + 1] == char
 
 
-def remove_robot_vars(name: str) -> str:
-    var_start = set("$@%&")
-    brackets = 0
-    open_bracket, close_bracket = "", ""
-    replaced = ""
-    index = 0
-    while index < len(name):
-        if brackets:
-            if name[index] == open_bracket:
-                brackets += 1
-            elif name[index] == close_bracket:
-                brackets -= 1
-            # check if next chars are not ['key']
-            if not brackets and next_char_is(name, index, "["):
-                brackets += 1
-                index += 1
-                open_bracket, close_bracket = "[", "]"
-        # it looks for $ (or other var starter) and then check if next char is { and previous is not escape \
-        elif name[index] in var_start and next_char_is(name, index, "{") and not (index and name[index - 1] == "\\"):
-            open_bracket = "{"
-            close_bracket = "}"
-            brackets += 1
-            index += 1
-        else:
-            replaced += name[index]
-        index += 1
-    return replaced
-
-
 def find_robot_vars(name: str) -> list[tuple[int, int]]:
     """Return list of tuples with (start, end) pos of vars in name"""
     var_start = set("$@%&")

--- a/src/robocop/parsing/string_operations.py
+++ b/src/robocop/parsing/string_operations.py
@@ -1,0 +1,89 @@
+from enum import Enum
+
+_VAR_PREFIXES = ("${", "@{", "&{", "%{")
+
+
+class StringPart(Enum):
+    MASKED = "masked"
+    UNMASKED = "unmasked"
+
+
+def map_string_to_mask(s: str) -> list[tuple[str, StringPart]]:
+    """
+    Map string to mask/unmask to make it possible to ignore part of strings in further processing.
+
+    Part of string that are enclosed with ', " or are Robot variables (${var}) are masked.
+
+    Returns:
+        list of tuple pairs: string part and MASKED/UNMASKED enum value.
+
+    """
+    if "'" not in s and '"' not in s and "{" not in s:
+        return [(s, StringPart.UNMASKED)]
+    n = len(s)
+    i = 0
+
+    out = []
+    buf_start = 0
+
+    while i < n:
+        # Variable block handling (outside quotes only)
+        for p in _VAR_PREFIXES:
+            if s.startswith(p, i):
+                out.append((s[buf_start:i], StringPart.UNMASKED))
+
+                depth = 1
+                j = i + 2
+                # find & ignore nested variables
+                while j < n and depth:
+                    for np in _VAR_PREFIXES:
+                        if s.startswith(np, j):
+                            depth += 1
+                            j += 2
+                            break
+                    else:
+                        if s[j] == "}":
+                            depth -= 1
+                        j += 1
+                # check for ${var}['item']
+                if j < n and s[j] == "[":
+                    bracket_end = s.find("]", j + 1)
+                    if bracket_end != -1:
+                        j = bracket_end + 1
+                out.append((s[i:j], StringPart.MASKED))
+                i = j
+                buf_start = i
+                break
+        if i >= n:
+            break
+        ch = s[i]
+
+        # Quote handling
+        if ch == "'":
+            quote_end = s.find("'", i + 1)
+            if quote_end != -1:
+                out.append((s[buf_start:i], StringPart.UNMASKED))
+                out.append((s[i : quote_end + 1], StringPart.MASKED))
+                i = quote_end + 1
+                buf_start = i
+                continue
+        if ch == '"':
+            quote_end = s.find('"', i + 1)
+            if quote_end != -1:
+                out.append((s[buf_start:i], StringPart.UNMASKED))
+                out.append((s[i : quote_end + 1], StringPart.MASKED))
+                i = quote_end + 1
+                buf_start = i
+                continue
+        i += 1
+
+    # remaining part
+    if buf_start < n:
+        out.append((s[buf_start:], StringPart.UNMASKED))
+
+    return out
+
+
+def get_unmasked_string(value: str) -> str:
+    """Return string with masked parts removed."""
+    return "".join(part for part, part_type in map_string_to_mask(value) if part_type == StringPart.UNMASKED)

--- a/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores And. Dots
     Foo. Bar Baz A B C
     Foo Bar Baz
+
+Quoted "${values_and_words}"
+    Values In Quotes "should REMAIN fully UNaffected"
+    Values In Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "

--- a/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full_first_letter.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/case_normalization_full_first_letter.robot
@@ -50,3 +50,11 @@ All upper case
 Underscores and. dots
     Foo. bar baz a b c
     foo bar baz
+
+Quoted "${values_and_words}"
+    Values in quotes "should REMAIN fully UNaffected"
+    Values in quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll need to test partial quotes
+    And "${variables}" and "some other ${variables}" "shall work"
+    And "nested quotation "should not be" considered " and single "

--- a/tests/formatter/formatters/RenameKeywords/expected/embedded_variables.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/embedded_variables.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Embedded ${variables} That Should Be ${ignored.and.dots}
-    Login With '{user.Uid}' And '${user.password}' To Check Validation
+    Login With '{user.uid}' And '${user.password}' To Check Validation
 
 Variable With Square Brackets
     Normalize This${variable['test']}

--- a/tests/formatter/formatters/RenameKeywords/expected/rename_pattern_partial.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/rename_pattern_partial.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores And. Dots
     Foo. BAR Baz A B C
     Foo Bar BAZ
+
+Quoted "${values_and_words}"
+    Values IN Quotes "should REMAIN fully UNaffected"
+    Values IN Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "

--- a/tests/formatter/formatters/RenameKeywords/expected/rename_pattern_whole.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/rename_pattern_whole.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores And. Dots
     Foo. BAR Baz A B C
     Foo Bar BAZ
+
+Quoted "${values_and_words}"
+    Values IN Quotes "should REMAIN fully UNaffected"
+    Values IN Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "

--- a/tests/formatter/formatters/RenameKeywords/expected/test.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/test.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores And. Dots
     Foo. BAR Baz A B C
     Foo Bar BAZ
+
+Quoted "${values_and_words}"
+    Values IN Quotes "should REMAIN fully UNaffected"
+    Values IN Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "

--- a/tests/formatter/formatters/RenameKeywords/expected/test_transform_library.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/test_transform_library.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores And. Dots
     Foo. BAR Baz A B C
     Foo Bar BAZ
+
+Quoted "${values_and_words}"
+    Values IN Quotes "should REMAIN fully UNaffected"
+    Values IN Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "

--- a/tests/formatter/formatters/RenameKeywords/expected/with_underscores.robot
+++ b/tests/formatter/formatters/RenameKeywords/expected/with_underscores.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores And. Dots
     Foo. BAR Baz A B C
     _Foo Bar BAZ
+
+Quoted "${values_and_words}"
+    Values IN Quotes "should REMAIN fully UNaffected"
+    Values IN Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "

--- a/tests/formatter/formatters/RenameKeywords/source/test.robot
+++ b/tests/formatter/formatters/RenameKeywords/source/test.robot
@@ -50,3 +50,11 @@ All Upper Case
 Underscores and. dots
     Foo. BAR Baz A b C
     _Foo bar BAZ
+
+Quoted "${values_and_words}"
+    Values IN quotes "should REMAIN fully UNaffected"
+    Values IN quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll need to test partial quotes
+    And "${variables}" and "some other ${variables}" "shall work"
+    And "nested quotation "should not be" considered " and single "

--- a/tests/linter/rules/naming/wrong_case_in_keyword_call/test.robot
+++ b/tests/linter/rules/naming/wrong_case_in_keyword_call/test.robot
@@ -111,3 +111,11 @@ Recognize Figure(s) (Math) From Picture
 
 Dot in name foo.bar
     No Operation
+
+Quoted "${values_and_words}"
+    Values IN Quotes "should REMAIN fully UNaffected"
+    Values IN Quotes 'should REMAIN fully UNaffected'
+    'Even if whole keyword is quote'
+    I'll Need To Test Partial Quotes
+    And "${variables}" And "some other ${variables}" "shall work"
+    And "nested quotation "Should Not Be" considered " And Single "


### PR DESCRIPTION
Quotes values are now ignored in RenameKeywords formatter and wrong-case-in-keyword-call rule.

Closes #1627