### PR TITLE
fix(formatter): keep inline comment cells together in ReplaceWithVAR

### DIFF
--- a/src/robocop/formatter/formatters/ReplaceWithVAR.py
+++ b/src/robocop/formatter/formatters/ReplaceWithVAR.py
@@ -191,8 +191,26 @@ class ReplaceWithVAR(Formatter):
             else:
                 node.tokens = [*node.tokens[:-1], Token(Token.SEPARATOR, "  "), comments[0], node.tokens[-1]]  # type: ignore[union-attr]
             return node
-        comment_nodes = [Comment.from_params(comment=comment.value, indent=indent) for comment in comments]
+        comment_nodes = [
+            Comment.from_params(comment=comment, indent=indent) for comment in self.merge_comment_values(comments)
+        ]
         return *comment_nodes, node
+
+    @staticmethod
+    def merge_comment_values(comments: list[Token]) -> list[str]:
+        """
+        Merge comment tokens that belong to the same comment.
+
+        A single inline comment is tokenized into one token per cell, and only the first one starts with ``#``.
+        Emitting the remaining cells as separate comments would turn them into executable lines.
+        """
+        merged: list[str] = []
+        for comment in comments:
+            if merged and not comment.value.startswith("#"):
+                merged[-1] = f"{merged[-1]}    {comment.value}"
+            else:
+                merged.append(comment.value)
+        return merged
 
     @staticmethod
     def resolve_variable_name(name: str) -> str | None:

--- a/tests/formatter/formatters/ReplaceWithVAR/test_formatter.py
+++ b/tests/formatter/formatters/ReplaceWithVAR/test_formatter.py
@@ -1,3 +1,7 @@
+import pytest
+import typer
+
+from robocop.run import format_files
 from tests.formatter import FormatterAcceptanceTest
 
 
@@ -53,3 +57,23 @@ class TestReplaceWithVAR(FormatterAcceptanceTest):
 
     def test_item_access(self):
         self.compare(source="item_access.robot", not_modified=True)
+
+    @pytest.mark.parametrize(
+        ("keyword_call", "expected_comment"),
+        [
+            (
+                "&{task_dict}    Create Dictionary    #    Task State=Task Name    Subtask Status=Subtask Name",
+                "    #    Task State=Task Name    Subtask Status=Subtask Name",
+            ),
+            ("@{list}    Create List    value    # comment    with cells", "    # comment    with cells"),
+        ],
+    )
+    def test_inline_comment_is_not_split_into_keyword_calls(self, keyword_call, expected_comment, tmp_path):
+        """Cells of a single inline comment must stay in one comment line (#1715)."""
+        source = tmp_path / "inline_comment.robot"
+        source.write_text(f"*** Test Cases ***\nTest\n    {keyword_call}\n", encoding="utf-8")
+
+        with pytest.raises(typer.Exit):
+            format_files(sources=[source], select=[self.FORMATTER_NAME], overwrite=True, cache=False)
+
+        assert source.read_text(encoding="utf-8").splitlines()[2] == expected_comment


### PR DESCRIPTION
Closes #1715

Robot Framework tokenizes a single inline comment into one `COMMENT` token per data cell, and only the first cell starts with `#`. When `ReplaceWithVAR` moved a multi-cell comment above the generated `VAR`, it emitted one comment line per token, so every cell after the first lost its `#` and became an executable line — silently breaking the suite at runtime.

Cells that do not start with `#` are now appended to the preceding comment, so the original comment stays on one line. Regression test added to `tests/formatter/formatters/ReplaceWithVAR/test_formatter.py` (parametrized over `Create Dictionary` and `Create List`); it fails on master and passes with the fix, and the full `tests/formatter` suite stays green.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
