### PR TITLE
feat: Make MCP aware of local config

### DIFF
--- a/src/robocop/mcp/cache.py
+++ b/src/robocop/mcp/cache.py
@@ -21,14 +21,13 @@ def get_linter_config() -> ResolvedConfig:
         LinterConfig: The cached linter configuration with rules loaded.
 
     """
-    from robocop.config.builder import ConfigBuilder
-    from robocop.config.schema import RawConfig
+    from robocop.config.manager import ConfigManager
     from robocop.runtime.resolver import ConfigResolver
 
-    # TODO: It will not load configuration files. We should probably cache configuration manager instead
-    config = ConfigBuilder().from_raw(cli_raw=RawConfig(silent=True), file_raw=None)
+    manager = ConfigManager()
     resolver = ConfigResolver(load_rules=True)
-    return resolver.resolve_config(config)
+
+    return resolver.resolve_config(manager.default_config)
 
 
 @lru_cache(maxsize=1)
@@ -43,14 +42,13 @@ def get_formatter_config() -> ResolvedConfig:
         FormatterConfig: The cached formatter configuration with formatters loaded.
 
     """
-    from robocop.config.builder import ConfigBuilder
-    from robocop.config.schema import RawConfig
+    from robocop.config.manager import ConfigManager
     from robocop.runtime.resolver import ConfigResolver
 
-    # TODO: It will not load configuration files. We should probably cache configuration manager instead
-    config = ConfigBuilder().from_raw(cli_raw=RawConfig(silent=True), file_raw=None)
+    manager = ConfigManager()
     resolver = ConfigResolver(load_formatters=True)
-    return resolver.resolve_config(config)
+
+    return resolver.resolve_config(manager.default_config)
 
 
 def clear_cache() -> None:

--- a/src/robocop/mcp/tools/linting.py
+++ b/src/robocop/mcp/tools/linting.py
@@ -28,9 +28,9 @@ def _create_linter_config(
 ) -> RawLinterConfig:
     """Create a RawConfig with the given options."""
     return RawLinterConfig(
-        select=select or [],
-        ignore=ignore or [],
-        configure=configure or [],
+        select=select,
+        ignore=ignore,
+        configure=configure,
         threshold=_parse_threshold(threshold),
         return_result=True,
     )
@@ -74,13 +74,11 @@ def _lint_content_impl(
             config = RawConfig(sources=[str(tmp_path)], linter=linter_config, silent=True)
             config_manager = ConfigManager(
                 sources=[str(tmp_path)],
-                ignore_file_config=True,
                 overwrite_config=config,
             )
 
             linter = RobocopLinter(config_manager)
-            # FIXME it should find config for specific file, not just some random. and those overwrites
-            # for now config -> default_config
+            # Since it's content, not file - we are using the default project configuration instead of a specific one.
             source_file = SourceFile(path=tmp_path, config=config_manager.default_config)
             diagnostics = linter.run_check(source_file)
 
@@ -134,7 +132,6 @@ def _lint_file_impl(
         config = RawConfig(sources=[str(path)], linter=linter_config, silent=True)
         config_manager = ConfigManager(
             sources=[str(path)],
-            ignore_file_config=True,
             overwrite_config=config,
         )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,8 @@ import contextlib
 import os
 from pathlib import Path
 
+TEST_DATA_LINTER_DIR = Path(__file__).parent / "linter" / "test_data"
+
 
 @contextlib.contextmanager
 def working_directory(path: Path):

--- a/tests/linter/test_data/custom_rules/custom_with_config/custom_rules.py
+++ b/tests/linter/test_data/custom_rules/custom_with_config/custom_rules.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from robocop.linter.rules import VisitorChecker
+from robocop.linter.rules import Rule, RuleSeverity
+
+
+class ExternalRule(Rule):
+    """
+    Custom rule summary.
+
+    Custom rule documentation.
+    """
+    name = "smth"
+    rule_id = "EXT01"
+    message = "Keyword call after [Return] statement"
+    severity = RuleSeverity.ERROR
+
+
+
+class SmthChecker(VisitorChecker):
+    """Empty checker.."""
+
+    smth: ExternalRule

--- a/tests/linter/test_data/custom_rules/custom_with_config/robot.toml
+++ b/tests/linter/test_data/custom_rules/custom_with_config/robot.toml
@@ -1,0 +1,4 @@
+[tool.robocop.lint]
+custom-rules = [
+    "custom_rules.py"
+]

--- a/tests/mcp/test_resources.py
+++ b/tests/mcp/test_resources.py
@@ -6,11 +6,15 @@ import pytest
 from fastmcp.exceptions import ResourceError
 
 from robocop.mcp import mcp
+from robocop.mcp.cache import clear_cache
 from robocop.mcp.resources import (
     _get_formatters_catalog,
     _get_rule_details,
     _get_rules_catalog,
 )
+from tests import TEST_DATA_LINTER_DIR, working_directory
+
+CUSTOM_RULES_DIR = TEST_DATA_LINTER_DIR / "custom_rules" / "custom_with_config"
 
 
 class TestRulesCatalog:
@@ -62,6 +66,17 @@ class TestRulesCatalog:
         rule_ids = [r["rule_id"] for r in rules]
         assert len(rule_ids) == len(set(rule_ids))
 
+    def test_custom_rule_is_loaded(self):
+        """Test that custom rule is loaded using a configuration file found in root directory."""
+        clear_cache()
+
+        with working_directory(CUSTOM_RULES_DIR):
+            rules = _get_rules_catalog()
+
+        assert any(rule["rule_id"] == "EXT01" for rule in rules)
+
+        clear_cache()
+
 
 class TestFormattersCatalog:
     """Tests for formatters catalog resource."""
@@ -87,8 +102,24 @@ class TestFormattersCatalog:
     def test_formatters_catalog_has_normalize_separators(self):
         """Test that catalog includes NormalizeSeparators formatter."""
         formatters = _get_formatters_catalog()
-        names = [f["name"] for f in formatters]
+        names = {f["name"]: f["enabled"] for f in formatters}
         assert "NormalizeSeparators" in names
+        assert names["NormalizeSeparators"] is True
+
+    def test_formatters_catalog_loads_user_config(self, tmp_path):
+        """Test that catalog NormalizeSeparators is disabled reflecting user configuration."""
+        clear_cache()
+
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("[tool.robocop.format]\nconfigure=['NormalizeSeparators.enabled=False']")
+
+        with working_directory(tmp_path):
+            formatters = _get_formatters_catalog()
+
+        names = {f["name"]: f["enabled"] for f in formatters}
+        assert "NormalizeSeparators" not in names
+
+        clear_cache()
 
     def test_formatters_catalog_has_descriptions(self):
         """Test that all formatters have non-empty descriptions."""


### PR DESCRIPTION
MCP was ignoring local configuration. Switched to ContextManager for resource listing, linting & formatting so it finds the configuration file closest to project root (if any).

MCP should also support custom rules / formatters.