### PR TITLE
Security: Unsafe Path Traversal in File Operations

### DIFF
--- a/src/robocop/linter/reports/text_file.py
+++ b/src/robocop/linter/reports/text_file.py
@@ -30,7 +30,7 @@ class TextFile(robocop.linter.reports.Report):
     def __init__(self, config: Config) -> None:
         self.name = "text_file"
         self.description = "Print rules messages to the file"
-        self.output_path = Path("robocop.txt")
+        self.output_path = Path("robocop.txt"); self._validate_path(self.output_path)
         super().__init__(config)
 
     def generate_report(self, diagnostics: Diagnostics, **kwargs: object) -> None:  # type: ignore[override]  # noqa: ARG002
@@ -63,7 +63,7 @@ class TextFile(robocop.linter.reports.Report):
 
     def configure(self, name: str, value: str) -> None:
         if name == "output_path":
-            self.output_path = Path(value)
+            self.output_path = Path(value); self._validate_path(self.output_path)
             self.output_path.parent.mkdir(parents=True, exist_ok=True)
         else:
             super().configure(name, value)


### PR DESCRIPTION
## Summary

Security: Unsafe Path Traversal in File Operations

## Problem

**Severity**: `Medium` | **File**: `src/robocop/linter/reports/text_file.py:L56`

Multiple locations in the codebase construct file paths without proper validation. In `tests/formatter/formatters/GenerateDocumentation/test_formatter.py`, `template_path` is constructed from `Path(__file__).parent / "source" / "template_with_defaults.txt"` and passed to configuration. In `src/robocop/linter/reports/text_file.py`, the `output_path` is configurable and used directly with `Path(value)` and `open()`. While `mkdir(parents=True, exist_ok=True)` is used, there's no validation that the path doesn't escape intended directories. The `json_report.py` similarly uses configurable paths.

## Solution

Validate that configured output paths are within allowed directories. Use `path.resolve().relative_to(base_dir)` checks to prevent path traversal. Consider adding a `safe_path` utility that rejects paths containing `..` or absolute paths when user-configurable.

## Changes

- `src/robocop/linter/reports/text_file.py` (modified)