### PR TITLE
refactor: merge keyword argument checkers into a single checker

### DIFF
--- a/src/robocop/linter/rules/arguments.py
+++ b/src/robocop/linter/rules/arguments.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, ClassVar
+
+from robot.api import Token
+
 from robocop.linter import sonar_qube
 from robocop.linter.rules import Rule, RuleParam, RuleSeverity
+from robocop.linter.utils.misc import normalize_robot_var_name, split_argument_default_value
+from robocop.version_handling import TYPE_SUPPORTED
+
+if TYPE_CHECKING:
+    from robot.parsing.model.statements import Arguments, KeywordCall
 
 
 class UnusedArgumentRule(Rule):
@@ -84,6 +93,23 @@ class UndefinedArgumentDefaultRule(Rule):
     )
     deprecated_names = ("0932",)
 
+    def check(self, node: Arguments) -> None:
+        if not self.enabled:
+            return
+        for token in node.get_tokens(Token.ARGUMENT):
+            arg = token.value
+            arg_name, default_val = split_argument_default_value(arg)
+            if arg_name == arg:  # has no default
+                continue
+            if default_val == "":
+                self.report(
+                    node=token,
+                    lineno=token.lineno,
+                    col=token.col_offset + 1,
+                    end_col=token.col_offset + len(token.value) + 1,
+                    arg_name=arg_name,
+                )
+
 
 class UndefinedArgumentValueRule(Rule):
     r"""
@@ -115,6 +141,33 @@ class UndefinedArgumentValueRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0933",)
+
+    # used by AssertionEngine library
+    assertion_operators: ClassVar[set[str]] = {"==", "!=", "<", ">", "<=", ">=", "*=", "^=", "$=", "$"}
+
+    def check(self, node: KeywordCall) -> None:
+        if not self.enabled:
+            return
+        for token in node.get_tokens(Token.ARGUMENT):
+            arg = token.value
+            if arg in self.assertion_operators:
+                continue
+            if "=" not in arg or arg.startswith("="):  # is a positional arg
+                continue
+            arg_name, default_val = arg.split("=", maxsplit=1)
+            if arg_name.endswith("\\"):  # `=` is escaped
+                continue
+            if default_val != "":  # has a value
+                continue
+            # Falsly triggers if a positional argument ends with `=`
+            # The language server has the same behavior
+            self.report(
+                node=token,
+                lineno=token.lineno,
+                col=token.col_offset + 1,
+                end_col=token.col_offset + len(token.value) + 1,
+                arg_name=arg_name,
+            )
 
 
 class InvalidArgumentsRule(Rule):
@@ -172,6 +225,24 @@ class DuplicatedArgumentRule(Rule):
     )
     deprecated_names = ("0811",)
 
+    def check(self, node: Arguments) -> None:
+        if not self.enabled:
+            return
+        args: set[str] = set()
+        for arg in node.get_tokens(Token.ARGUMENT):
+            orig, *_ = arg.value.split("=", maxsplit=1)
+            name = normalize_robot_var_name(orig, strip_type=TYPE_SUPPORTED)
+            if name in args:  # TODO could be handled with other variables rules
+                self.report(
+                    argument_name=orig,
+                    node=node,
+                    lineno=arg.lineno,
+                    col=arg.col_offset + 1,
+                    end_col=arg.col_offset + len(orig) + 1,
+                )
+            else:
+                args.add(name)
+
 
 class ArgumentsPerLineRule(Rule):
     """
@@ -214,3 +285,30 @@ class ArgumentsPerLineRule(Rule):
     )
     deprecated_names = ("0532",)
     # TODO flag to allow for [Arguments] multiple args ine one line, just not in other ...
+
+    def check(self, node: Arguments) -> None:
+        if not self.enabled:
+            return
+        if not node.get_token(Token.CONTINUATION):  # only one line, ignoring
+            return
+        max_args = self.max_args
+        for line in node.lines:
+            args_count = sum(1 for token in line if token.type == Token.ARGUMENT)
+            if args_count <= max_args:
+                continue
+            data_token = self.first_non_sep(line)
+            if data_token:
+                self.report(
+                    node=data_token,
+                    col=data_token.col_offset + 1,
+                    end_col=line[-1].end_col_offset,
+                    arguments_count=args_count,
+                    max_arguments_count=max_args,
+                )
+
+    @staticmethod
+    def first_non_sep(line: list[Token]) -> Token | None:
+        for token in line:
+            if token.type != Token.SEPARATOR:
+                return token
+        return None

