### PR TITLE
fix: References to upstream `click` causing further side effects (#1754)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ maintainers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "click>=8.0.0",
     "jinja2>=3.1.4",
     "robotframework>=5.0,<7.5",
     "typer>=0.12.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "jinja2>=3.1.4",
     "robotframework>=5.0,<7.5",
-    "typer>=0.12.5",
+    "typer>=0.26.0",
     "rich>=10.11.0",
     "tomli==2.2.1; python_version < '3.11'",
     "tomli-w>=1.0",

--- a/src/robocop/config/parser.py
+++ b/src/robocop/config/parser.py
@@ -6,8 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-import click
 import typer
+from typer._click.exceptions import FileError
 
 try:
     import tomllib as toml  # type: ignore[import-not-found]
@@ -141,7 +141,7 @@ def load_toml_file(config_path: Path) -> dict[str, Any]:
             config: dict[str, Any] = toml.load(tf)
             return config
     except (toml.TOMLDecodeError, OSError) as e:
-        raise click.FileError(filename=str(config_path), hint=f"Error reading configuration file: {e}") from None
+        raise FileError(filename=str(config_path), hint=f"Error reading configuration file: {e}") from None
 
 
 def merge_dicts(dict1: dict[str, Any], dict2: dict[str, Any]) -> dict[str, Any]:

--- a/src/robocop/formatter/runner.py
+++ b/src/robocop/formatter/runner.py
@@ -50,7 +50,7 @@ class RobocopFormatter:
                 # if str(source) == "-":
                 #     stdin = True
                 #     if self.config.verbose:
-                #         click.echo("Loading file from stdin")
+                #         typer.echo("Loading file from stdin")
                 #     source = self.load_from_stdin()
                 if self.config.verbose:
                     print(f"Formatting {source_file.path} file")

--- a/src/robocop/formatter/utils/misc.py
+++ b/src/robocop/formatter/utils/misc.py
@@ -5,7 +5,7 @@ import difflib
 import re
 from typing import TYPE_CHECKING
 
-import click
+import typer
 from rich.markup import escape
 from robot.api.parsing import Comment, End, If, IfHeader, ModelVisitor, Token
 from robot.parsing.model import Statement
@@ -19,7 +19,7 @@ def validate_regex(value: str | None) -> re.Pattern[str] | None:
     try:
         return re.compile(value) if value is not None else None
     except re.error:
-        raise click.BadParameter("Not a valid regular expression") from None
+        raise typer.BadParameter("Not a valid regular expression") from None
 
 
 def decorate_diff_with_color(contents: list[str]) -> list[str]:

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -1,12 +1,11 @@
 import textwrap
+from importlib import metadata
 from pathlib import Path
 from typing import Annotated, Any
 
-import click
 import typer
 from rich.console import Console
 
-from robocop import __version__
 from robocop.config import defaults, manager, parser, schema
 from robocop.formatter.runner import RobocopFormatter
 from robocop.linter import rules_list
@@ -20,11 +19,7 @@ from robocop.runtime.resolver import ConfigResolver
 
 
 class CliWithVersion(typer.core.TyperGroup):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        click.version_option(version=__version__)(self)
-
-    def list_commands(self, ctx: click.Context) -> list[str]:  # noqa: ARG002
+    def list_commands(self, ctx: Any) -> list[str]:  # noqa: ARG002
         """Return the list of commands in the set order."""
         commands = ["check", "check-project", "format", "list", "docs"]
         for command in self.commands:
@@ -43,6 +38,28 @@ app = typer.Typer(
 )
 list_app = typer.Typer(help="List available rules, reports or formatters.")
 app.add_typer(list_app, name="list")
+
+
+def version_callback(value: bool | None) -> None:
+    if not value:
+        return
+    typer.echo(f"robocop, version {metadata.version('robotframework-robocop')}")
+    raise typer.Exit
+
+
+@app.callback()
+def main_callback(
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            help="Show the version and exit.",
+            callback=version_callback,
+            is_eager=True,
+        ),
+    ] = None,
+) -> None:
+    """Run Robocop."""
 
 
 config_option = Annotated[

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -12,7 +12,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
-import click
+import typer
 
 try:
     from robot.api import Languages  # RF 6.0
@@ -164,7 +164,7 @@ class RuleMatcher:
         ]
 
         if errors:
-            click.echo("\n".join(errors), err=True)
+            typer.echo("\n".join(errors), err=True)
 
 
 def is_checker(checker_class_def: tuple[str, type]) -> bool:
