### PR TITLE
refactor: merge raw file checkers into a single checker

### DIFF
--- a/src/robocop/linter/rules/comments.py
+++ b/src/robocop/linter/rules/comments.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
 from typing import TYPE_CHECKING, ClassVar
 
 from robot.api import Token, get_tokens
@@ -11,7 +10,6 @@ from robot.parsing.model.statements import Documentation
 
 from robocop.linter import sonar_qube
 from robocop.linter.rules import (
-    RawFileChecker,
     Rule,
     RuleParam,
     RuleSeverity,
@@ -20,8 +18,6 @@ from robocop.linter.rules import (
 from robocop.version_handling import ROBOT_VERSION
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from robot.parsing.model import Keyword, Statement, TestCase
     from robot.parsing.model.blocks import CommentSection
     from robot.parsing.model.statements import Comment
@@ -222,6 +218,36 @@ class IgnoredDataRule(Rule):
     )
     deprecated_names = ("0704",)
 
+    SECTION_HEADER = "***"
+    IGNORE_DIRECTIVES = ("# robocop:", "# fmt:")
+    LANGUAGE_HEADER = "language:"
+
+    def check(self, lines: list[str], is_bom: bool) -> None:
+        """Scan lines preceding the first section header and report them as ignored data."""
+        if not self.enabled:
+            return
+        # ignore empty lines if the language header or robocop disabler is present
+        ignore_empty_lines = False
+        for lineno, line in enumerate(lines, start=1):
+            if line.startswith(self.SECTION_HEADER):
+                return
+            if line.startswith(self.IGNORE_DIRECTIVES):
+                ignore_empty_lines = True
+                continue
+            if lineno == 1:
+                if line.lower().startswith(self.LANGUAGE_HEADER):
+                    ignore_empty_lines = True
+                    continue
+                if is_bom:
+                    # if it's BOM encoded file, the first line can be ignored
+                    if "***" in line:
+                        return
+                    continue
+            if ignore_empty_lines and not line.strip():
+                continue
+            self.report(lineno=lineno, col=1, end_col=len(line.rstrip()) + 1)
+            return
+
 
 class BomEncodingRule(Rule):
     """
@@ -247,6 +273,11 @@ class BomEncodingRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0705",)
+
+    def check(self, is_bom: bool) -> None:
+        if not self.enabled or not is_bom:
+            return
+        self.report(lineno=1, col=1)
 
 
 class CommentedOutCodeRule(Rule):
@@ -578,55 +609,3 @@ class CommentChecker(VisitorChecker):
 
     def is_block_comment(self, comment: str) -> bool:
         return comment == "#" or self.missing_space_after_comment.block.match(comment) is not None
-
-
-class IgnoredDataChecker(RawFileChecker):
-    """Checker for ignored data."""
-
-    ignored_data: IgnoredDataRule
-    bom_encoding_in_file: BomEncodingRule
-
-    BOM = [BOM_UTF32_BE, BOM_UTF32_LE, BOM_UTF8, BOM_UTF16_LE, BOM_UTF16_BE]
-    SECTION_HEADER = "***"
-    IGNORE_DIRECTIVES = ("# robocop:", "# fmt:")
-    LANGUAGE_HEADER = "language:"
-
-    def __init__(self) -> None:
-        self.is_bom = False
-        self.ignore_empty_lines = False  # ignore empty lines if the language header or robocop disabler is present
-        super().__init__()
-
-    def parse_file(self) -> None:
-        self.is_bom = False
-        self.ignore_empty_lines = False
-        self.detect_bom(self.source_file.path)
-        if not self.ignored_data.enabled:
-            return
-        for lineno, line in enumerate(self.source_file.source_lines, start=1):
-            if self.check_line(line, lineno):
-                break
-
-    def check_line(self, line: str, lineno: int) -> bool:  # type: ignore[override]
-        if line.startswith(self.SECTION_HEADER):
-            return True
-        if line.startswith(self.IGNORE_DIRECTIVES):
-            self.ignore_empty_lines = True
-            return False
-        if lineno == 1:
-            if line.lower().startswith(self.LANGUAGE_HEADER):
-                self.ignore_empty_lines = True
-                return False
-            if self.is_bom:
-                # if it's BOM encoded file, first line can be ignored
-                return "***" in line
-        if self.ignore_empty_lines and not line.strip():
-            return False
-        self.report(self.ignored_data, lineno=lineno, col=1, end_col=len(line.rstrip()) + 1)
-        return True
-
-    def detect_bom(self, source: Path) -> None:
-        with open(source, "rb") as raw_file:
-            first_four = raw_file.read(4)
-            self.is_bom = any(first_four.startswith(bom_marker) for bom_marker in IgnoredDataChecker.BOM)
-            if self.is_bom:
-                self.report(self.bom_encoding_in_file, lineno=1, col=1)

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -30,7 +30,6 @@ except ImportError:
 
 from robocop.linter import sonar_qube
 from robocop.linter.rules import (
-    RawFileChecker,
     Rule,
     RuleParam,
     RuleSeverity,
@@ -293,6 +292,44 @@ class LineTooLongRule(Rule):
     )
     deprecated_names = ("0508",)
     fix_suggestion = "Break long lines using the '...' continuation syntax."
+
+    def check(self, line: str, lineno: int) -> None:
+        if not self.enabled:
+            return
+        line = line.rstrip().expandtabs(4)
+        if len(line) <= self.line_length:
+            return
+        # the line is potentially too long, so we need to check if it can be false positive
+        if self.line_is_ignored(line):
+            return
+        if self.url_in_line(line):
+            return
+        line = self.strip_disablers(line)
+        if len(line) > self.line_length:
+            self.report(
+                line_length=len(line),
+                allowed_length=self.line_length,
+                lineno=lineno,
+                col=self.line_length,
+                end_col=len(line) + 1,
+                sev_threshold_value=len(line),
+            )
+
+    @staticmethod
+    def strip_disablers(line: str) -> str:
+        """Strip whole comments if it contains disabler."""
+        if "#" not in line:
+            return line
+        if "noqa" in line or "robocop:" in line or "fmt: " in line:
+            return line.split("# ", 1)[0].rstrip()
+        return line
+
+    def url_in_line(self, line: str) -> bool:
+        """Check if a line contains URL starting before the maximum line length."""
+        return bool(0 < line.find("://") < self.line_length)
+
+    def line_is_ignored(self, line: str) -> bool:
+        return bool(self.ignore_pattern and self.ignore_pattern.search(line))
 
 
 class EmptySectionRule(Rule):
@@ -1013,51 +1050,6 @@ class VariableNameLengthChecker(VisitorChecker):
         if (node.type is Token.EXCEPT) and (variable := node.header.get_token(Token.VARIABLE)):
             self.add_variable_to_scope(variable)
         self.generic_visit(node)  # continue to all branches
-
-
-class LineLengthChecker(RawFileChecker):
-    """Checker for the maximum length of a line."""
-
-    line_too_long: LineTooLongRule
-
-    def check_line(self, line: str, lineno: int) -> None:
-        line = line.rstrip().expandtabs(4)
-        if len(line) <= self.line_too_long.line_length:
-            return
-        # the line is potentially too long, so we need to check if it can be false positive
-        if self.line_is_ignored(line):
-            return
-        if self.url_in_line(line):
-            return
-        if self.line_too_long.ignore_pattern and self.line_too_long.ignore_pattern.search(line):
-            return
-        line = self.strip_disablers(line)
-        if len(line) > self.line_too_long.line_length:
-            self.report(
-                self.line_too_long,
-                line_length=len(line),
-                allowed_length=self.line_too_long.line_length,
-                lineno=lineno,
-                col=self.line_too_long.line_length,
-                end_col=len(line) + 1,
-                sev_threshold_value=len(line),
-            )
-
-    @staticmethod
-    def strip_disablers(line: str) -> str:
-        """Strip whole comments if it contains disabler."""
-        if "#" not in line:
-            return line
-        if "noqa" in line or "robocop:" in line or "fmt: " in line:
-            return line.split("# ", 1)[0].rstrip()
-        return line
-
-    def url_in_line(self, line: str) -> bool:
-        """Check if a line contains URL starting before the maximum line length."""
-        return bool(0 < line.find("://") < self.line_too_long.line_length)
-
-    def line_is_ignored(self, line: str) -> bool:
-        return bool(self.line_too_long.ignore_pattern) and self.line_too_long.ignore_pattern.search(line)
 
 
 class EmptySectionChecker(VisitorChecker):

--- a/src/robocop/linter/rules/raw_file.py
+++ b/src/robocop/linter/rules/raw_file.py
@@ -1,0 +1,53 @@
+"""
+Checker for rules that analyze the raw file content.
+
+Rules that inspect the source lines instead of the parsed Robot Framework model are all handled by a single
+checker, so the file content is only iterated once. Rule definitions stay in their own category modules
+(``comments``, ``lengths``, ``spacing``) - only the ``check`` methods are called from here.
+"""
+
+from __future__ import annotations
+
+from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
+from typing import TYPE_CHECKING
+
+from robocop.linter.rules import RawFileChecker, comments, lengths, spacing
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+BOM_MARKERS = (BOM_UTF32_BE, BOM_UTF32_LE, BOM_UTF8, BOM_UTF16_LE, BOM_UTF16_BE)
+
+
+class RawFileRulesChecker(RawFileChecker):
+    """Checker for rules reported based on the raw file content."""
+
+    trailing_whitespace: spacing.TrailingWhitespaceRule
+    missing_trailing_blank_line: spacing.MissingTrailingBlankLineRule
+    too_many_trailing_blank_lines: spacing.TooManyTrailingBlankLinesRule
+    line_too_long: lengths.LineTooLongRule
+    ignored_data: comments.IgnoredDataRule
+    bom_encoding_in_file: comments.BomEncodingRule
+
+    def parse_file(self) -> None:
+        self.lines = self.source_file.source_lines
+        if self.ignored_data.enabled or self.bom_encoding_in_file.enabled:
+            is_bom = detect_bom(self.source_file.path)
+            self.bom_encoding_in_file.check(is_bom)
+            self.ignored_data.check(self.lines, is_bom)
+        if self.trailing_whitespace.enabled or self.line_too_long.enabled:
+            for lineno, line in enumerate(self.lines, start=1):
+                self.trailing_whitespace.check(line, lineno)
+                self.line_too_long.check(line, lineno)
+        self.too_many_trailing_blank_lines.check(self.lines)
+        self.missing_trailing_blank_line.check(self.lines)
+
+
+def detect_bom(source: Path) -> bool:
+    """Return whether the file starts with a Byte Order Mark."""
+    try:
+        with open(source, "rb") as raw_file:
+            first_four = raw_file.read(4)
+    except OSError:
+        return False
+    return any(first_four.startswith(bom_marker) for bom_marker in BOM_MARKERS)

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 from contextlib import contextmanager
+from itertools import takewhile
 from typing import TYPE_CHECKING
 
 from robot.api import Token
@@ -20,7 +21,6 @@ from robocop.linter import sonar_qube
 from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
 from robocop.linter.rules import (
     FixableRule,
-    RawFileChecker,
     Rule,
     RuleParam,
     RuleSeverity,
@@ -82,6 +82,19 @@ class TrailingWhitespaceRule(FixableRule):
             applicability=FixApplicability.SAFE,
         )
 
+    def check(self, line: str, lineno: int) -> None:
+        if not self.enabled:
+            return
+        stripped_line = line.rstrip("\n\r")
+        if not stripped_line or stripped_line[-1] not in " \t":
+            return
+        whitespace_length = len(stripped_line) - len(stripped_line.rstrip())
+        self.report(
+            lineno=lineno,
+            col=len(stripped_line) - whitespace_length + 1,
+            end_col=len(stripped_line) + 1,
+        )
+
 
 class MissingTrailingBlankLineRule(Rule):
     """Missing trailing blank line at the end of file."""
@@ -96,6 +109,14 @@ class MissingTrailingBlankLineRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.FORMATTED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("1002",)
+
+    def check(self, lines: list[str]) -> None:
+        if not self.enabled or not lines:
+            return
+        last_line = lines[-1]
+        # blank last line is handled by too-many-trailing-blank-lines
+        if last_line.strip() and not last_line.endswith(("\n", "\r")):
+            self.report(lineno=len(lines), end_col=len(last_line) + 1)
 
 
 class EmptyLinesBetweenSectionsRule(Rule):
@@ -367,6 +388,17 @@ class TooManyTrailingBlankLinesRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.FORMATTED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("1010",)
+
+    def check(self, lines: list[str]) -> None:
+        if not self.enabled or not lines:
+            return
+        last_line = lines[-1]
+        if last_line in ("\n", "\r", "\r\n"):
+            self.report(lineno=len(lines) + 1, end_col=len(last_line) + 1)
+            return
+        trailing_empty_lines = takewhile(lambda line: not line.strip(), reversed(lines))
+        if sum(1 for _ in trailing_empty_lines) > 1:
+            self.report(lineno=len(lines), end_col=len(last_line) + 1)
 
 
 class MisalignedContinuationRule(Rule):
@@ -694,45 +726,6 @@ class FirstArgumentInNewLineRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("1018",)
-
-
-class InvalidSpacingChecker(RawFileChecker):  # TODO merge, we can just use single RawFileChecker
-    """Checker for trailing spaces and lines."""
-
-    trailing_whitespace: TrailingWhitespaceRule
-    missing_trailing_blank_line: MissingTrailingBlankLineRule
-    too_many_trailing_blank_lines: TooManyTrailingBlankLinesRule
-
-    def parse_file(self) -> None:
-        super().parse_file()
-        if not self.lines:
-            return
-        last_line = self.lines[-1]
-        if last_line in ["\n", "\r", "\r\n"]:
-            self.report(self.too_many_trailing_blank_lines, lineno=len(self.lines) + 1, end_col=len(last_line) + 1)
-            return
-        empty_lines = 0
-        for line in self.lines[::-1]:
-            if not line.strip():
-                empty_lines += 1
-            else:
-                break
-            if empty_lines > 1:
-                self.report(self.too_many_trailing_blank_lines, lineno=len(self.lines), end_col=len(last_line) + 1)
-                return
-        if not empty_lines and not last_line.endswith(("\n", "\r")):
-            self.report(self.missing_trailing_blank_line, lineno=len(self.lines), end_col=len(last_line) + 1)
-
-    def check_line(self, line: str, lineno: int) -> None:
-        stripped_line = line.rstrip("\n\r")
-        if stripped_line and stripped_line[-1] in [" ", "\t"]:
-            whitespace_length = len(stripped_line) - len(stripped_line.rstrip())
-            self.report(
-                self.trailing_whitespace,
-                lineno=lineno,
-                col=len(stripped_line) - whitespace_length + 1,
-                end_col=len(stripped_line) + 1,
-            )
 
 
 class EmptyLinesChecker(VisitorChecker):


### PR DESCRIPTION
## Summary

First step towards the single-visitor linter design: a file should be scanned once, with the visitor gathering data and the rules deciding whether to report.

Robocop had three separate `RawFileChecker` classes, each iterating the source lines of every scanned file:

| Checker | Module | Rules |
| --- | --- | --- |
| `InvalidSpacingChecker` | `spacing` | `trailing-whitespace`, `missing-trailing-blank-line`, `too-many-trailing-blank-lines` |
| `LineLengthChecker` | `lengths` | `line-too-long` |
| `IgnoredDataChecker` | `comments` | `ignored-data`, `bom-encoding-in-file` |

They are now merged into a single `RawFileRulesChecker` in the new `robocop/linter/rules/raw_file.py`. **3 passes over the file content -> 1.**

## Design

- The **checker only gathers data**: it reads `source_lines` and detects the BOM once, then hands the data to the rules.
- The **`check-like` logic lives in `check()` methods on the rules**, following the pattern already used by `deprecated.py` and `typing.py`.
- **Rule definitions stay in their own category modules** (`comments`, `lengths`, `spacing`). Only the checker moved, so rule ids, names, categories, docs and configuration are untouched.
- The merged checker intentionally **groups rules from different categories**. It is the file content, not the rule category, that decides how these rules are evaluated.

Notable detail: `IgnoredDataChecker.detect_bom` previously both reported `bom-encoding-in-file` *and* set shared `is_bom` state consumed by the `ignored-data` scan. That entanglement is gone - the checker computes `is_bom` once and feeds it to both rules.

Because a merged checker is registered whenever *any* of its rules is enabled, every `check()` starts with an `enabled` guard. BOM detection and the line loop are additionally skipped when no relevant rule is enabled - previously the file was opened for BOM detection whenever either comment rule was on, so this is a small improvement.

Two incidental cleanups: `line-too-long` evaluated `ignore_pattern` twice (once via `line_is_ignored`, once inline), and `ignored-data` used a `bool`-returning `check_line` as a "stop scanning" protocol, now a plain bounded prefix loop.

## Testing

- `pytest tests` -> 1849 passed. (`test_cli.py::test_version` fails identically on a clean `main` checkout - pre-existing, stale installed version.)
- `ruff check`, `ruff format`, and `mypy --strict` are clean for the touched files.
- **Differential testing** old vs. new over a 515-issue corpus (`tests/linter/rules` + `tests/formatter`): byte-identical output, both with all six rules together **and with each rule selected in isolation**. The isolation run is what verifies the new `enabled` guards.
- BOM edge cases verified by hand: BOM + ignored data, BOM where line 1 *is* the section header, BOM-only file.
- `--fix` for `trailing-whitespace` and `--configure line-too-long.line_length` / `.ignore_pattern` verified (parameter access moved from `self.rule.param` to `self.param`).
- `robocop list rules`, `list rules --verbose` and `robocop docs line-too-long` produce byte-identical output, confirming the merge is invisible to users.

## Follow-ups

Next waves of the same refactor, roughly in order of value:

1. `KeywordCallChecker` - `visit_KeywordCall` is implemented by 21 checkers and the keyword name is normalized ~8x per call. Would start with the stateless ones (`sleep-keyword-used`, `not-allowed-keyword`, `if-can-be-used`, `number-of-returned-values`, `missing-keyword-name`, `not-enough-whitespace-after-setting`) plus the already-matching `DeprecatedStatementChecker`.
2. `ArgumentsChecker` - merge `first-argument-in-new-line` (spacing) with `arguments-per-line` (lengths).
3. Keyword-body scanners - `ReturnChecker` + `UnreachableCodeChecker` share the same traversal shape.
