### PR TITLE
feat(SplitTooLongLine): add per-type align_new_line options

### DIFF
--- a/docs/formatter/formatters/SplitTooLongLine.md
+++ b/docs/formatter/formatters/SplitTooLongLine.md
@@ -294,9 +294,54 @@ will result in:
 
 ## Align a new line
 
-It is possible to align a new line to the previous line when splitting too long line. This mode works only when we are
-filling the line until line the length limit (with one of the ``split_on_every_arg``, ``split_on_every_value`` and
-``split_on_every_setting_arg`` flags). To enable it, configure it using ``align_new_line``:
+The new line can be aligned to the previous line when splitting the line.
+
+By default, only settings (such as ``[Tags]`` or ``[Arguments]``) are aligned.
+
+Use the following flags to enable/disable this behaviour for a given type:
+
+- ``align_new_line_arg`` (default ``False``) for keyword arguments alignment
+- ``align_new_line_setting_arg`` (default ``True``) for settings arguments alignment
+- ``align_new_line_value`` (default ``False``) for values alignment
+
+For example, to align keyword arguments and values while keeping the default settings alignment:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop format --configure SplitTooLongLine.align_new_line_arg=True --configure SplitTooLongLine.align_new_line_value=True
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.format]
+    configure = [
+        "SplitTooLongLine.align_new_line_arg=True",
+        "SplitTooLongLine.align_new_line_value=True"
+    ]
+    ```
+
+Or to disable the settings arguments alignment enabled by default:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop format --configure SplitTooLongLine.align_new_line_setting_arg=False
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.format]
+    configure = [
+        "SplitTooLongLine.align_new_line_setting_arg=False"
+    ]
+    ```
+
+Alignment can be also enabled for all types at once using ``align_new_line``. This flag takes precedence over
+the granular flags above - when it is set to ``True``, every type is aligned regardless of the
+``align_new_line_arg``, ``align_new_line_setting_arg`` and ``align_new_line_value`` values:
 
 === ":octicons-command-palette-24: cli"
 
@@ -329,9 +374,11 @@ will result in:
     ```robotframework
     *** Keywords ***
     Keyword
-        [Tags]    longertagname1    longertagname2
+        [Tags]    longertagname1
+        ...    longertagname2
         ...    longertagname3
-        Keyword With Longer Name    ${arg1}    ${arg2}
+        Keyword With Longer Name    ${arg1}
+        ...    ${arg2}
         ...    ${arg3}
     ```
 
@@ -340,9 +387,11 @@ will result in:
     ```robotframework
     *** Keywords ***
     Keyword
-        [Tags]    longertagname1    longertagname2
+        [Tags]    longertagname1
+        ...       longertagname2
         ...       longertagname3
-        Keyword With Longer Name    ${arg1}    ${arg2}
+        Keyword With Longer Name    ${arg1}
+        ...                         ${arg2}
         ...                         ${arg3}
     ```
 

--- a/src/robocop/formatter/formatters/SplitTooLongLine.py
+++ b/src/robocop/formatter/formatters/SplitTooLongLine.py
@@ -117,6 +117,9 @@ class SplitTooLongLine(Formatter):
         split_on_every_setting_arg: bool = True,
         split_single_value: bool = False,
         align_new_line: bool = False,
+        align_new_line_arg: bool = False,
+        align_new_line_setting_arg: bool = True,
+        align_new_line_value: bool = False,
     ) -> None:
         super().__init__()
         # TODO: Replace Robot importer
@@ -126,6 +129,9 @@ class SplitTooLongLine(Formatter):
         self.split_on_every_setting_arg = split_on_every_setting_arg
         self.split_single_value = split_single_value
         self.align_new_line = align_new_line
+        self.align_new_line_arg = align_new_line_arg
+        self.align_new_line_setting_arg = align_new_line_setting_arg
+        self.align_new_line_value = align_new_line_value
 
     @property
     def line_length(self) -> int:
