### PR TITLE
fix: Fix circular import error due to ConfigManager split from config.py

### DIFF
--- a/src/robocop/cache.py
+++ b/src/robocop/cache.py
@@ -20,7 +20,7 @@ from robocop.source_file import SourceFile
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic
     from robocop.runtime.resolved_config import ResolvedConfig
 

--- a/src/robocop/config/__init__.py
+++ b/src/robocop/config/__init__.py
@@ -1,4 +1,0 @@
-from robocop.config.manager import ConfigManager
-from robocop.config.schema import Config
-
-__all__ = ["Config", "ConfigManager"]

--- a/src/robocop/formatter/runner.py
+++ b/src/robocop/formatter/runner.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 
     from robot.parsing import File
 
-    from robocop.config import Config
     from robocop.config.manager import ConfigManager
+    from robocop.config.schema import Config
     from robocop.runtime.resolved_config import ResolvedConfig
 
 

--- a/src/robocop/linter/reports/__init__.py
+++ b/src/robocop/linter/reports/__init__.py
@@ -12,7 +12,7 @@ from robocop.linter.utils.misc import get_robocop_cache_directory
 from robocop.runtime.resolver import LinterImporter
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
 
 
 class Report:

--- a/src/robocop/linter/reports/file_stats_report.py
+++ b/src/robocop/linter/reports/file_stats_report.py
@@ -6,7 +6,7 @@ import robocop.linter.reports
 from robocop.linter.utils.misc import get_plural_form, get_string_diff
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic, Diagnostics
 
 

--- a/src/robocop/linter/reports/gitlab.py
+++ b/src/robocop/linter/reports/gitlab.py
@@ -9,7 +9,7 @@ from robocop.files import get_relative_path
 from robocop.linter.rules import RuleSeverity
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic, Diagnostics
 
 

--- a/src/robocop/linter/reports/json_report.py
+++ b/src/robocop/linter/reports/json_report.py
@@ -7,7 +7,7 @@ import robocop.linter.reports
 from robocop.files import get_relative_path
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic, Diagnostics
 
 

--- a/src/robocop/linter/reports/print_issues.py
+++ b/src/robocop/linter/reports/print_issues.py
@@ -15,7 +15,7 @@ from robocop.files import get_relative_path
 from robocop.formatter.utils.misc import decorate_diff_with_color
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic, Diagnostics, RunStatistic
     from robocop.source_file import SourceFile
 

--- a/src/robocop/linter/reports/return_status_report.py
+++ b/src/robocop/linter/reports/return_status_report.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import robocop.linter.reports
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostics
     from robocop.linter.rules import RuleSeverity
 

--- a/src/robocop/linter/reports/robocop_version_report.py
+++ b/src/robocop/linter/reports/robocop_version_report.py
@@ -6,7 +6,7 @@ import robocop.linter.reports
 from robocop import __version__
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
 
 
 class RobocopVersionReport(robocop.linter.reports.ComparableReport):

--- a/src/robocop/linter/reports/rules_by_id_report.py
+++ b/src/robocop/linter/reports/rules_by_id_report.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import robocop.linter.reports
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostics
 
 

--- a/src/robocop/linter/reports/rules_by_severity_report.py
+++ b/src/robocop/linter/reports/rules_by_severity_report.py
@@ -8,7 +8,7 @@ from robocop.linter.rules import RuleSeverity
 from robocop.linter.utils.misc import get_plural_form, get_string_diff
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostics
 
 

--- a/src/robocop/linter/reports/sarif.py
+++ b/src/robocop/linter/reports/sarif.py
@@ -9,8 +9,8 @@ from robocop.files import get_relative_path
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from robocop.config import Config
     from robocop.config.manager import ConfigManager
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostics
     from robocop.linter.rules import Rule, RuleSeverity
     from robocop.runtime.resolved_config import ResolvedConfig

--- a/src/robocop/linter/reports/sonarqube.py
+++ b/src/robocop/linter/reports/sonarqube.py
@@ -11,8 +11,8 @@ from robocop.linter.rules import RuleSeverity
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from robocop.config import Config
     from robocop.config.manager import ConfigManager
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic, Diagnostics
     from robocop.linter.rules import Rule
 

--- a/src/robocop/linter/reports/text_file.py
+++ b/src/robocop/linter/reports/text_file.py
@@ -8,7 +8,7 @@ from robocop.exceptions import FatalError
 from robocop.files import get_relative_path
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostics
 
 

--- a/src/robocop/linter/reports/time_taken_report.py
+++ b/src/robocop/linter/reports/time_taken_report.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import robocop.linter.reports
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
 
 
 class TimeTakenReport(robocop.linter.reports.ComparableReport):

