### PR TITLE
refactor: merge keyword call checkers into a single checker

### DIFF
--- a/src/robocop/linter/rules/deprecated.py
+++ b/src/robocop/linter/rules/deprecated.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import string
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from robot.api import Token
 
@@ -63,6 +63,19 @@ class IfCanBeUsedRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0908",)
+
+    run_keyword_variants: ClassVar[set[str]] = {"runkeywordif", "runkeywordunless"}
+
+    def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> None:
+        if not self.enabled or normalized_keyword_name not in self.run_keyword_variants:
+            return
+        col = utils.keyword_col(node)
+        self.report(
+            run_keyword=keyword_name,
+            node=node,
+            col=col,
+            end_col=col + len(keyword_name),
+        )
 
 
 class DeprecatedStatementRule(Rule):
@@ -252,6 +265,8 @@ class ReplaceSetVariableWithVarRule(Rule):
 
     def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> bool:
         """Check and return True if issue not found, otherwise return False."""
+        if not self.enabled:
+            return True
         if normalized_keyword_name in self.set_variable_keywords:
             col = utils.token_col(node, Token.NAME, Token.KEYWORD)
             self.report(
@@ -302,6 +317,8 @@ class ReplaceCreateWithVarRule(Rule):
 
     def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> bool:
         """Check and return True if issue not found, otherwise return False."""
+        if not self.enabled:
+            return True
         if normalized_keyword_name in self.create_keywords:
             col = utils.token_col(node, Token.NAME, Token.KEYWORD)
             self.report(
@@ -403,6 +420,8 @@ class DeprecatedRunKeywordIfRule(Rule):
 
     def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> bool:
         """Check and return True if issue not found, otherwise return False."""
+        if not self.enabled:
+            return True
         if normalized_keyword_name in self.run_keyword_if_names:
             col = utils.token_col(node, Token.NAME, Token.KEYWORD)
             self.report(
@@ -476,6 +495,8 @@ class DeprecatedLoopKeywordRule(Rule):
 
     def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> bool:
         """Check and return True if issue not found, otherwise return False."""
+        if not self.enabled:
+            return True
         if normalized_keyword_name in self.deprecated_keywords:
             col = utils.token_col(node, Token.NAME, Token.KEYWORD)
             alternative = self.deprecated_keywords[normalized_keyword_name]
@@ -511,6 +532,8 @@ class DeprecatedReturnKeyword(FixableRule):
 
     def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> bool:
         """Check and return True if issue not found, otherwise return False."""
+        if not self.enabled:
+            return True
         if normalized_keyword_name in self.deprecated_keywords:
             col = utils.token_col(node, Token.NAME, Token.KEYWORD)
             alternative = self.deprecated_keywords[normalized_keyword_name]

--- a/src/robocop/linter/rules/errors.py
+++ b/src/robocop/linter/rules/errors.py
@@ -56,6 +56,29 @@ class MissingKeywordNameRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
 
+    def check(self, node: KeywordCall) -> None:
+        if not self.enabled or node.keyword:
+            return
+        self.report(
+            node=node,
+            lineno=node.lineno,
+            col=node.data_tokens[0].col_offset + 1,
+            end_col=node.data_tokens[0].end_col_offset + 1,
+        )
+
+    def check_assign_without_keyword(self, node: EmptyLine) -> None:
+        """Values assigned in a line without a keyword name are parsed as an empty line."""
+        if not self.enabled or ROBOT_VERSION.major < 5:
+            return
+        assign_token = node.get_token(Token.ASSIGN)
+        if assign_token:
+            self.report(
+                node=node,
+                lineno=node.lineno,
+                col=assign_token.col_offset + 1,
+                end_col=node.data_tokens[0].end_col_offset + 1,
+            )
+
 
 class VariablesImportWithArgsRule(Rule):
     """
@@ -607,74 +630,6 @@ class ParsingErrorChecker(VisitorChecker):
                 node=node,
                 lineno=node.lineno,
                 end_col=node.end_col_offset,
-            )
-
-
-class TwoSpacesAfterSettingsChecker(VisitorChecker):
-    """Checker for not enough whitespaces after [Setting] header."""
-
-    not_enough_whitespace_after_setting: whitespace.NotEnoughWhitespaceAfterSettingRule
-
-    def __init__(self) -> None:
-        self.headers = {
-            "arguments",
-            "documentation",
-            "setup",
-            "timeout",
-            "teardown",
-            "template",
-            "tags",
-        }
-        self.setting_pattern = re.compile(r"\[\s?(\w+)\s?\]")
-        super().__init__()
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        """Invalid settings like '[Arguments] ${var}' will be parsed as keyword call"""
-        if not node.keyword:
-            return
-
-        match = self.setting_pattern.match(node.keyword)
-        if not match:
-            return
-        if match.group(1).lower() in self.headers:
-            self.report(
-                self.not_enough_whitespace_after_setting,
-                setting_name=match.group(0),
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.data_tokens[0].end_col_offset + 1,
-            )
-
-
-class MissingKeywordName(VisitorChecker):  # TODO should be part of other checker
-    """Checker for missing keyword name."""
-
-    missing_keyword_name: MissingKeywordNameRule
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        self.generic_visit(node)
-
-    def visit_EmptyLine(self, node: EmptyLine) -> None:  # noqa: N802
-        if ROBOT_VERSION.major < 5:
-            return
-        assign_token = node.get_token(Token.ASSIGN)
-        if assign_token:
-            self.report(
-                self.missing_keyword_name,
-                node=node,
-                lineno=node.lineno,
-                col=assign_token.col_offset + 1,
-                end_col=node.data_tokens[0].end_col_offset + 1,
-            )
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        if not node.keyword:
-            self.report(
-                self.missing_keyword_name,
-                node=node,
-                lineno=node.lineno,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.data_tokens[0].end_col_offset + 1,
             )
 
 

--- a/src/robocop/linter/rules/keyword_calls.py
+++ b/src/robocop/linter/rules/keyword_calls.py
@@ -1,0 +1,86 @@
+"""Checker for rules triggered by keyword calls and keyword-name-like settings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robot.api import Token
+
+from robocop.linter.rules import VisitorChecker, deprecated, errors, keywords, lengths, whitespace
+from robocop.linter.utils.misc import normalize_robot_name
+from robocop.version_handling import ROBOT_VERSION
+
+if TYPE_CHECKING:
+    from robot.parsing.model.statements import EmptyLine, KeywordCall, Node, Return, Setup, Template
+
+
+class KeywordCallChecker(VisitorChecker):
+    """Checker for rules reported for keyword calls and keyword names used in the settings."""
+
+    sleep_keyword_used: keywords.SleepKeywordUsedRule
+    not_allowed_keyword: keywords.NotAllowedKeywordRule
+    if_can_be_used: deprecated.IfCanBeUsedRule
+    number_of_returned_values: lengths.NumberOfReturnedValuesRule
+    missing_keyword_name: errors.MissingKeywordNameRule
+    not_enough_whitespace_after_setting: whitespace.NotEnoughWhitespaceAfterSettingRule
+    deprecated_run_keyword_if: deprecated.DeprecatedRunKeywordIfRule
+    deprecated_loop_keyword: deprecated.DeprecatedLoopKeywordRule
+    deprecated_return_keyword: deprecated.DeprecatedReturnKeyword
+    replace_set_variable_with_var: deprecated.ReplaceSetVariableWithVarRule
+    replace_create_with_var: deprecated.ReplaceCreateWithVarRule
+
+    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
+        self.missing_keyword_name.check(node)
+        # not allowed keyword is also checked for nested run keywords, even if the keyword name is empty
+        self.not_allowed_keyword.check(node, Token.KEYWORD)
+        if not node.keyword:  # keyword name can be empty if the syntax is invalid
+            return
+        self.not_enough_whitespace_after_setting.check(node)
+        # Robot Framework ignores a case, underscores and whitespace when searching for keywords
+        # It will match sleep, Sleep, BuiltIn.Sleep or S_leep. That's why we need to normalize name first
+        normalized_name = normalize_robot_name(node.keyword, remove_prefix="builtin.")
+        self.sleep_keyword_used.check(node, normalized_name)
+        self.if_can_be_used.check(node, node.keyword, normalized_name)
+        self.number_of_returned_values.check_keyword_call(node, normalized_name)
+        self.check_if_keyword_is_deprecated(node.keyword, node, normalized_name)
+        self.check_keyword_can_be_replaced_with_var(node.keyword, node, normalized_name)
+
+    def visit_Setup(self, node: Setup) -> None:  # noqa: N802
+        self.not_allowed_keyword.check(node, Token.NAME)
+        if node.name:
+            self.check_if_keyword_is_deprecated(
+                node.name, node, normalize_robot_name(node.name, remove_prefix="builtin.")
+            )
+
+    visit_TestSetup = visit_SuiteSetup = visit_Teardown = visit_TestTeardown = visit_SuiteTeardown = visit_Setup  # noqa: N815
+
+    def visit_Template(self, node: Template) -> None:  # noqa: N802
+        if node.value:
+            self.not_allowed_keyword.check_keyword_name(node.value, node.get_token(Token.NAME))
+            self.check_if_keyword_is_deprecated(
+                node.value, node, normalize_robot_name(node.value, remove_prefix="builtin.")
+            )
+
+    visit_TestTemplate = visit_Template  # noqa: N815
+
+    def visit_EmptyLine(self, node: EmptyLine) -> None:  # noqa: N802
+        self.missing_keyword_name.check_assign_without_keyword(node)
+
+    def visit_Return(self, node: Return) -> None:  # noqa: N802
+        self.number_of_returned_values.check(len(node.values), node)
+
+    visit_ReturnStatement = visit_ReturnSetting = visit_Return  # noqa: N815
+
+    def check_if_keyword_is_deprecated(self, keyword_name: str, node: Node, normalized_name: str) -> None:
+        if not self.deprecated_run_keyword_if.check(node, keyword_name, normalized_name):
+            return
+        if not self.deprecated_loop_keyword.check(node, keyword_name, normalized_name):
+            return
+        self.deprecated_return_keyword.check(node, keyword_name, normalized_name)
+
+    def check_keyword_can_be_replaced_with_var(self, keyword_name: str, node: Node, normalized_name: str) -> None:
+        if ROBOT_VERSION.major < 7:
+            return
+        if not self.replace_set_variable_with_var.check(node, keyword_name, normalized_name):
+            return
+        self.replace_create_with_var.check(node, keyword_name, normalized_name)

--- a/src/robocop/linter/rules/keywords.py
+++ b/src/robocop/linter/rules/keywords.py
@@ -13,7 +13,7 @@ from robocop.parsing.run_keywords import iterate_keyword_names
 
 if TYPE_CHECKING:
     from robot.model import Keyword
-    from robot.parsing.model.statements import KeywordCall, Setup, Template
+    from robot.parsing.model.statements import KeywordCall, Setup
 
 
 def comma_separated_list(value: str | None) -> set[str]:
@@ -65,6 +65,32 @@ class SleepKeywordUsedRule(Rule):
     )
     deprecated_names = ("10001",)
 
+    def check(self, node: KeywordCall, normalized_keyword_name: str) -> None:
+        if not self.enabled or normalized_keyword_name != "sleep":
+            return
+        # retrieve sleep time: get first argument-like token from keyword node. Returns None if token does not exist
+        time_token = node.get_token(Token.ARGUMENT)
+        allowed_time = self.max_time
+        if allowed_time:
+            if not time_token:  # Sleep without time
+                return
+            try:
+                time_from_sleep = timestr_to_secs(time_token.value)
+            except ValueError:
+                # ignore invalid or not recognized time string
+                return
+            if allowed_time >= time_from_sleep:  # if Sleep time is less than an allowed maximum, we can ignore issue
+                return
+        # node can be multiline, ie Sleep ...  1 min -> report either just Sleep or multi-line report
+        duration_time = time_token.value if time_token else ""
+        name_token = node.get_token(Token.KEYWORD)
+        self.report(
+            duration_time=duration_time,
+            node=name_token,
+            col=name_token.col_offset + 1,
+            end_col=name_token.end_col_offset + 1,
+        )
+
 
 class NotAllowedKeywordRule(Rule):
     """
@@ -108,6 +134,32 @@ class NotAllowedKeywordRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("10002",)
+
+    def check(self, node: KeywordCall | Setup, name_token_type: str) -> None:
+        """Check the keyword name together with the names of the nested run keywords."""
+        if not self.enabled:
+            return
+        for keyword in iterate_keyword_names(node, name_token_type):
+            self.check_keyword_name(keyword.value, keyword)
+
+    def check_keyword_name(self, name: str, keyword: Token) -> None:
+        if not self.enabled or not name:
+            return
+        not_allowed = self.keywords  # TODO: handle not set not allowed
+        normalized_name = normalize_robot_name(name)
+        if normalized_name not in not_allowed:
+            if "." not in normalized_name:
+                return
+            # handle possible library names (builtin.log)
+            normalized_name = normalized_name.split(".")[-1]
+            if normalized_name not in not_allowed:
+                return
+        self.report(
+            keyword=name,
+            node=keyword,
+            col=keyword.col_offset + 1,
+            end_col=keyword.end_col_offset + 1,
+        )
 
 
 class NoEmbeddedKeywordArgumentsRule(Rule):
@@ -162,95 +214,6 @@ class NoEmbeddedKeywordArgumentsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("10003",)
-
-
-class SleepKeywordUsedChecker(VisitorChecker):  # TODO: merge with a checker for keyword calls
-    """
-    Find and report the use of the Sleep keyword in tests and keywords.
-
-    If max_time is configured, it can be used to only report Sleep with time higher than configured value.
-
-    Sleep in Run Keyword variants and with BDD are ignored.
-    """
-
-    sleep_keyword_used: SleepKeywordUsedRule
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        if not node.keyword:  # Keyword name can be empty if the syntax is invalid
-            return
-        # Robot Framework ignores a case, underscores and whitespace when searching for keywords
-        # It will match sleep, Sleep, BuiltIn.Sleep or S_leep. That's why we need to normalize name first
-        normalized_name = normalize_robot_name(node.keyword, remove_prefix="builtin.")
-        if normalized_name != "sleep":
-            return
-        # retrieve sleep time: get first argument-like token from keyword node. Returns None if token does not exist
-        time_token = node.get_token(Token.ARGUMENT)
-        allowed_time = self.sleep_keyword_used.max_time
-        if allowed_time:
-            if not time_token:  # Sleep without time
-                return
-            try:
-                time_from_sleep = timestr_to_secs(time_token.value)
-            except ValueError:
-                # ignore invalid or not recognized time string
-                return
-            if allowed_time >= time_from_sleep:  # if Sleep time is less than an allowed maximum, we can ignore issue
-                return
-        # node can be multiline, ie Sleep ...  1 min -> report either just Sleep or multi-line report
-        duration_time = time_token.value if time_token else ""
-        name_token = node.get_token(Token.KEYWORD)
-        self.report(
-            self.sleep_keyword_used,
-            duration_time=duration_time,
-            node=name_token,
-            col=name_token.col_offset + 1,
-            end_col=name_token.end_col_offset + 1,
-        )
-
-
-class NotAllowedKeyword(VisitorChecker):
-    not_allowed_keyword: NotAllowedKeywordRule
-
-    def check_keyword_naming_with_subkeywords(self, node: KeywordCall | Setup, name_token_type: str) -> None:
-        for keyword in iterate_keyword_names(node, name_token_type):
-            self.check_keyword_naming(keyword.value, keyword)
-
-    def check_keyword_naming(self, name: str, keyword: Token) -> None:
-        if not name:
-            return
-        not_allowed = self.not_allowed_keyword.keywords  # TODO: handle not set not allowed
-        normalized_name = normalize_robot_name(name)
-        if normalized_name not in not_allowed:
-            if "." not in normalized_name:
-                return
-            # handle possible library names (builtin.log)
-            normalized_name = normalized_name.split(".")[-1]
-            if normalized_name not in not_allowed:
-                return
-        self.report(
-            self.not_allowed_keyword,
-            keyword=name,
-            node=keyword,
-            col=keyword.col_offset + 1,
-            end_col=keyword.end_col_offset + 1,
-        )
-
-    def visit_Setup(self, node: Setup) -> None:  # noqa: N802
-        self.check_keyword_naming_with_subkeywords(node, Token.NAME)
-
-    visit_TestTeardown = visit_SuiteTeardown = visit_Teardown = visit_TestSetup = visit_SuiteSetup = visit_Setup  # noqa: N815
-
-    def visit_Template(self, node: Template) -> None:  # noqa: N802
-        # allow / disallow param
-        if node.value:
-            name_token = node.get_token(Token.NAME)
-            self.check_keyword_naming(node.value, name_token)
-        self.generic_visit(node)
-
-    visit_TestTemplate = visit_Template  # noqa: N815
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        self.check_keyword_naming_with_subkeywords(node, Token.KEYWORD)
 
 
 class NoEmbeddedKeywordArgumentsChecker(VisitorChecker):  # TODO merge

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -52,7 +52,7 @@ from robocop.version_handling import TYPE_SUPPORTED
 if TYPE_CHECKING:
     from robot.parsing import File
     from robot.parsing.model.blocks import For, Section, Try, VariableSection
-    from robot.parsing.model.statements import Node, Return, Statement
+    from robot.parsing.model.statements import Node, Statement
 
 
 class TooLongKeywordRule(Rule):
@@ -364,6 +364,26 @@ class NumberOfReturnedValuesRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.FOCUSED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0510",)
+
+    def check(self, return_count: int, node: Node) -> None:
+        if not self.enabled or return_count <= self.max_returns:
+            return
+        self.report(
+            return_count=return_count,
+            max_allowed_count=self.max_returns,
+            node=node,
+            col=node.data_tokens[0].col_offset + 1,
+            end_col=node.data_tokens[0].end_col_offset + 1,
+            sev_threshold_value=return_count,
+        )
+
+    def check_keyword_call(self, node: KeywordCall, normalized_keyword_name: str) -> None:
+        if not self.enabled:
+            return
+        if normalized_keyword_name == "returnfromkeyword":
+            self.check(len(node.args), node)
+        elif normalized_keyword_name == "returnfromkeywordif":
+            self.check(len(node.args) - 1, node)
 
 
 class EmptyMetadataRule(Rule):
@@ -1072,39 +1092,6 @@ class EmptySectionChecker(VisitorChecker):
 
     def visit_Section(self, node: Section) -> None:  # noqa: N802
         self.check_if_empty(node)
-
-
-class NumberOfReturnedArgsChecker(VisitorChecker):
-    """Checker for number of returned values from a keyword."""
-
-    number_of_returned_values: NumberOfReturnedValuesRule
-
-    def visit_Return(self, node: Return) -> None:  # noqa: N802
-        self.check_node_returns(len(node.values), node)
-
-    visit_ReturnStatement = visit_ReturnSetting = visit_Return  # noqa: N815
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        if not node.keyword:
-            return
-
-        normalized_name = normalize_robot_name(node.keyword, remove_prefix="builtin.")
-        if normalized_name == "returnfromkeyword":
-            self.check_node_returns(len(node.args), node)
-        elif normalized_name == "returnfromkeywordif":
-            self.check_node_returns(len(node.args) - 1, node)
-
-    def check_node_returns(self, return_count: int, node: Node) -> None:
-        if return_count > self.number_of_returned_values.max_returns:
-            self.report(
-                self.number_of_returned_values,
-                return_count=return_count,
-                max_allowed_count=self.number_of_returned_values.max_returns,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.data_tokens[0].end_col_offset + 1,
-                sev_threshold_value=return_count,
-            )
 
 
 class EmptySettingsChecker(VisitorChecker):

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -37,7 +37,6 @@ from robocop.linter.rules import (
     SeverityThreshold,
     VisitorChecker,
     arguments,
-    deprecated,
     typing,
     variables,
 )
@@ -806,30 +805,6 @@ class NestedForLoopsChecker(VisitorChecker):  # TODO: merge
                     col=token.col_offset + 1,
                     end_col=token.end_col_offset + 1,
                 )
-
-
-class IfBlockCanBeUsed(VisitorChecker):
-    """
-    Checker for potential IF block usage in Robot Framework 4.0
-
-    Run Keyword variants (Run Keyword If, Run Keyword Unless) can be replaced with IF in RF 4.0
-    """
-
-    if_can_be_used: deprecated.IfCanBeUsedRule
-    run_keyword_variants = {"runkeywordif", "runkeywordunless"}
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        if not node.keyword:
-            return
-        if utils.normalize_robot_name(node.keyword, remove_prefix="builtin.") in self.run_keyword_variants:
-            col = utils.keyword_col(node)
-            self.report(
-                self.if_can_be_used,
-                run_keyword=node.keyword,
-                node=node,
-                col=col,
-                end_col=col + len(node.keyword),
-            )
 
 
 class ConsistentAssignmentSignChecker(VisitorChecker):

--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -1390,31 +1390,12 @@ class DeprecatedStatementChecker(VisitorChecker):
     deprecated_with_name: deprecated.DeprecatedWithNameRule
     deprecated_singular_header: deprecated.DeprecatedSingularHeaderRule
     deprecated_force_tags: deprecated.DeprecatedForceTagsRule
-    deprecated_run_keyword_if: deprecated.DeprecatedRunKeywordIfRule
-    deprecated_loop_keyword: deprecated.DeprecatedLoopKeywordRule
-    deprecated_return_keyword: deprecated.DeprecatedReturnKeyword
     deprecated_return_setting: deprecated.DeprecatedReturnSetting
-    replace_set_variable_with_var: deprecated.ReplaceSetVariableWithVarRule
-    replace_create_with_var: deprecated.ReplaceCreateWithVarRule
 
     def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
         self.context.keyword = node
         self.generic_visit(node)
         self.context.keyword = None
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        self.check_if_keyword_is_deprecated(node.keyword, node)
-        self.check_keyword_can_be_replaced_with_var(node.keyword, node)
-
-    def visit_SuiteSetup(self, node: Setup) -> None:  # noqa: N802
-        self.check_if_keyword_is_deprecated(node.name, node)
-
-    visit_TestSetup = visit_Setup = visit_SuiteTeardown = visit_TestTeardown = visit_Teardown = visit_SuiteSetup  # noqa: N815
-
-    def visit_Template(self, node: Template) -> None:  # noqa: N802
-        self.check_if_keyword_is_deprecated(node.value, node)
-
-    visit_TestTemplate = visit_Template  # noqa: N815
 
     def visit_Return(self, node: Return) -> None:  # noqa: N802
         """For RETURN use visit_ReturnStatement - visit_Return will most likely visit RETURN in the future"""
@@ -1427,26 +1408,6 @@ class DeprecatedStatementChecker(VisitorChecker):
 
     def visit_ForceTags(self, node: ForceTags) -> None:  # noqa: N802
         self.deprecated_force_tags.check(node)
-
-    def check_if_keyword_is_deprecated(self, keyword_name: str | None, node: Node) -> None:
-        if not keyword_name:
-            return
-        normalized_keyword_name = utils.normalize_robot_name(keyword_name, remove_prefix="builtin.")
-        if not self.deprecated_run_keyword_if.check(node, keyword_name, normalized_keyword_name):
-            return
-        if not self.deprecated_loop_keyword.check(node, keyword_name, normalized_keyword_name):
-            return
-        if not self.deprecated_return_keyword.check(node, keyword_name, normalized_keyword_name):
-            return
-
-    def check_keyword_can_be_replaced_with_var(self, keyword_name: str | None, node: Node) -> None:
-        if ROBOT_VERSION.major < 7 or not keyword_name:
-            return
-        normalized = utils.normalize_robot_name(keyword_name, remove_prefix="builtin.")
-        if not self.replace_set_variable_with_var.check(node, keyword_name, normalized):
-            return
-        if not self.replace_create_with_var.check(node, keyword_name, normalized):
-            return
 
     def visit_LibraryImport(self, node: LibraryImport) -> None:  # noqa: N802
         self.deprecated_with_name.check(node)

--- a/src/robocop/linter/rules/whitespace.py
+++ b/src/robocop/linter/rules/whitespace.py
@@ -7,8 +7,14 @@ can be moved here.
 
 from __future__ import annotations
 
+import re
+from typing import TYPE_CHECKING, ClassVar
+
 from robocop.linter import sonar_qube
 from robocop.linter.rules import Rule, RuleSeverity
+
+if TYPE_CHECKING:
+    from robot.parsing.model.statements import KeywordCall
 
 
 class NotEnoughWhitespaceAfterSettingRule(Rule):
@@ -54,6 +60,32 @@ class NotEnoughWhitespaceAfterSettingRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("0402",)
+
+    headers: ClassVar[set[str]] = {
+        "arguments",
+        "documentation",
+        "setup",
+        "timeout",
+        "teardown",
+        "template",
+        "tags",
+    }
+    setting_pattern = re.compile(r"\[\s?(\w+)\s?\]")
+
+    def check(self, node: KeywordCall) -> None:
+        """Invalid settings like '[Arguments] ${var}' will be parsed as keyword call."""
+        if not self.enabled:
+            return
+        match = self.setting_pattern.match(node.keyword)
+        if not match:
+            return
+        if match.group(1).lower() in self.headers:
+            self.report(
+                setting_name=match.group(0),
+                node=node,
+                col=node.data_tokens[0].col_offset + 1,
+                end_col=node.data_tokens[0].end_col_offset + 1,
+            )
 
 
 class NotEnoughWhitespaceAfterNewlineMarkerRule(Rule):


### PR DESCRIPTION
Wave 2 of the single-visitor migration (follow-up to #1806).

## What

Collapses **seven AST visitors into one**. Each of these previously did its own full walk of every file just to look at keyword calls:

| Removed checker | Module |
| --- | --- |
| `SleepKeywordUsedChecker` | `keywords.py` |
| `NotAllowedKeyword` | `keywords.py` |
| `IfBlockCanBeUsed` | `misc.py` |
| `NumberOfReturnedArgsChecker` | `lengths.py` |
| `MissingKeywordName` | `errors.py` |
| `TwoSpacesAfterSettingsChecker` | `errors.py` |
| keyword-name part of `DeprecatedStatementChecker` | `naming.py` |

They are replaced by a single `KeywordCallChecker` in the new `src/robocop/linter/rules/keyword_calls.py`, hosting 11 rules from 5 categories (keywords, deprecated, lengths, errors, whitespace).

Following the design already used by the deprecated rules, the decision logic moved out of the visitors and into `check()` methods on the `Rule` classes. The visitor is now only responsible for traversal and for gathering shared data.

`DeprecatedStatementChecker` stays in `naming.py`, slimmed to the four statement/setting-triggered rules (`deprecated-with-name`, `deprecated-singular-header`, `deprecated-force-tags`, `deprecated-return-setting`). It keeps `visit_Keyword` because `deprecated-return-setting` relies on the keyword context.

## Why

The keyword name is now normalized **once** per keyword call and shared by 8 rules, instead of each checker recomputing it. More importantly it removes 6 redundant AST traversals per file.

Runtime checker count drops from 53 to 48.

## No user-visible change

Checkers are an internal implementation detail - rule ids, names, messages, severities, positions, configuration and documentation are untouched.

## Validation

- `pytest tests` - 1849 passed, 79 skipped (only the pre-existing `test_cli.py::test_version` failure, which also fails on a clean `main`)
- `ruff check` / `ruff format` clean, `mypy --strict` reports the same 7 pre-existing errors as `main`
- **Differential run against `main`** over the full `tests/linter/rules` + `tests/formatter` corpus (~19k reported issues) - byte-identical output, both with all 15 affected rules enabled together **and** with each rule selected in isolation (the latter validates the newly added `enabled` guards in the rule `check()` methods)
- `robocop list rules` and `robocop list rules --verbose` byte-identical
