### PR TITLE
fix: ensure that configuration files are loaded in the order (robocop.toml > robot.toml > pyproject.toml)

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -25,11 +25,11 @@ Robocop uses a configuration file closest to the source, which allows multiple c
 that apply to the entire execution (such as ``--exit-zero`` or report settings) are exclusively read from the top-level
 configuration file.
 
-When looking for the configuration file, Robocop searches either for:
+When looking for the configuration file, Robocop searches in the following order:
 
+- ``robocop.toml``
+- ``robot.toml``
 - ``pyproject.toml``
-- or ``robocop.toml``
-- or ``robot.toml``
 
 It will visit parent directories until it finds root of the project determined by existence of ``.git`` directory.
 This behaviour can be disabled with ``--ignore-git-dir``.

--- a/src/robocop/config/manager.py
+++ b/src/robocop/config/manager.py
@@ -16,7 +16,7 @@ from robocop.source_file import SourceFile
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
-CONFIG_NAMES = frozenset(("robocop.toml", "pyproject.toml", "robot.toml"))
+CONFIG_NAMES = ("robocop.toml", "robot.toml", "pyproject.toml")
 
 
 class GitIgnoreResolver:

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -572,6 +572,28 @@ class TestConfigFinder:
         # Assert
         assert "IndentNestedKeywords" in resolved_config.formatters
 
+    def test_config_order(self, tmp_path):
+        # Single file
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("[tool.robocop]\nverbose = true\n", encoding="utf-8")
+        with working_directory(tmp_path):
+            config_manager = ConfigManager()
+        assert config_manager.default_config.config_source.endswith("pyproject.toml")
+
+        # Two files
+        config_file = tmp_path / "robot.toml"
+        config_file.write_text("[tool.robocop]\nverbose = true\n", encoding="utf-8")
+        with working_directory(tmp_path):
+            config_manager = ConfigManager()
+        assert config_manager.default_config.config_source.endswith("robot.toml")
+
+        # Three files
+        config_file = tmp_path / "robocop.toml"
+        config_file.write_text("[tool.robocop]\nverbose = true\n", encoding="utf-8")
+        with working_directory(tmp_path):
+            config_manager = ConfigManager()
+        assert config_manager.default_config.config_source.endswith("robocop.toml")
+
 
 class TestCacheConfigOverride:
     """Test that CLI cache options properly override config file cache settings."""

--- a/tests/config/test_data/multiple_configs_one_dir/pyproject.toml
+++ b/tests/config/test_data/multiple_configs_one_dir/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.robocop]
+verbose = false

--- a/tests/config/test_data/multiple_configs_one_dir/robocop.toml
+++ b/tests/config/test_data/multiple_configs_one_dir/robocop.toml
@@ -1,0 +1,2 @@
+[tool.robocop]
+verbose = true

--- a/tests/config/test_data/multiple_configs_one_dir/robot.toml
+++ b/tests/config/test_data/multiple_configs_one_dir/robot.toml
@@ -1,0 +1,2 @@
+[tool.robot.format]
+diff = true


### PR DESCRIPTION
Fixes #1709 
Fixes #1727