### PR TITLE
ci: let refactor commits trigger a release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,7 +18,7 @@
     {"type": "fix", "section": "Bug Fixes"},
     {"type": "docs", "section": "Documentation"},
     {"type": "perf", "section": "Performance"},
-    {"type": "refactor", "section": "Refactoring", "hidden": true},
+    {"type": "refactor", "section": "Refactoring"},
     {"type": "chore", "section": "Miscellaneous", "hidden": true},
     {"type": "test", "section": "Tests", "hidden": true}
   ],


### PR DESCRIPTION
## Problem

The recent `refactor:` commits (#1806, #1807) did not trigger release-please. The workflow log for the last one shows:

```
✔ Considering: 4 commits
❯ pull request title pattern: undefined
✔ No user facing commits found since 4529e53900bd18524f542e728e66f8425090d3bd - skipping
```

`refactor` **was** already listed in `changelog-sections`, but with `"hidden": true`. release-please treats hidden types as not user facing, so a push that contains only hidden-type commits is skipped and no release PR is opened.

## Fix

Remove `"hidden": true` from the `refactor` section. Refactor commits now count as releasable and show up under a "Refactoring" heading in the changelog.

## Note on the version bump

release-please's `default` versioning strategy hardcodes the type-to-bump mapping:

- breaking change -> major
- `feat` -> minor
- everything else -> **patch**

There is no config option to remap another type to a minor bump, so `refactor:` commits will produce a patch bump. If a particular refactor warrants a minor release, add a `Release-As: X.Y.0` footer to that commit.
