### PR TITLE
fix: mark --ignore values as matched for rules below --threshold

### DIFF
--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -129,9 +129,12 @@ class RuleMatcher:
     def _is_rule_disabled(self, rule: Rule) -> bool:
         if rule.is_disabled(self.target_version):
             return True
+        # Evaluate --ignore first so the filter is recorded as matched even when the rule is
+        # also filtered out by --threshold, otherwise it is falsely reported as unmatched.
+        ignored = self.ignore_filter.matches(rule)
         if rule.severity < self.threshold and not rule.config.get("severity_threshold"):
             return True
-        return self.ignore_filter.matches(rule)
+        return ignored
 
     def is_rule_fixable(self, rule: Rule) -> bool:
         """Determine if rule is fixable based on --fixable and --unfixable options."""

--- a/tests/linter/test_rule_matcher.py
+++ b/tests/linter/test_rule_matcher.py
@@ -455,3 +455,21 @@ class TestRuleMatcher:
         rule_matcher.check_unmatched_filters()
         _, err = capsys.readouterr()
         assert err == ""
+
+    def test_check_matched_ignored_rule_below_threshold(self, capsys):
+        """Rule filtered out by --threshold should still mark --ignore as matched (#1775)."""
+        rule_matcher = RuleMatcher(
+            select=[],
+            extend_select=[],
+            ignore=["some-message-0101"],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.ERROR,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert not rule_matcher.is_rule_enabled(get_enabled_rule("0101", severity=RuleSeverity.WARNING))
+
+        rule_matcher.check_unmatched_filters()
+        _, err = capsys.readouterr()
+        assert err == ""


### PR DESCRIPTION
Closes #1775

`robocop check --threshold E --ignore sleep-keyword-used` printed `Option value 'sleep-keyword-used' from '--ignore' did not match with any rule name or id.` even though the rule exists. `RuleMatcher._is_rule_disabled` returned early on the severity-threshold check, so `ignore_filter.matches()` never ran for those rules and the ignore value was never recorded as matched. The ignore filter is now evaluated before the threshold short-circuit; rule enable/disable behaviour is unchanged.

Regression test added to `tests/linter/test_rule_matcher.py` (fails without the fix, passes with it); `tests/linter` is green, ruff check/format on the changed files is baseline-identical.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
