### PR TITLE
refactor: merge keyword body checkers into a single checker

### DIFF
--- a/src/robocop/linter/rules/keyword_body.py
+++ b/src/robocop/linter/rules/keyword_body.py
@@ -1,0 +1,32 @@
+"""Checker for rules triggered by scanning the body of a keyword or a block."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robocop.linter.rules import VisitorChecker, misc
+
+if TYPE_CHECKING:
+    from robot.parsing.model.blocks import Block
+    from robot.parsing.model.statements import Node
+
+
+class BodyChecker(VisitorChecker):
+    """Checker for rules that scan the direct children of a keyword or a block."""
+
+    keyword_after_return: misc.KeywordAfterReturnRule
+    empty_return: misc.EmptyReturnRule
+    unreachable_code: misc.UnreachableCodeRule
+    nested_for_loop: misc.NestedForLoopRule
+
+    def visit_Keyword(self, node: Block) -> None:  # noqa: N802
+        self.keyword_after_return.check(node)
+        self.empty_return.check(node)
+        self.unreachable_code.check(node)
+        self.generic_visit(node)
+
+    visit_If = visit_For = visit_While = visit_Try = visit_Keyword  # noqa: N815
+
+    def visit_ForLoop(self, node: Node) -> None:  # noqa: N802
+        # For RF 4.0 node is "For" but we purposely don't visit it because nested for loop is allowed in 4.0
+        self.nested_for_loop.check(node)

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from robot.parsing.model import File, Keyword, TestCase
-    from robot.parsing.model.blocks import For, KeywordSection, Try, VariableSection, While
+    from robot.parsing.model.blocks import Block, For, KeywordSection, Try, VariableSection, While
     from robot.parsing.model.statements import Error, LibraryImport, Node, Var
 
     from robocop.linter.diagnostics import Diagnostic
@@ -93,6 +93,39 @@ class KeywordAfterReturnRule(Rule):
     )
     deprecated_names = ("0901",)
 
+    def check(self, node: Block) -> None:
+        """Report a keyword call placed after the keyword already returned."""
+        if not self.enabled:
+            return
+        return_node: Node | None = None
+        keyword_after_return = False
+        return_from = False
+        error = ""
+        for child in node.body:
+            if isinstance(child, utils.RETURN_CLASSES.return_setting_class):
+                return_node = child
+                error = (
+                    "[Return] is not defined at the end of keyword. "
+                    "Note that [Return] does not quit from keyword but only set variables to be returned"
+                )
+            elif not isinstance(child, (EmptyLine, Comment, Teardown)) and return_node is not None:
+                keyword_after_return = True
+            if isinstance(child, KeywordCall):
+                if return_from:
+                    keyword_after_return = True
+                    return_node = child
+                    error = "Keyword call after 'Return From Keyword'"
+                elif utils.normalize_robot_name(child.keyword, remove_prefix="builtin.") == "returnfromkeyword":
+                    return_from = True
+        if keyword_after_return and return_node is not None:
+            token = return_node.data_tokens[0]
+            self.report(
+                error_msg=error,
+                node=token,
+                col=token.col_offset + 1,
+                end_col=token.end_col_offset + 1,
+            )
+
 
 class EmptyReturnRule(Rule):
     """
@@ -129,6 +162,19 @@ class EmptyReturnRule(Rule):
     )
     deprecated_names = ("0903",)
 
+    def check(self, node: Block) -> None:
+        """Report ``[Return]`` settings that do not return any value."""
+        if not self.enabled:
+            return
+        for child in node.body:
+            if isinstance(child, utils.RETURN_CLASSES.return_setting_class) and not child.values:
+                token = child.data_tokens[0]
+                self.report(
+                    node=child,
+                    col=token.col_offset + 1,
+                    end_col=token.col_offset + len(token.value),
+                )
+
 
 class NestedForLoopRule(Rule):
     """
@@ -157,6 +203,19 @@ class NestedForLoopRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0907",)
+
+    def check(self, node: Node) -> None:
+        """Report FOR loops nested directly in another FOR loop."""
+        if not self.enabled:
+            return
+        for child in node.body:
+            if child.type == "FOR":
+                token = child.get_token(Token.FOR)
+                self.report(
+                    node=child,
+                    col=token.col_offset + 1,
+                    end_col=token.end_col_offset + 1,
+                )
 
 
 class InconsistentAssignmentRule(Rule):
@@ -473,6 +532,26 @@ class UnreachableCodeRule(Rule):
     )
     deprecated_names = ("0917",)
 
+    def check(self, node: Block) -> None:
+        """Report statements placed after RETURN, BREAK or CONTINUE."""
+        if not self.enabled:
+            return
+        statement_node = None
+        for child in node.body:
+            if isinstance(child, (utils.RETURN_CLASSES.return_class, Break, Continue)):
+                statement_node = child
+            elif not isinstance(child, (EmptyLine, Comment, Teardown)) and statement_node is not None:
+                token = statement_node.data_tokens[0]
+                reported_node = child.header if hasattr(child, "header") else child
+                code_after_statement = reported_node.data_tokens[0]
+                self.report(
+                    statement=token.value,
+                    node=reported_node,
+                    col=code_after_statement.col_offset + 1,
+                    end_col=reported_node.end_col_offset,
+                )
+                statement_node = None
+
 
 class MultilineInlineIfRule(Rule):
     """
