### PR TITLE
feat: keep first setting argument on the setting line in SplitTooLongLine

### DIFF
--- a/docs/formatter/formatters/SplitTooLongLine.md
+++ b/docs/formatter/formatters/SplitTooLongLine.md
@@ -185,12 +185,15 @@ will result in:
     ```robotframework
     *** Keywords ***
     Arguments
-        [Arguments]
-        ...    ${short}
+        [Arguments]    ${short}
         ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
         ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
         Step
     ```
+
+    The first argument is kept on the same line as the setting name and the remaining arguments are split one per
+    line. This follows the [Robot Framework style guide](https://docs.robotframework.org/docs/style_guide) and does
+    not conflict with the `first-argument-in-new-line` (SPC18) and `arguments-per-line` (ARG07) linter rules.
 
 === "After (split_on_every_setting_arg set to False)"
 

--- a/src/robocop/formatter/formatters/SplitTooLongLine.py
+++ b/src/robocop/formatter/formatters/SplitTooLongLine.py
@@ -90,6 +90,18 @@ class SplitTooLongLine(Formatter):
 
     ```
 
+    Settings such as ``[Arguments]`` and ``[Tags]`` keep their first argument on the same line as the setting
+    name and split the remaining arguments one per line. This follows the Robot Framework style guide and avoids
+    conflicts with the ``first-argument-in-new-line`` (SPC18) and ``arguments-per-line`` (ARG07) linter rules:
+
+    ```robotframework
+    *** Keywords ***
+    Keyword With Multiple Arguments
+        [Arguments]    ${first_argument}
+        ...    ${second_argument}
+        ...    ${third_argument}
+    ```
+
     Supports global formatting params: ``space-count`` and ``separator``.
     """
 
@@ -259,7 +271,13 @@ class SplitTooLongLine(Formatter):
             token_index = 2
         line: list[Token] = list(node.tokens[:token_index])
         tokens, comments = self.split_tokens(
-            node.tokens, line, self.split_on_every_setting_arg, indent, split_types=split_types, keep_types=keep_types
+            node.tokens,
+            line,
+            self.split_on_every_setting_arg,
+            indent,
+            split_types=split_types,
+            keep_types=keep_types,
+            keep_first_on_line=True,
         )
         if indent:
             comments = [Comment([indent, comment, EOL]) for comment in comments]
@@ -294,6 +312,7 @@ class SplitTooLongLine(Formatter):
         indent: Token | int | None = None,
         split_types: set[str] = ARGUMENTS_ONLY,  # type: ignore[assignment]
         keep_types: set[str] | None = None,
+        keep_first_on_line: bool = False,
     ) -> tuple[list[Token], list[Token]]:
         if not keep_types:
             keep_types = set()
@@ -309,6 +328,7 @@ class SplitTooLongLine(Formatter):
         # [COMMENT, SEPARATOR, COMMENT] tokens in the AST, so to preserve the
         # original comment, we need a lookback at the separator tokens.
         last_separator = None
+        first_split_token = True
         for token in tokens:
             if token.type in self.IGNORED_WHITESPACE:
                 continue
@@ -319,7 +339,12 @@ class SplitTooLongLine(Formatter):
             elif token.type in split_types:
                 if token.value == "":
                     token.value = "${EMPTY}"
-                if split_on or not self.col_fit_in_line([*line, separator, token]):
+                # Keep the first argument on the same line as the setting to follow the style guide
+                # (e.g. ``[Arguments]    ${first}``) so the output does not clash with linter rules
+                # first-argument-in-new-line (SPC18) and arguments-per-line (ARG07).
+                keep_on_line = keep_first_on_line and first_split_token
+                first_split_token = False
+                if not keep_on_line and (split_on or not self.col_fit_in_line([*line, separator, token])):
                     if align_new_line and cont_indent is None:  # we are yet to calculate aligned indent
                         cont_indent = Token(Token.SEPARATOR, self.calculate_align_separator(line))
                     line.append(EOL)

--- a/tests/formatter/formatters/SplitTooLongLine/expected/settings_on_every_arg.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/settings_on_every_arg.robot
@@ -1,20 +1,16 @@
 *** Settings ***
 Documentation    Test documentation for suite with logs of long lines. Test documentation for suite with logs of long lines.
 
-Library    ShortButSpaced
-...    ${1}
+Library    ShortButSpaced    ${1}
 ...    ${2}
 ...    ${3}
-Library    CustomLibraryWithLongerNameAndSeveralArguments
-...    first_argument
+Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument
 ...    second_argument=${longer_variable_name}
 ...    third_argument=${longer_variable_name}
-Library    CustomLibraryWithLongerNameAndSeveralArguments
-...    first_argument
+Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument
 ...    second_argument=${longer_variable_name}
 ...    WITH NAME    name
-Library    CustomLibraryWithLongerNameAndSeveralArguments
-...    first_argument
+Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument
 ...    second_argument=${longer_variable_name}
 ...    AS    name
 Library
@@ -22,8 +18,7 @@ Library
 # there is also resource but it rarely goes over, variable imports, suite setup/suite teardown (but indentnested should take care of that)
 Metadata      Name of metadata variable  For more information about *Robot Framework* see http://robotframework.org or visit dedicated documentation site.
 
-Keyword Tags
-...    PS_CSMON_15838
+Keyword Tags    PS_CSMON_15838
 ...    PR_PPD
 ...    PR_B450
 ...    PR_B650
@@ -33,8 +28,7 @@ Keyword Tags
 ...    PAR_ECG
 ...    PAR_IP_1
 ...    PAR_SPO2
-Test Tags
-...    PS_CSMON_15838
+Test Tags    PS_CSMON_15838
 ...    PR_PPD
 ...    PR_B450
 ...    PR_B650
@@ -44,8 +38,7 @@ Test Tags
 ...    PAR_ECG
 ...    PAR_IP_1
 ...    PAR_SPO2
-Default Tags
-...    PS_CSMON_15838
+Default Tags    PS_CSMON_15838
 ...    PR_PPD
 ...    PR_B450
 ...    PR_B650
@@ -60,8 +53,7 @@ Default Tags
 
 *** Test Cases ***
 Test with lots of tags
-    [Tags]
-    ...    PS_CSMON_15838
+    [Tags]    PS_CSMON_15838
     ...    PR_PPD
     ...    PR_B450
     ...    PR_B650
@@ -76,8 +68,7 @@ Test with lots of tags
     Assert
 
 Test with comments in settings
-    [Tags]
-    ...    tag
+    [Tags]    tag
     ...    tag
     ...    PS_CSMON_15838
     ...    PR_PPD
@@ -96,8 +87,7 @@ Test with comments in settings
 
 *** Keywords ***
 Arguments
-    [Arguments]
-    ...    ${short}
+    [Arguments]    ${short}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
@@ -108,15 +98,13 @@ Arguments multiline
     Step
 
 Arguments single line over limit
-    [Arguments]
-    ...    ${short}
+    [Arguments]    ${short}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Comment that goes over the allowed length
-    [Arguments]
-    ...    ${short}
+    [Arguments]    ${short}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step

--- a/tests/formatter/formatters/SplitTooLongLine/expected/settings_skip_tests.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/settings_skip_tests.robot
@@ -30,8 +30,7 @@ Test with comments in settings
 
 *** Keywords ***
 Arguments
-    [Arguments]
-    ...    ${short}
+    [Arguments]    ${short}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
@@ -42,15 +41,13 @@ Arguments multiline
     Step
 
 Arguments single line over limit
-    [Arguments]
-    ...    ${short}
+    [Arguments]    ${short}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Comment that goes over the allowed length
-    [Arguments]
-    ...    ${short}
+    [Arguments]    ${short}
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step


### PR DESCRIPTION
## Summary

Fixes #1723.

`SplitTooLongLine` split `[Arguments]` (and other settings) so that **neither** default mode matched the [Robot Framework style guide](https://docs.robotframework.org/docs/style_guide):

- `split_on_every_setting_arg=True` (**default**) moved the first argument onto its own continuation line, conflicting with the **`first-argument-in-new-line` (SPC18)** linter rule.
- `split_on_every_setting_arg=False` filled continuation lines with multiple arguments, conflicting with the **`arguments-per-line` (ARG07)** linter rule.

So running the formatter with defaults produced code that the linter then flagged.

## Change

The formatter now keeps the **first** argument on the same line as the setting name and splits the remaining arguments **one per continuation line** — matching the style guide and avoiding conflicts with SPC18 and ARG07.

Before (default output):

```robotframework
Keyword With Multiple Arguments
    [Arguments]
    ...    ${first_argument}
    ...    ${second_argument}
    ...    ${third_argument}
```

After (default output):

```robotframework
Keyword With Multiple Arguments
    [Arguments]    ${first_argument}
    ...    ${second_argument}
    ...    ${third_argument}
```

Implementation: added a `keep_first_on_line` flag to `split_tokens`, passed from `split_setting_with_args`. It applies to settings that hold arguments/values (`[Arguments]`, `[Tags]`, `Library`, etc.).

> [!NOTE]
> This changes the **default** formatting output for split settings. Existing files that were formatted with the old default will be re-formatted (first setting argument moved back onto the setting line).

## Verification

- End-to-end: formatted a long `[Arguments]`, then `robocop check --select first-argument-in-new-line --select arguments-per-line` → **No issues found**.
- Updated fixtures: `settings_on_every_arg.robot`, `settings_skip_tests.robot`.
- Updated docstring and `docs/formatter/formatters/SplitTooLongLine.md`.
- Full formatter suite passes; full `tests` suite passes except the pre-existing, unrelated `test_cli.py::test_version` (editable-install metadata mismatch).
- `ruff check`, `ruff format`, and `mypy` clean (pre-commit hooks pass).