@@ -201,8 +207,14 @@ class SplitTooLongLine(Formatter):
         indent = node.tokens[0]
         separator = Token(Token.SEPARATOR, self.formatting_config.separator)
         line: list[Token] = [indent, node.data_tokens[0], separator, var_name]
+        align_new_line = self.align_new_line or self.align_new_line_value
         tokens, comments = self.split_tokens(
-            node.tokens, line, self.split_on_every_value, indent=indent, split_types={Token.ARGUMENT, Token.OPTION}
+            node.tokens,
+            line,
+            self.split_on_every_value,
+            align_new_line,
+            indent=indent,
+            split_types={Token.ARGUMENT, Token.OPTION},
         )
         node.tokens = self.insert_comments_in_first_line(tokens, comments)
         return (*comments, node)
@@ -270,10 +282,12 @@ class SplitTooLongLine(Formatter):
             indent = node.tokens[0]
             token_index = 2
         line: list[Token] = list(node.tokens[:token_index])
+        align_new_line = self.align_new_line or self.align_new_line_setting_arg
         tokens, comments = self.split_tokens(
             node.tokens,
             line,
             self.split_on_every_setting_arg,
+            align_new_line,
             indent,
             split_types=split_types,
             keep_types=keep_types,
@@ -309,6 +323,7 @@ class SplitTooLongLine(Formatter):
         tokens: list[Token],
         line: list[Token],
         split_on: bool,
+        align_line: bool,
         indent: Token | int | None = None,
         split_types: set[str] = ARGUMENTS_ONLY,  # type: ignore[assignment]
         keep_types: set[str] | None = None,
@@ -317,8 +332,7 @@ class SplitTooLongLine(Formatter):
         if not keep_types:
             keep_types = set()
         separator = Token(Token.SEPARATOR, self.formatting_config.separator)
-        align_new_line = self.align_new_line and not split_on
-        if align_new_line:
+        if align_line:
             cont_indent = None
         else:
             cont_indent = Token(Token.SEPARATOR, self.formatting_config.continuation_indent)
@@ -345,7 +359,7 @@ class SplitTooLongLine(Formatter):
                 keep_on_line = keep_first_on_line and first_split_token
                 first_split_token = False
                 if not keep_on_line and (split_on or not self.col_fit_in_line([*line, separator, token])):
-                    if align_new_line and cont_indent is None:  # we are yet to calculate aligned indent
+                    if align_line and cont_indent is None:  # we are yet to calculate aligned indent
                         cont_indent = Token(Token.SEPARATOR, self.calculate_align_separator(line))
                     line.append(EOL)
                     split_tokens.extend(line)
@@ -389,7 +403,8 @@ class SplitTooLongLine(Formatter):
         if len(node.value) < 2 and not self.split_single_value:
             return node
         line = [node.data_tokens[0]]
-        tokens, comments = self.split_tokens(node.tokens, line, self.split_on_every_value)
+        align_new_line = self.align_new_line or self.align_new_line_value
+        tokens, comments = self.split_tokens(node.tokens, line, self.split_on_every_value, align_new_line)
         comments = [Comment([comment, EOL]) for comment in comments]
         node.tokens = tokens
         return (*comments, node)
@@ -416,8 +431,9 @@ class SplitTooLongLine(Formatter):
             line = []
         else:
             head = []
+        align_new_line = self.align_new_line or self.align_new_line_arg
         tokens, comments = self.split_tokens(
-            node.tokens[node.tokens.index(keyword) + 1 :], line, self.split_on_every_arg, indent
+            node.tokens[node.tokens.index(keyword) + 1 :], line, self.split_on_every_arg, align_new_line, indent
         )
         head.extend(tokens)
         node.tokens = self.insert_comments_in_first_line(head, comments)

--- a/tests/formatter/formatters/SplitTooLongLine/expected/align_new_line_arg.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/align_new_line_arg.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Force Tags    PS_CSMON_15838    PR_PPD    PR_B450
+...           PR_B650    PR_B850    PR_CS1000
+...           PR_CS1000L    PAR_ECG    PAR_IP_1
+...           PAR_SPO2
+
+
+*** Variables ***  # variables are not aligned but it will be handled by AlignVariablesSection
+@{LIST}
+...    valuevaluevaluevaluevalue
+...    valuevaluevaluevaluevalue
+...    valuevaluevaluevaluevalue
+
+
+*** Test Cases ***
+Testcase with a lot of tags
+    [Tags]    Tag1    Tag10    Tag11    Tag12
+    ...       Tag13    Tag2    Tag3    Tag4
+    ...       Tag5    Tag6    Tag7    Tag8    Tag9
+    ...       Tag14    Tag15
+    Fail
+
+
+*** Keywords ***
+Keyword
+    Keyword With Longer Name    ${arg1}    ${arg2}
+    ...                         ${arg3}
+
+Keyword Longer Than Limit
+    This Keyword Goes Beyond Limit And Next Argument Should Be In New Line
+    ...    ${arg}

--- a/tests/formatter/formatters/SplitTooLongLine/expected/align_new_line_setting_arg.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/align_new_line_setting_arg.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Force Tags    PS_CSMON_15838    PR_PPD    PR_B450
+...    PR_B650    PR_B850    PR_CS1000
+...    PR_CS1000L    PAR_ECG    PAR_IP_1
+...    PAR_SPO2
+
+
+*** Variables ***  # variables are not aligned but it will be handled by AlignVariablesSection
+@{LIST}
+...    valuevaluevaluevaluevalue
+...    valuevaluevaluevaluevalue
+...    valuevaluevaluevaluevalue
+
+
+*** Test Cases ***
+Testcase with a lot of tags
+    [Tags]    Tag1    Tag10    Tag11    Tag12
+    ...    Tag13    Tag2    Tag3    Tag4    Tag5
+    ...    Tag6    Tag7    Tag8    Tag9    Tag14
+    ...    Tag15
+    Fail
+
+
+*** Keywords ***
+Keyword
+    Keyword With Longer Name    ${arg1}    ${arg2}
+    ...    ${arg3}
+
+Keyword Longer Than Limit
+    This Keyword Goes Beyond Limit And Next Argument Should Be In New Line
+    ...    ${arg}

--- a/tests/formatter/formatters/SplitTooLongLine/expected/align_new_line_value.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/align_new_line_value.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Force Tags    PS_CSMON_15838    PR_PPD    PR_B450
+...           PR_B650    PR_B850    PR_CS1000
+...           PR_CS1000L    PAR_ECG    PAR_IP_1
+...           PAR_SPO2
+
+
+*** Variables ***  # variables are not aligned but it will be handled by AlignVariablesSection
+@{LIST}    valuevaluevaluevaluevalue
+...        valuevaluevaluevaluevalue
+...        valuevaluevaluevaluevalue
+
+
+*** Test Cases ***
+Testcase with a lot of tags
+    [Tags]    Tag1    Tag10    Tag11    Tag12
+    ...       Tag13    Tag2    Tag3    Tag4
+    ...       Tag5    Tag6    Tag7    Tag8    Tag9
+    ...       Tag14    Tag15
+    Fail
+
+
+*** Keywords ***
+Keyword
+    Keyword With Longer Name    ${arg1}    ${arg2}
+    ...    ${arg3}
+
+Keyword Longer Than Limit
+    This Keyword Goes Beyond Limit And Next Argument Should Be In New Line
+    ...    ${arg}

--- a/tests/formatter/formatters/SplitTooLongLine/expected/settings_on_every_arg.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/settings_on_every_arg.robot
@@ -2,84 +2,84 @@
 Documentation    Test documentation for suite with logs of long lines. Test documentation for suite with logs of long lines.
 
 Library    ShortButSpaced    ${1}
-...    ${2}
-...    ${3}
+...        ${2}
+...        ${3}
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument
-...    second_argument=${longer_variable_name}
-...    third_argument=${longer_variable_name}
+...        second_argument=${longer_variable_name}
+...        third_argument=${longer_variable_name}
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument
-...    second_argument=${longer_variable_name}
-...    WITH NAME    name
+...        second_argument=${longer_variable_name}
+...        WITH NAME    name
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument
-...    second_argument=${longer_variable_name}
-...    AS    name
+...        second_argument=${longer_variable_name}
+...        AS    name
 Library
 
 # there is also resource but it rarely goes over, variable imports, suite setup/suite teardown (but indentnested should take care of that)
 Metadata      Name of metadata variable  For more information about *Robot Framework* see http://robotframework.org or visit dedicated documentation site.
 
 Keyword Tags    PS_CSMON_15838
-...    PR_PPD
-...    PR_B450
-...    PR_B650
-...    PR_B850
-...    PR_CS1000
-...    PR_CS1000L
-...    PAR_ECG
-...    PAR_IP_1
-...    PAR_SPO2
+...             PR_PPD
+...             PR_B450
+...             PR_B650
+...             PR_B850
+...             PR_CS1000
+...             PR_CS1000L
+...             PAR_ECG
+...             PAR_IP_1
+...             PAR_SPO2
 Test Tags    PS_CSMON_15838
-...    PR_PPD
-...    PR_B450
-...    PR_B650
-...    PR_B850
-...    PR_CS1000
-...    PR_CS1000L
-...    PAR_ECG
-...    PAR_IP_1
-...    PAR_SPO2
+...          PR_PPD
+...          PR_B450
+...          PR_B650
+...          PR_B850
+...          PR_CS1000
+...          PR_CS1000L
+...          PAR_ECG
+...          PAR_IP_1
+...          PAR_SPO2
 Default Tags    PS_CSMON_15838
-...    PR_PPD
-...    PR_B450
-...    PR_B650
-...    PR_B850
-...    PR_CS1000
-...    PR_CS1000L
-...    PAR_ECG
-...    PAR_IP_1
-...    PAR_SPO2
+...             PR_PPD
+...             PR_B450
+...             PR_B650
+...             PR_B850
+...             PR_CS1000
+...             PR_CS1000L
+...             PAR_ECG
+...             PAR_IP_1
+...             PAR_SPO2
 # comment
 
 
 *** Test Cases ***
 Test with lots of tags
     [Tags]    PS_CSMON_15838
-    ...    PR_PPD
-    ...    PR_B450
-    ...    PR_B650
-    ...    PR_B850
-    ...    PR_CS1000
-    ...    PR_CS1000L
-    ...    PAR_ECG
-    ...    PAR_IP_1
-    ...    PAR_SPO2
+    ...       PR_PPD
+    ...       PR_B450
+    ...       PR_B650
+    ...       PR_B850
+    ...       PR_CS1000
+    ...       PR_CS1000L
+    ...       PAR_ECG
+    ...       PAR_IP_1
+    ...       PAR_SPO2
     Prepare
     Run
     Assert
 
 Test with comments in settings
     [Tags]    tag
-    ...    tag
-    ...    PS_CSMON_15838
-    ...    PR_PPD
-    ...    PR_B450
-    ...    PR_B650
-    ...    PR_B850
-    ...    PR_CS1000
-    ...    PR_CS1000L
-    ...    PAR_ECG
-    ...    PAR_IP_1
-    ...    PAR_SPO2
+    ...       tag
+    ...       PS_CSMON_15838
+    ...       PR_PPD
+    ...       PR_B450
+    ...       PR_B650
+    ...       PR_B850
+    ...       PR_CS1000
+    ...       PR_CS1000L
+    ...       PAR_ECG
+    ...       PAR_IP_1
+    ...       PAR_SPO2
     # comment1
     # comment2
     # comment3
@@ -88,8 +88,8 @@ Test with comments in settings
 *** Keywords ***
 Arguments
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Arguments multiline
@@ -99,13 +99,13 @@ Arguments multiline
 
 Arguments single line over limit
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Comment that goes over the allowed length
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step
 

--- a/tests/formatter/formatters/SplitTooLongLine/expected/settings_skip_tests.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/settings_skip_tests.robot
@@ -31,8 +31,8 @@ Test with comments in settings
 *** Keywords ***
 Arguments
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Arguments multiline
@@ -42,13 +42,13 @@ Arguments multiline
 
 Arguments single line over limit
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Comment that goes over the allowed length
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step
 

--- a/tests/formatter/formatters/SplitTooLongLine/expected/settings_until_line_length.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/settings_until_line_length.robot
@@ -3,36 +3,36 @@ Documentation    Test documentation for suite with logs of long lines. Test docu
 
 Library    ShortButSpaced    ${1}    ${2}    ${3}
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument    second_argument=${longer_variable_name}
-...    third_argument=${longer_variable_name}
+...        third_argument=${longer_variable_name}
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument    second_argument=${longer_variable_name}
-...    WITH NAME    name
+...        WITH NAME    name
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument    second_argument=${longer_variable_name}
-...    AS    name
+...        AS    name
 Library
 
 # there is also resource but it rarely goes over, variable imports, suite setup/suite teardown (but indentnested should take care of that)
 Metadata      Name of metadata variable  For more information about *Robot Framework* see http://robotframework.org or visit dedicated documentation site.
 
 Keyword Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-...    PAR_IP_1    PAR_SPO2
+...             PAR_IP_1    PAR_SPO2
 Test Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-...    PAR_IP_1    PAR_SPO2
+...          PAR_IP_1    PAR_SPO2
 Default Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-...    PAR_IP_1    PAR_SPO2
+...             PAR_IP_1    PAR_SPO2
 # comment
 
 
 *** Test Cases ***
 Test with lots of tags
     [Tags]    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-    ...    PAR_IP_1    PAR_SPO2
+    ...       PAR_IP_1    PAR_SPO2
     Prepare
     Run
     Assert
 
 Test with comments in settings
     [Tags]    tag    tag    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L
-    ...    PAR_ECG    PAR_IP_1    PAR_SPO2
+    ...       PAR_ECG    PAR_IP_1    PAR_SPO2
     # comment1
     # comment2
     # comment3
@@ -41,7 +41,7 @@ Test with comments in settings
 *** Keywords ***
 Arguments
     [Arguments]    ${short}    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Arguments multiline
@@ -51,8 +51,8 @@ Arguments multiline
 
 Arguments single line over limit
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Comment that goes over the allowed length

--- a/tests/formatter/formatters/SplitTooLongLine/expected/settings_until_line_length_skip_comments.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/settings_until_line_length_skip_comments.robot
@@ -3,36 +3,36 @@ Documentation    Test documentation for suite with logs of long lines. Test docu
 
 Library    ShortButSpaced    ${1}    ${2}    ${3}
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument    second_argument=${longer_variable_name}
-...    third_argument=${longer_variable_name}
+...        third_argument=${longer_variable_name}
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument    second_argument=${longer_variable_name}
-...    WITH NAME    name
+...        WITH NAME    name
 Library    CustomLibraryWithLongerNameAndSeveralArguments    first_argument    second_argument=${longer_variable_name}
-...    AS    name
+...        AS    name
 Library
 
 # there is also resource but it rarely goes over, variable imports, suite setup/suite teardown (but indentnested should take care of that)
 Metadata      Name of metadata variable  For more information about *Robot Framework* see http://robotframework.org or visit dedicated documentation site.
 
 Keyword Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-...    PAR_IP_1    PAR_SPO2
+...             PAR_IP_1    PAR_SPO2
 Test Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-...    PAR_IP_1    PAR_SPO2
+...          PAR_IP_1    PAR_SPO2
 Default Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-...    PAR_IP_1    PAR_SPO2
+...             PAR_IP_1    PAR_SPO2
 # comment
 
 
 *** Test Cases ***
 Test with lots of tags
     [Tags]    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG
-    ...    PAR_IP_1    PAR_SPO2
+    ...       PAR_IP_1    PAR_SPO2
     Prepare
     Run
     Assert
 
 Test with comments in settings
     [Tags]    tag    tag    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L
-    ...    PAR_ECG    PAR_IP_1    PAR_SPO2
+    ...       PAR_ECG    PAR_IP_1    PAR_SPO2
     # comment1
     # comment2
     # comment3
@@ -41,7 +41,7 @@ Test with comments in settings
 *** Keywords ***
 Arguments
     [Arguments]    ${short}    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Arguments multiline
@@ -51,8 +51,8 @@ Arguments multiline
 
 Arguments single line over limit
     [Arguments]    ${short}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
-    ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLengthveryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
+    ...            ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     Step
 
 Comment that goes over the allowed length

--- a/tests/formatter/formatters/SplitTooLongLine/test_formatter.py
+++ b/tests/formatter/formatters/SplitTooLongLine/test_formatter.py
@@ -226,6 +226,62 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             run_all=True,
         )
 