--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypeVar
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker, arguments, order, variables
+from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker, order, variables
 from robocop.linter.utils.misc import (
     normalize_robot_name,
     normalize_robot_var_name,
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from robot.parsing import File
     from robot.parsing.model.blocks import Keyword, TestCase, VariableSection
     from robot.parsing.model.statements import (
-        Arguments,
         Error,
         KeywordCall,
         LibraryImport,
@@ -299,7 +298,6 @@ class DuplicationsChecker(VisitorChecker):
     duplicated_library: DuplicatedLibraryRule
     duplicated_metadata: DuplicatedMetadataRule
     duplicated_variables_import: DuplicatedVariablesImportRule
-    duplicated_argument_name: arguments.DuplicatedArgumentRule
     duplicated_assigned_var_name: variables.DuplicatedAssignedVarNameRule
     duplicated_setting: DuplicatedSettingRule
 
@@ -422,23 +420,6 @@ class DuplicationsChecker(VisitorChecker):
             return
         name_with_args = node.name + "".join(token.value for token in node.data_tokens[2:])
         self.variable_imports[name_with_args].append(node)
-
-    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
-        args = set()
-        for arg in node.get_tokens(Token.ARGUMENT):
-            orig, *_ = arg.value.split("=", maxsplit=1)
-            name = normalize_robot_var_name(orig, strip_type=TYPE_SUPPORTED)
-            if name in args:  # TODO could be handled with other variables rules
-                self.report(
-                    self.duplicated_argument_name,
-                    argument_name=orig,
-                    node=node,
-                    lineno=arg.lineno,
-                    col=arg.col_offset + 1,
-                    end_col=arg.col_offset + len(orig) + 1,
-                )
-            else:
-                args.add(name)
 
     def visit_Error(self, node: Error) -> None:  # noqa: N802
         for error in node.errors:

--- a/src/robocop/linter/rules/keyword_arguments.py
+++ b/src/robocop/linter/rules/keyword_arguments.py
@@ -1,0 +1,31 @@
+"""Checker for rules triggered by keyword arguments."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robocop.linter.rules import VisitorChecker, arguments, keywords, spacing
+
+if TYPE_CHECKING:
+    from robot.parsing.model.blocks import Keyword
+    from robot.parsing.model.statements import Arguments
+
+
+class ArgumentsChecker(VisitorChecker):
+    """Checker for rules reported for the keyword arguments."""
+
+    first_argument_in_new_line: spacing.FirstArgumentInNewLineRule
+    arguments_per_line: arguments.ArgumentsPerLineRule
+    undefined_argument_default: arguments.UndefinedArgumentDefaultRule
+    duplicated_argument_name: arguments.DuplicatedArgumentRule
+    no_embedded_keyword_arguments: keywords.NoEmbeddedKeywordArgumentsRule
+
+    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
+        self.no_embedded_keyword_arguments.check(node)
+        self.generic_visit(node)
+
+    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
+        self.first_argument_in_new_line.check(node)
+        self.arguments_per_line.check(node)
+        self.undefined_argument_default.check(node)
+        self.duplicated_argument_name.check(node)

--- a/src/robocop/linter/rules/keyword_calls.py
+++ b/src/robocop/linter/rules/keyword_calls.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from robot.api import Token
 
-from robocop.linter.rules import VisitorChecker, deprecated, errors, keywords, lengths, whitespace
+from robocop.linter.rules import VisitorChecker, arguments, deprecated, errors, keywords, lengths, whitespace
 from robocop.linter.utils.misc import normalize_robot_name
 from robocop.version_handling import ROBOT_VERSION
 
@@ -28,9 +28,11 @@ class KeywordCallChecker(VisitorChecker):
     deprecated_return_keyword: deprecated.DeprecatedReturnKeyword
     replace_set_variable_with_var: deprecated.ReplaceSetVariableWithVarRule
     replace_create_with_var: deprecated.ReplaceCreateWithVarRule
+    undefined_argument_value: arguments.UndefinedArgumentValueRule
 
     def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
         self.missing_keyword_name.check(node)
+        self.undefined_argument_value.check(node)
         # not allowed keyword is also checked for nested run keywords, even if the keyword name is empty
         self.not_allowed_keyword.check(node, Token.KEYWORD)
         if not node.keyword:  # keyword name can be empty if the syntax is invalid

--- a/src/robocop/linter/rules/keywords.py
+++ b/src/robocop/linter/rules/keywords.py
@@ -7,7 +7,7 @@ from robot.errors import VariableError
 from robot.utils.robottime import timestr_to_secs
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker
+from robocop.linter.rules import Rule, RuleParam, RuleSeverity
 from robocop.linter.utils.misc import normalize_robot_name
 from robocop.parsing.run_keywords import iterate_keyword_names
 
@@ -215,21 +215,17 @@ class NoEmbeddedKeywordArgumentsRule(Rule):
     )
     deprecated_names = ("10003",)
 
-
-class NoEmbeddedKeywordArgumentsChecker(VisitorChecker):  # TODO merge
-    no_embedded_keyword_arguments: NoEmbeddedKeywordArgumentsRule
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
+    def check(self, node: Keyword) -> None:
+        if not self.enabled:
+            return
         name_token: Token = node.header.get_token(Token.KEYWORD_NAME)
         try:
             variable_tokens = [t for t in name_token.tokenize_variables() if t.type == Token.VARIABLE]
         except VariableError:
             return
-
         if not variable_tokens:
             return
         self.report(
-            self.no_embedded_keyword_arguments,
             node=name_token,
             end_col=name_token.end_col_offset + 1,
             arguments=", ".join([t.value for t in variable_tokens]),

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -35,7 +35,6 @@ from robocop.linter.rules import (
     RuleSeverity,
     SeverityThreshold,
     VisitorChecker,
-    arguments,
 )
 from robocop.linter.utils.misc import (
     RETURN_CLASSES,
@@ -1273,34 +1272,3 @@ class TestCaseNumberChecker(VisitorChecker):  # TODO: good example of checker th
                 end_col=node.header.end_col_offset,
                 sev_threshold_value=discovered_testcases,
             )
-
-
-class TooManyArgumentsInLineChecker(VisitorChecker):
-    arguments_per_line: arguments.ArgumentsPerLineRule
-
-    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
-        any_cont_token = node.get_token(Token.CONTINUATION)
-        if not any_cont_token:  # only one line, ignoring
-            return
-        max_args = self.arguments_per_line.max_args
-        for line in node.lines:
-            args_count = sum(1 for token in line if token.type == Token.ARGUMENT)
-            if args_count > max_args:
-                data_token = self.first_non_sep(line)
-                last_token = line[-1]
-                if data_token:
-                    self.report(
-                        self.arguments_per_line,
-                        node=data_token,
-                        col=data_token.col_offset + 1,
-                        end_col=last_token.end_col_offset,
-                        arguments_count=args_count,
-                        max_arguments_count=max_args,
-                    )
-
-    @staticmethod
-    def first_non_sep(line: list[Token]) -> Token | None:
-        for token in line:
-            if token.type != Token.SEPARATOR:
-                return token
-        return None

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -1856,62 +1856,6 @@ class NonLocalVariableChecker(VisitorChecker):
         )
 
 
-class UndefinedArgumentDefaultChecker(VisitorChecker):
-    undefined_argument_default: arguments.UndefinedArgumentDefaultRule
-    undefined_argument_value: arguments.UndefinedArgumentValueRule
-    # used by AssertionEngine library
-    assertion_operators = {"==", "!=", "<", ">", "<=", ">=", "*=", "^=", "$=", "$"}
-
-    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
-        for token in node.get_tokens(Token.ARGUMENT):
-            arg = token.value
-            arg_name, default_val = utils.split_argument_default_value(arg)
-
-            if arg_name == arg:
-                # has no default
-                continue
-
-            if default_val == "":
-                self.report(
-                    self.undefined_argument_default,
-                    node=token,
-                    lineno=token.lineno,
-                    col=token.col_offset + 1,
-                    end_col=token.col_offset + len(token.value) + 1,
-                    arg_name=arg_name,
-                )
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        for token in node.get_tokens(Token.ARGUMENT):
-            arg = token.value
-
-            if arg in self.assertion_operators:
-                continue
-            if "=" not in arg or arg.startswith("="):
-                # Is a positional arg
-                continue
-
-            arg_name, default_val = arg.split("=", maxsplit=1)
-            if arg_name.endswith("\\"):
-                # `=` is escaped
-                continue
-
-            if default_val != "":
-                # Has a value
-                continue
-
-            # Falsly triggers if a positional argument ends with `=`
-            # The language server has the same behavior
-            self.report(
-                self.undefined_argument_value,
-                node=token,
-                lineno=token.lineno,
-                col=token.col_offset + 1,
-                end_col=token.col_offset + len(token.value) + 1,
-                arg_name=arg_name,
-            )
-
-
 class UnusedDiagnosticChecker(AfterRunChecker):
     unused_disabler: DisablerNotUsedRule
 

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     from robot.parsing import File
     from robot.parsing.model import Block, Section
-    from robot.parsing.model.statements import Node, Statement
+    from robot.parsing.model.statements import Arguments, Node, Statement
 
     from robocop.linter.diagnostics import Diagnostic
 
@@ -727,6 +727,24 @@ class FirstArgumentInNewLineRule(Rule):
     )
     deprecated_names = ("1018",)
 
+    def check(self, node: Arguments) -> None:
+        if not self.enabled:
+            return
+        eol_already = None
+        for token in node.tokens:
+            if token.type == Token.EOL:
+                eol_already = token
+            elif token.type == Token.ARGUMENT:
+                if eol_already is not None:
+                    self.report(
+                        argument_name=token.value,
+                        lineno=eol_already.lineno,
+                        end_lineno=token.lineno,
+                        col=eol_already.end_col_offset,
+                        end_col=token.end_col_offset,
+                    )
+                return
+
 
 class EmptyLinesChecker(VisitorChecker):
     """Checker for invalid spacing."""
@@ -1364,25 +1382,3 @@ class LeftAlignedChecker(VisitorChecker):
                         col=indent + 1,
                     )
                     break
-
-
-class ArgumentsChecker(VisitorChecker):  # TODO merge!!, candidate to check inside rule
-    first_argument_in_new_line: FirstArgumentInNewLineRule
-
-    def visit_Arguments(self, node: Node) -> None:  # noqa: N802
-        eol_already = None
-        for t in node.tokens:
-            if t.type == Token.EOL:
-                eol_already = t
-                continue
-            if t.type == Token.ARGUMENT:
-                if eol_already is not None:
-                    self.report(
-                        self.first_argument_in_new_line,
-                        argument_name=t.value,
-                        lineno=eol_already.lineno,
-                        end_lineno=t.lineno,
-                        col=eol_already.end_col_offset,
-                        end_col=t.end_col_offset,
-                    )
-                return


### PR DESCRIPTION
Wave 3 of the single-visitor migration (follow-up to #1806 and #1807).

## What

Four AST visitors that each walked every file only to look at `[Arguments]` are collapsed into a single `ArgumentsChecker` in the new `src/robocop/linter/rules/keyword_arguments.py`:

| Removed checker | Module | Rule |
| --- | --- | --- |
| `ArgumentsChecker` | `spacing.py` | `first-argument-in-new-line` |
| `TooManyArgumentsInLineChecker` | `lengths.py` | `arguments-per-line` |
| `UndefinedArgumentDefaultChecker` | `misc.py` | `undefined-argument-default` |
| `NoEmbeddedKeywordArgumentsChecker` | `keywords.py` | `no-embedded-keyword-arguments` |

Two rules are also relocated:

- `duplicated-argument-name` moves out of `DuplicationsChecker` into the new checker. Its `visit_Arguments` was stateless and had nothing to do with the duplicate tracking the rest of that checker does.
- `undefined-argument-value` is triggered by **keyword calls**, not by `[Arguments]`, so it moves into the existing `KeywordCallChecker`. This splits `UndefinedArgumentDefaultChecker` along the lines of what actually triggers each of its two rules.

As in the previous waves, the decision logic moves into `check()` methods on the `Rule` classes and the visitor is left responsible only for traversal.

Runtime checker count drops from 48 to 45 (53 before this refactor series started).

## No user-visible change

Checkers are an internal implementation detail - rule ids, names, messages, severities, positions, configuration and documentation are untouched.

## Validation

- `pytest tests` - 1849 passed, 79 skipped (only the pre-existing `test_cli.py::test_version` failure, which also fails on a clean `main`)
- `ruff check` / `ruff format` clean, `mypy --strict` reports the same 7 pre-existing errors as `main`
- **Differential run against `main`** over `tests/linter/rules` + `tests/formatter`, byte-identical in every configuration:
  - the 6 affected rules enabled together
  - each of the 6 rules selected in isolation (validates the new `enabled` guards in the rule `check()` methods)
  - a full `--select ALL` run covering ~189k reported issues, which also guards the checkers that were edited but not moved
- `robocop list rules --verbose` byte-identical