@@ -702,109 +781,6 @@ class DisablerNotUsedRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL,
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
-
-
-class ReturnChecker(VisitorChecker):
-    """Checker for [Return] and Return From Keyword violations."""
-
-    keyword_after_return: KeywordAfterReturnRule
-    empty_return: EmptyReturnRule
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
-        return_setting_node: Node = None
-        keyword_after_return = False
-        return_from = False
-        error = ""
-        for child in node.body:
-            if isinstance(child, utils.RETURN_CLASSES.return_setting_class):
-                return_setting_node = child
-                error = (
-                    "[Return] is not defined at the end of keyword. "
-                    "Note that [Return] does not quit from keyword but only set variables to be returned"
-                )
-                if not child.values:
-                    token = child.data_tokens[0]
-                    self.report(
-                        self.empty_return,
-                        node=child,
-                        col=token.col_offset + 1,
-                        end_col=token.col_offset + len(token.value),
-                    )
-            elif not isinstance(child, (EmptyLine, Comment, Teardown)):
-                if return_setting_node is not None:
-                    keyword_after_return = True
-
-            if isinstance(child, KeywordCall):
-                if return_from:
-                    keyword_after_return = True
-                    return_setting_node = child
-                    error = "Keyword call after 'Return From Keyword'"
-                elif utils.normalize_robot_name(child.keyword, remove_prefix="builtin.") == "returnfromkeyword":
-                    return_from = True
-        if keyword_after_return and return_setting_node is not None:
-            token = return_setting_node.data_tokens[0]
-            self.report(
-                self.keyword_after_return,
-                error_msg=error,
-                node=token,
-                col=token.col_offset + 1,
-                end_col=token.end_col_offset + 1,
-            )
-        self.generic_visit(node)
-
-    visit_If = visit_For = visit_While = visit_Try = visit_Keyword  # noqa: N815
-
-
-class UnreachableCodeChecker(VisitorChecker):
-    """Checker for unreachable code after RETURN, BREAK or CONTINUE statements."""
-
-    unreachable_code: UnreachableCodeRule
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
-        statement_node = None
-
-        for child in node.body:
-            if isinstance(child, (utils.RETURN_CLASSES.return_class, Break, Continue)):
-                statement_node = child
-            elif not isinstance(child, (EmptyLine, Comment, Teardown)) and statement_node is not None:
-                token = statement_node.data_tokens[0]
-                if hasattr(child, "header"):
-                    child = child.header
-                code_after_statement = child.data_tokens[0]
-                self.report(
-                    self.unreachable_code,
-                    statement=token.value,
-                    node=child,
-                    col=code_after_statement.col_offset + 1,
-                    end_col=child.end_col_offset,
-                )
-                statement_node = None
-
-        self.generic_visit(node)
-
-    visit_If = visit_For = visit_While = visit_Try = visit_Keyword  # noqa: N815
-
-
-class NestedForLoopsChecker(VisitorChecker):  # TODO: merge
-    """
-    Checker for not supported nested FOR loops.
-
-    Deprecated in RF 4.0
-    """
-
-    nested_for_loop: NestedForLoopRule
-
-    def visit_ForLoop(self, node: Node) -> None:  # noqa: N802
-        # For RF 4.0 node is "For" but we purposely don't visit it because nested for loop is allowed in 4.0
-        for child in node.body:
-            if child.type == "FOR":
-                token = child.get_token(Token.FOR)
-                self.report(
-                    self.nested_for_loop,
-                    node=child,
-                    col=token.col_offset + 1,
-                    end_col=token.end_col_offset + 1,
-                )
 
 
 class ConsistentAssignmentSignChecker(VisitorChecker):


### PR DESCRIPTION
Wave 4 of the single-visitor migration (follow-up to #1806, #1807, #1808).

## What

Three AST visitors that each walked every file to scan the direct children of a keyword or block are collapsed into a single `BodyChecker` in the new `src/robocop/linter/rules/keyword_body.py`:

| Removed checker | Rules |
| --- | --- |
| `ReturnChecker` | `keyword-after-return`, `empty-return` |
| `UnreachableCodeChecker` | `unreachable-code` |
| `NestedForLoopsChecker` | `nested-for-loop` |

`ReturnChecker` and `UnreachableCodeChecker` already had an identical traversal (`visit_Keyword = visit_If = visit_For = visit_While = visit_Try`), so they were walking exactly the same nodes twice.

As in the previous waves, the decision logic moves into `check()` methods on the `Rule` classes and the visitor is left responsible only for traversal.

One structural note: `empty-return` and `keyword-after-return` used to be computed in a single interleaved loop over `node.body`. They are now two independent passes, so each rule owns its own logic and can be skipped entirely when it is disabled. The reported diagnostics are unchanged.

Runtime checker count drops from 45 to 43 (53 before this refactor series started).

## No user-visible change

Checkers are an internal implementation detail - rule ids, names, messages, severities, positions, configuration and documentation are untouched.

## Validation

- `pytest tests` - 1849 passed, 79 skipped (only the pre-existing `test_cli.py::test_version` failure, which also fails on a clean `main`)
- `ruff check` / `ruff format` clean, `mypy --strict` reports the same 7 pre-existing errors as `main`
- **Differential run against `main`** over `tests/linter/rules` + `tests/formatter`, byte-identical in every configuration:
  - a full `--select ALL` run covering ~189k reported issues
  - each of the 4 affected rules selected in isolation (validates the new `enabled` guards in the rule `check()` methods)
- `robocop list rules --verbose` byte-identical