--- a/src/robocop/linter/reports/timestamp_report.py
+++ b/src/robocop/linter/reports/timestamp_report.py
@@ -10,7 +10,7 @@ import robocop.linter.reports
 from robocop import exceptions
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
 
 
 class TimestampReport(robocop.linter.reports.Report):

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -22,8 +22,8 @@ from robocop.source_file import SourceFile, VirtualSourceFile
 if TYPE_CHECKING:
     from robot.parsing import File
 
-    from robocop.config import Config
     from robocop.config.manager import ConfigManager
+    from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic
 
 

--- a/src/robocop/mcp/tools/documentation.py
+++ b/src/robocop/mcp/tools/documentation.py
@@ -263,7 +263,7 @@ def _list_prompts_impl(mcp: FastMCP) -> list[PromptSummary]:
             if prompt.arguments
             else [],
         )
-        for prompt in mcp._prompt_manager._prompts.values()  # noqa: SLF001
+        for prompt in mcp._prompt_manager._prompts.values()  # type: ignore[attr-defined] # noqa: SLF001
     ]
     return sorted(prompts, key=lambda p: p.name)
 

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -393,7 +393,7 @@ def check_files(
         verbose=verbose,
         target_version=target_version,
     )
-    manager = config.ConfigManager(
+    manager = config.manager.ConfigManager(
         sources=sources,
         config=configuration_file,
         root=root,
@@ -509,7 +509,7 @@ def check_project(
         silent=silent,
         target_version=target_version,
     )
-    manager = config.ConfigManager(
+    manager = config.manager.ConfigManager(
         sources=sources,
         config=configuration_file,
         root=root,
@@ -731,7 +731,7 @@ def format_files(
         silent=silent,
         target_version=target_version,
     )
-    manager = config.ConfigManager(
+    manager = config.manager.ConfigManager(
         sources=sources,
         config=configuration_file,
         root=root,
@@ -784,7 +784,7 @@ def list_rules(
         silent=silent,
         target_version=target_version,
     )
-    manager = config.ConfigManager(overwrite_config=overwrite_config)
+    manager = config.manager.ConfigManager(overwrite_config=overwrite_config)
     resolver = ConfigResolver(load_rules=True)
     resolved_config = resolver.resolve_config(manager.default_config)
     if filter_pattern:
@@ -840,7 +840,7 @@ def list_reports(
     console = Console(soft_wrap=True)
     linter_config = config.schema.RawLinterConfig(reports=reports)
     overwrite_config = config.schema.RawConfig(linter=linter_config, silent=silent)
-    manager = config.ConfigManager(overwrite_config=overwrite_config)
+    manager = config.manager.ConfigManager(overwrite_config=overwrite_config)
     runner = RobocopLinter(manager)
     if not silent:
         console.print(print_reports(runner.reports, enabled))  # TODO: color etc
@@ -861,7 +861,7 @@ def list_formatters(
     overwrite_config = config.schema.RawConfig(
         silent=silent, target_version=target_version, formatter=config.schema.RawFormatterConfig(allow_disabled=True)
     )
-    manager = config.ConfigManager(overwrite_config=overwrite_config)
+    manager = config.manager.ConfigManager(overwrite_config=overwrite_config)
     resolver = ConfigResolver(load_rules=True, load_formatters=True)
     resolved_config = resolver.resolve_config(manager.default_config)
 
@@ -894,7 +894,7 @@ def print_resource_documentation(name: Annotated[str, typer.Argument(help="Rule 
     """Print formatter, rule or report documentation."""
     # TODO load external from cli
     console = Console(soft_wrap=True)
-    manager = config.ConfigManager()
+    manager = config.manager.ConfigManager()
     resolver = ConfigResolver(load_rules=True, load_formatters=True)
     resolved_config = resolver.resolve_config(manager.default_config)
 

--- a/src/robocop/source_file.py
+++ b/src/robocop/source_file.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from robot.parsing.model import File
     from robot.parsing.model.statements import Statement
 
-    from robocop.config import Config
+    from robocop.config.schema import Config
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from robocop.config.builder import ConfigBuilder
 
 if TYPE_CHECKING:
-    from robocop.config import Config
+    from robocop.config.schema import Config
 
 # We are appending tests directory to sys path so we can use tests utils inside tests
 sys.path.append(str(Path(__file__).parent.parent))


### PR DESCRIPTION
Due to refactor of our configuration handling ConfigManager was also moved under config/. For backward compatiblity reasons I re-imported it in ``config.__init__.py`` but that led to circular imports in specific situations.

Fixes #1694 