@@ -189,14 +189,14 @@ def can_run_in_robot_version(formatter: Formatter, overwritten: bool, target_ver
     if overwritten:
         # --select FormatterDisabledInVersion or --configure FormatterDisabledInVersion.enabled=True
         if target_version == ROBOT_VERSION.major:
-            click.echo(
+            typer.echo(
                 f"{formatter.__class__.__name__} formatter requires Robot Framework {min_version}.* "
                 f"version but you have {ROBOT_VERSION} installed. "
                 f"Upgrade installed Robot Framework if you want to use this formatter.",
                 err=True,
             )
         else:
-            click.echo(
+            typer.echo(
                 f"{formatter.__class__.__name__} formatter requires Robot Framework {min_version}.* "
                 f"version but you set --target-version rf{target_version}. "
                 f"Set --target-version to {min_version} or do not forcefully enable this formatter "

--- a/tests/config/test_extend_config.py
+++ b/tests/config/test_extend_config.py
@@ -1,9 +1,9 @@
 import textwrap
 from pathlib import Path
 
-import click
 import pytest
 import typer
+from typer._click.exceptions import FileError
 
 from robocop.config.parser import read_toml_config
 from robocop.config.schema import RawConfig
@@ -115,7 +115,7 @@ class TestExtendConfig:
         # Arrange
         config_path = DATA_DIR / "extends" / "invalid.toml"
         # Act
-        with pytest.raises(click.FileError) as exc_info:
+        with pytest.raises(FileError) as exc_info:
             read_toml_config(config_path)
         # Assert
         assert (
@@ -199,7 +199,7 @@ class TestExtendConfig:
             """,
         )
         # Act
-        with pytest.raises(click.FileError) as exc_info:
+        with pytest.raises(FileError) as exc_info:
             read_toml_config(config_path)
         # Assert
         assert "Error reading configuration file: [Errno 2] No such file or directory:" in exc_info.value.message

--- a/tests/formatter/__init__.py
+++ b/tests/formatter/__init__.py
@@ -4,8 +4,8 @@ import filecmp
 from difflib import unified_diff
 from pathlib import Path
 
-import click
 import pytest
+import typer
 from packaging import version
 from packaging.specifiers import SpecifierSet
 from rich.console import Console
@@ -91,7 +91,7 @@ class FormatterAcceptanceTest:
             source_path = self.FORMATTERS_DIR / self.FORMATTER_NAME / "source"
         else:
             source_path = self.FORMATTERS_DIR / self.FORMATTER_NAME / "source" / source
-        with pytest.raises(click.exceptions.Exit) as exc_info:
+        with pytest.raises(typer.Exit) as exc_info:
             format_files(
                 sources=[source_path],
                 select=select,

--- a/tests/linter/utils/__init__.py
+++ b/tests/linter/utils/__init__.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
 
-import click.exceptions
 import pytest
+import typer
 from rich.console import Console
 
 from robocop.run import check_files, check_project
@@ -132,7 +132,7 @@ class RuleAcceptance:
         configure.append(f"print_issues.output_format={output_format}")
         with isolated_output() as output, working_directory(test_data):
             try:
-                with pytest.raises(click.exceptions.Exit) as exc_info:
+                with pytest.raises(typer.Exit) as exc_info:
                     test_fn(
                         sources=paths,
                         select=select,
@@ -202,7 +202,7 @@ class RuleAcceptance:
 
         with isolated_output() as output, working_directory(test_data):
             try:
-                with pytest.raises(click.exceptions.Exit):
+                with pytest.raises(typer.Exit):
                     check_files(
                         sources=paths,
                         select=select,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,12 @@
 """Test CLI commands / options common for linter and formatter."""
 
+from importlib import metadata
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
-from robocop import __version__
 from robocop.run import app
 from robocop.version_handling import ROBOT_VERSION
 from tests import working_directory
@@ -15,7 +15,7 @@ from tests import working_directory
 def test_version():
     runner = CliRunner()
     result = runner.invoke(app, ["--version"])
-    assert result.stdout == f"robocop, version {__version__}\n"
+    assert result.stdout == f"robocop, version {metadata.version('robotframework-robocop')}\n"
 
 
 def test_print_docs_rule():

--- a/uv.lock
+++ b/uv.lock
@@ -2062,7 +2062,6 @@ wheels = [
 name = "robotframework-robocop"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
     { name = "jinja2" },
     { name = "msgpack" },
     { name = "pathspec" },
@@ -2111,7 +2110,6 @@ mcp = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.0.0" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0.0" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "msgpack", specifier = ">=1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2120,7 +2129,7 @@ requires-dist = [
     { name = "robotframework", specifier = ">=5.0,<7.5" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = "==2.2.1" },
     { name = "tomli-w", specifier = ">=1.0" },
-    { name = "typer", specifier = ">=0.12.5" },
+    { name = "typer", specifier = ">=0.26.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 provides-extras = ["mcp"]
@@ -2427,17 +2436,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.20.1"
+version = "0.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/c1/933d30fd7a123ed981e2a1eedafceab63cb379db0402e438a13bc51bbb15/typer-0.20.1.tar.gz", hash = "sha256:68585eb1b01203689c4199bc440d6be616f0851e9f0eb41e4a778845c5a0fd5b", size = 105968, upload-time = "2025-12-19T16:48:56.302Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/26/8e9a4f2c98caefcf4ac25788d48939516a9dd4265fcf9bdd578a2a1b55dd/typer-0.26.1.tar.gz", hash = "sha256:537d27ae686d82967f6383382a952cb32ba4768898541effccb69ca75bbd5d23", size = 198884, upload-time = "2026-05-26T17:49:07.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/52/1f2df7e7d1be3d65ddc2936d820d4a3d9777a54f4204f5ca46b8513eff77/typer-0.20.1-py3-none-any.whl", hash = "sha256:4b3bde918a67c8e03d861aa02deca90a95bbac572e71b1b9be56ff49affdb5a8", size = 47381, upload-time = "2025-12-19T16:48:53.679Z" },
+    { url = "https://files.pythonhosted.org/packages/be/27/8a22d4833fe8aa0836ce7fa59096ad50d7e93b83be6d5383f11f9a140d54/typer-0.26.1-py3-none-any.whl", hash = "sha256:933e4f0083521f3c57d6a5aedf3b073271b2f95a19761b171b494dd6fdb21ff6", size = 123097, upload-time = "2026-05-26T17:49:09.065Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request removes the dependency on `click` and fully migrates the CLI and related error handling to use `typer` and its APIs. It updates imports, exception handling, and test code accordingly. Additionally, it refactors the version display logic to use `importlib.metadata` for version retrieval.

Key changes include:

**Dependency and Import Cleanup:**
- Removed `click` from the dependencies in `pyproject.toml` and all code imports, replacing them with `typer` or `typer._click.exceptions` where necessary. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L14) [[2]](diffhunk://#diff-ef02154bf08dbf2bcfb6cf8a1bea4a087ecb75b6fa3fde2171869c8aef2c322dL9-R10) [[3]](diffhunk://#diff-6d281692e3cfbb845850a1cc2a52dcbe4f780a3e0eca0a62061a4b1e59387176L8-R8) [[4]](diffhunk://#diff-d3678702427c86574e7f6cbf0ff266ae2d4dfa4b4fb15a22e918a9ee3d7081daL15-R15) [[5]](diffhunk://#diff-9b47de8c9205937ddad340f49a7e4be57c4df38727ceb20eebff05f56b54cf64L4-R6) [[6]](diffhunk://#diff-322c36b3f022c20ceb85ae11a42c1a085e4f73f4f90911eed16bae4931eba71cL7-R8) [[7]](diffhunk://#diff-c9ee72e2535d54df1566050d67d883fbac55fe6f722b78c79ac508905c32f24bL15-R16)

**Error and Exception Handling:**
- Replaced all uses of `click.FileError` and `click.BadParameter` with `typer` equivalents throughout the codebase and tests, ensuring consistent error handling. [[1]](diffhunk://#diff-ef02154bf08dbf2bcfb6cf8a1bea4a087ecb75b6fa3fde2171869c8aef2c322dL144-R144) [[2]](diffhunk://#diff-6d281692e3cfbb845850a1cc2a52dcbe4f780a3e0eca0a62061a4b1e59387176L22-R22) [[3]](diffhunk://#diff-9b47de8c9205937ddad340f49a7e4be57c4df38727ceb20eebff05f56b54cf64L118-R118) [[4]](diffhunk://#diff-9b47de8c9205937ddad340f49a7e4be57c4df38727ceb20eebff05f56b54cf64L202-R202)

**CLI Output and Echo:**
- Updated all `click.echo` calls to `typer.echo` for output and error messages. [[1]](diffhunk://#diff-20ced7f99a1d823d5ebd8faf5b329a9852e6db1fb2ec27464e851c7b186f0eeeL53-R53) [[2]](diffhunk://#diff-d3678702427c86574e7f6cbf0ff266ae2d4dfa4b4fb15a22e918a9ee3d7081daL167-R167) [[3]](diffhunk://#diff-d3678702427c86574e7f6cbf0ff266ae2d4dfa4b4fb15a22e918a9ee3d7081daL192-R199)

**CLI Version Handling:**
- Refactored version reporting to use a `--version` option handled via a `typer` callback, retrieving the version with `importlib.metadata` instead of importing from the package. [[1]](diffhunk://#diff-a2da9031064e5cac6561f3d11abd20467fa404512e54d483d103cb3650acdce7R2-L9) [[2]](diffhunk://#diff-a2da9031064e5cac6561f3d11abd20467fa404512e54d483d103cb3650acdce7L23-R22) [[3]](diffhunk://#diff-a2da9031064e5cac6561f3d11abd20467fa404512e54d483d103cb3650acdce7R43-R64) [[4]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR3-L9) [[5]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL18-R18)

**Test Suite Updates:**
- Updated all test cases to use `typer.Exit` and related exceptions instead of `click` exceptions, ensuring tests remain valid after the migration. [[1]](diffhunk://#diff-322c36b3f022c20ceb85ae11a42c1a085e4f73f4f90911eed16bae4931eba71cL94-R94) [[2]](diffhunk://#diff-c9ee72e2535d54df1566050d67d883fbac55fe6f722b78c79ac508905c32f24bL135-R135) [[3]](diffhunk://#diff-c9ee72e2535d54df1566050d67d883fbac55fe6f722b78c79ac508905c32f24bL205-R205)

These changes collectively modernize the CLI implementation, streamline dependencies, and improve maintainability by unifying on the `typer` library.

**Issues:**
Closes #1754 .