+    def test_align_new_line_arg(self):
+        configure = [
+            f"{self.FORMATTER_NAME}.align_new_line_arg=True",
+            f"{self.FORMATTER_NAME}.split_on_every_arg=False",
+            f"{self.FORMATTER_NAME}.split_on_every_setting_arg=False",
+            f"{self.FORMATTER_NAME}.line_length=51",
+        ]
+        self.compare(
+            source="align_new_line.robot",
+            expected="align_new_line_arg.robot",
+            configure=configure,
+        )
+
+    def test_align_new_line_value(self):
+        configure = [
+            f"{self.FORMATTER_NAME}.align_new_line_value=True",
+            f"{self.FORMATTER_NAME}.split_on_every_value=False",
+            f"{self.FORMATTER_NAME}.split_on_every_arg=False",
+            f"{self.FORMATTER_NAME}.split_on_every_setting_arg=False",
+            f"{self.FORMATTER_NAME}.line_length=51",
+        ]
+        self.compare(
+            source="align_new_line.robot",
+            expected="align_new_line_value.robot",
+            configure=configure,
+        )
+
+    def test_align_new_line_setting_arg(self):
+        configure = [
+            f"{self.FORMATTER_NAME}.align_new_line_setting_arg=False",
+            f"{self.FORMATTER_NAME}.split_on_every_arg=False",
+            f"{self.FORMATTER_NAME}.split_on_every_setting_arg=False",
+            f"{self.FORMATTER_NAME}.line_length=51",
+        ]
+        self.compare(
+            source="align_new_line.robot",
+            expected="align_new_line_setting_arg.robot",
+            configure=configure,
+        )
+
+    def test_align_new_line_supersedes_granular_flags(self):
+        # ``align_new_line=True`` aligns every type regardless of the granular flags being disabled
+        configure = [
+            f"{self.FORMATTER_NAME}.align_new_line=True",
+            f"{self.FORMATTER_NAME}.align_new_line_arg=False",
+            f"{self.FORMATTER_NAME}.align_new_line_setting_arg=False",
+            f"{self.FORMATTER_NAME}.align_new_line_value=False",
+            f"{self.FORMATTER_NAME}.split_on_every_arg=False",
+            f"{self.FORMATTER_NAME}.split_on_every_setting_arg=False",
+            f"{self.FORMATTER_NAME}.line_length=51",
+        ]
+        self.compare(
+            source="align_new_line.robot",
+            configure=configure,
+        )
+
     def test_var_syntax(self):
         self.compare(source="VAR_syntax.robot", test_on_version=">=7")
 


### PR DESCRIPTION
Add align_new_line_arg, align_new_line_setting_arg and align_new_line_value parameters to allow aligning continuation lines independently for keyword arguments, setting arguments and variable values.

Fixes #1793