### PR TITLE
fix: Keyword naming rules with library import with underscores is now detected properly

### DIFF
--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -825,6 +825,8 @@ class KeywordNamingChecker(VisitorChecker):
                 if " " in part:
                     normalized = ".".join(parts[i:])
                     break
+            else:
+                normalized = parts[-1]
         normalized = normalized.replace("'", "")  # replace ' apostrophes
         if "_" in normalized:
             self.report(

--- a/tests/linter/rules/naming/wrong_case_in_keyword_call/test.robot
+++ b/tests/linter/rules/naming/wrong_case_in_keyword_call/test.robot
@@ -119,3 +119,9 @@ Quoted "${values_and_words}"
     I'll Need To Test Partial Quotes
     And "${variables}" And "some other ${variables}" "shall work"
     And "nested quotation "Should Not Be" considered " And Single "
+
+Library With Underscore
+    # Bug #1733
+    fk_CommonXml.Compare
+    fk_CommonXml.Compare    ${argument}
+    fk_CommonXml.Compare With Words    ${argument}


### PR DESCRIPTION
Fixes #1733 