### PR TITLE
refactor: merge section-level checkers into single SectionsChecker

### DIFF
--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypeVar
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker, order, variables
+from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker, variables
 from robocop.linter.utils.misc import (
     normalize_robot_name,
     normalize_robot_var_name,
@@ -239,6 +239,16 @@ class SectionAlreadyDefinedRule(Rule):
     )
     deprecated_names = ("0808",)
 
+    def check(self, node: SectionHeader, first_occurrence_line: int | None) -> None:
+        if not self.enabled or first_occurrence_line is None:
+            return
+        self.report(
+            section_name=node.data_tokens[0].value,
+            first_occurrence_line=first_occurrence_line,
+            node=node,
+            end_col=node.end_col_offset,
+        )
+
 
 class BothTestsAndTasksRule(Rule):
     """
@@ -261,6 +271,11 @@ class BothTestsAndTasksRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("0810",)
+
+    def check(self, node: SectionHeader, other_kind_already_defined: bool) -> None:
+        if not self.enabled or not other_kind_already_defined:
+            return
+        self.report(node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
 
 
 class DuplicatedSettingRule(Rule):
@@ -431,75 +446,3 @@ class DuplicationsChecker(VisitorChecker):
                     col=node.data_tokens[0].col_offset + 1,
                     end_col=node.data_tokens[0].end_col_offset + 1,
                 )
-
-
-class SectionHeadersChecker(VisitorChecker):
-    """Checker for duplicated or out of order section headers."""
-
-    section_already_defined: SectionAlreadyDefinedRule
-    section_out_of_order: order.SectionOutOfOrderRule
-    both_tests_and_tasks: BothTestsAndTasksRule
-
-    def __init__(self) -> None:
-        self.sections_by_order: list[int] = []
-        self.sections_by_existence: dict[str, int] = {}
-        super().__init__()
-
-    @staticmethod
-    def section_order_to_str(order: dict[str, int]) -> str:
-        by_index = sorted(order.items(), key=lambda x: x[1])
-        name_map = {
-            Token.COMMENT_HEADER: "Comments",
-            Token.SETTING_HEADER: "Settings",
-            Token.VARIABLE_HEADER: "Variables",
-            Token.TESTCASE_HEADER: "Test Cases / Tasks",
-            "TASK HEADER": "Test Cases / Tasks",
-            Token.KEYWORD_HEADER: "Keywords",
-        }
-        order_str = []
-        for name, _ in by_index:
-            mapped_name = name_map[name]
-            if mapped_name not in order_str:
-                order_str.append(mapped_name)
-        return " > ".join(order_str)
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        self.sections_by_order = []
-        self.sections_by_existence = {}
-        super().visit_File(node)
-
-    def visit_SectionHeader(self, node: SectionHeader) -> None:  # noqa: N802
-        section_name = node.type
-        if section_name not in self.section_out_of_order.sections_order:
-            return
-        if section_name in (Token.TESTCASE_HEADER, "TASK HEADER"):
-            # a bit awkward implementation because before RF 6.0 task header used TESTCASE_HEADER type
-            if "task" in node.name.lower():
-                section_name = "TASK HEADER"
-                if Token.TESTCASE_HEADER in self.sections_by_existence:
-                    self.report(
-                        self.both_tests_and_tasks, node=node, col=node.col_offset + 1, end_col=node.end_col_offset
-                    )
-            elif "TASK HEADER" in self.sections_by_existence:
-                self.report(self.both_tests_and_tasks, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-        order_id = self.section_out_of_order.sections_order[section_name]
-        if section_name in self.sections_by_existence:
-            self.report(
-                self.section_already_defined,
-                section_name=node.data_tokens[0].value,
-                first_occurrence_line=self.sections_by_existence[section_name],
-                node=node,
-                end_col=node.end_col_offset,
-            )
-        else:
-            self.sections_by_existence[section_name] = node.lineno
-        if any(previous_id > order_id for previous_id in self.sections_by_order):
-            token = node.data_tokens[0]
-            self.report(
-                self.section_out_of_order,
-                section_name=token.value,
-                recommended_order=self.section_order_to_str(self.section_out_of_order.sections_order),
-                node=node,
-                end_col=token.end_col_offset + 1,
-            )
-        self.sections_by_order.append(order_id)

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -344,6 +344,18 @@ class EmptySectionRule(Rule):
     )
     deprecated_names = ("0509",)
 
+    def check(self, node: Section) -> None:
+        if not self.enabled or not node.header:
+            return
+        anything_but = EmptyLine if isinstance(node, CommentSection) else (Comment, EmptyLine)
+        if all(isinstance(child, anything_but) for child in node.body):
+            self.report(
+                section_name=get_section_name(node),
+                node=node,
+                col=node.col_offset + 1,
+                end_col=node.header.end_col_offset,
+            )
+
 
 class NumberOfReturnedValuesRule(Rule):
     """Too many return values."""
@@ -646,6 +658,20 @@ class TooManyTestCasesRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.MODULAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0527",)
+
+    def check(self, node: Statement, templated_suite: bool) -> None:
+        if not self.enabled:
+            return
+        max_testcases = self.max_templated_testcases if templated_suite else self.max_testcases
+        discovered_testcases = sum(isinstance(child, TestCase) for child in node.body)
+        if discovered_testcases > max_testcases:
+            self.report(
+                test_count=discovered_testcases,
+                max_allowed_count=max_testcases,
+                node=node,
+                end_col=node.header.end_col_offset,
+                sev_threshold_value=discovered_testcases,
+            )
 
 
 class EmptyTestTemplateRule(Rule):
@@ -1071,28 +1097,6 @@ class VariableNameLengthChecker(VisitorChecker):
         self.generic_visit(node)  # continue to all branches
 
 
-class EmptySectionChecker(VisitorChecker):
-    """Checker for detecting empty sections."""
-
-    empty_section: EmptySectionRule
-
-    def check_if_empty(self, node: Section) -> None:
-        if not node.header:
-            return
-        anything_but = EmptyLine if isinstance(node, CommentSection) else (Comment, EmptyLine)
-        if all(isinstance(child, anything_but) for child in node.body):
-            self.report(
-                self.empty_section,
-                section_name=get_section_name(node),
-                node=node,
-                col=node.col_offset + 1,
-                end_col=node.header.end_col_offset,
-            )
-
-    def visit_Section(self, node: Section) -> None:  # noqa: N802
-        self.check_if_empty(node)
-
-
 class EmptySettingsChecker(VisitorChecker):
     """Checker for detecting empty settings."""
 
@@ -1248,27 +1252,4 @@ class EmptySettingsChecker(VisitorChecker):
                 node=node,
                 col=node.data_tokens[0].col_offset + 1,
                 end_col=node.end_col_offset,
-            )
-
-
-class TestCaseNumberChecker(VisitorChecker):  # TODO: good example of checker that could be merged
-    """Checker for counting number of test cases depending on suite type"""
-
-    too_many_test_cases: TooManyTestCasesRule
-
-    def visit_TestCaseSection(self, node: Statement) -> None:  # noqa: N802
-        max_testcases = (
-            self.too_many_test_cases.max_templated_testcases
-            if self.templated_suite
-            else self.too_many_test_cases.max_testcases
-        )
-        discovered_testcases = sum(isinstance(child, TestCase) for child in node.body)
-        if discovered_testcases > max_testcases:
-            self.report(
-                self.too_many_test_cases,
-                test_count=discovered_testcases,
-                max_allowed_count=max_testcases,
-                node=node,
-                end_col=node.header.end_col_offset,
-                sev_threshold_value=discovered_testcases,
             )

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -380,6 +380,23 @@ class CanBeResourceFileRule(Rule):
     )
     deprecated_names = ("0913",)
 
+    def check(self, node: File, source: str) -> None:
+        if not self.enabled or not source:
+            return
+        extension = Path(source).suffix
+        file_name = Path(source).stem
+        if (
+            ".resource" not in extension
+            and "__init__" not in file_name
+            and node.sections
+            and not any(isinstance(section, TestCaseSection) for section in node.sections)
+        ):
+            self.report(
+                file_name=Path(source).name,
+                file_name_stem=file_name,
+                node=node,
+            )
+
 
 class IfCanBeMergedRule(Rule):
     """
@@ -932,30 +949,6 @@ class EmptyVariableChecker(VisitorChecker):
                     lineno=token.lineno,
                     col=token.col_offset + 1,
                     end_col=token.end_col_offset + 1,
-                )
-
-
-class ResourceFileChecker(VisitorChecker):
-    """Checker for resource files."""
-
-    can_be_resource_file: CanBeResourceFileRule
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        source = self.source_file.path.name
-        if source:
-            extension = Path(source).suffix
-            file_name = Path(source).stem
-            if (
-                ".resource" not in extension
-                and "__init__" not in file_name
-                and node.sections
-                and not any(isinstance(section, TestCaseSection) for section in node.sections)
-            ):
-                self.report(
-                    self.can_be_resource_file,
-                    file_name=Path(source).name,
-                    file_name_stem=file_name,
-                    node=node,
                 )
 
 

--- a/src/robocop/linter/rules/order.py
+++ b/src/robocop/linter/rules/order.py
@@ -10,6 +10,7 @@ from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker
 
 if TYPE_CHECKING:
     from robot.parsing import File
+    from robot.parsing.model.statements import SectionHeader
 
 
 def parse_order_comma_sep_list(value: str, mapping: dict[str, Any]) -> list[str]:
@@ -246,6 +247,35 @@ class SectionOutOfOrderRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0809",)
+
+    def check(self, node: SectionHeader, previous_order_ids: list[int], order_id: int) -> None:
+        if not self.enabled or not any(previous_id > order_id for previous_id in previous_order_ids):
+            return
+        token = node.data_tokens[0]
+        self.report(
+            section_name=token.value,
+            recommended_order=self.section_order_to_str(self.sections_order),
+            node=node,
+            end_col=token.end_col_offset + 1,
+        )
+
+    @staticmethod
+    def section_order_to_str(order: dict[str, int]) -> str:
+        by_index = sorted(order.items(), key=lambda x: x[1])
+        name_map = {
+            Token.COMMENT_HEADER: "Comments",
+            Token.SETTING_HEADER: "Settings",
+            Token.VARIABLE_HEADER: "Variables",
+            Token.TESTCASE_HEADER: "Test Cases / Tasks",
+            "TASK HEADER": "Test Cases / Tasks",
+            Token.KEYWORD_HEADER: "Keywords",
+        }
+        order_str: list[str] = []
+        for name, _ in by_index:
+            mapped_name = name_map[name]
+            if mapped_name not in order_str:
+                order_str.append(mapped_name)
+        return " > ".join(order_str)
 
 
 class TestAndKeywordOrderChecker(VisitorChecker):

--- a/src/robocop/linter/rules/sections.py
+++ b/src/robocop/linter/rules/sections.py
@@ -1,0 +1,74 @@
+"""Checker for rules triggered by sections and section headers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robot.api import Token
+from robot.parsing.model.blocks import SettingSection, TestCaseSection, VariableSection
+
+from robocop.linter.rules import VisitorChecker, duplications, lengths, misc, order, spacing
+
+if TYPE_CHECKING:
+    from robot.parsing.model import File
+    from robot.parsing.model.blocks import Section
+    from robot.parsing.model.statements import SectionHeader
+
+
+class SectionsChecker(VisitorChecker):
+    """Checker for rules reported for the sections and their headers."""
+
+    can_be_resource_file: misc.CanBeResourceFileRule
+    empty_section: lengths.EmptySectionRule
+    too_many_test_cases: lengths.TooManyTestCasesRule
+    variable_not_left_aligned: spacing.VariableNotLeftAlignedRule
+    suite_setting_not_left_aligned: spacing.SuiteSettingNotLeftAlignedRule
+    section_already_defined: duplications.SectionAlreadyDefinedRule
+    both_tests_and_tasks: duplications.BothTestsAndTasksRule
+    section_out_of_order: order.SectionOutOfOrderRule
+
+    def __init__(self) -> None:
+        self.sections_by_order: list[int] = []
+        self.sections_by_existence: dict[str, int] = {}
+        super().__init__()
+
+    def visit_File(self, node: File) -> None:  # noqa: N802
+        self.sections_by_order = []
+        self.sections_by_existence = {}
+        self.can_be_resource_file.check(node, self.source_file.path.name)
+        super().visit_File(node)
+
+    def visit_Section(self, node: Section) -> None:  # noqa: N802
+        """
+        Visit every section type.
+
+        Rules that used to live in their own checker relied on the ``ModelVisitor`` dispatch picking the most
+        specific ``visit_<SectionType>`` method. They are dispatched with ``isinstance`` here instead so that a
+        single visitor can serve all section types at once.
+        """
+        self.empty_section.check(node)
+        if isinstance(node, VariableSection):
+            self.variable_not_left_aligned.check(node)
+        elif isinstance(node, SettingSection):
+            self.suite_setting_not_left_aligned.check(node)
+        elif isinstance(node, TestCaseSection):
+            self.too_many_test_cases.check(node, self.templated_suite)
+        self.generic_visit(node)
+
+    def visit_SectionHeader(self, node: SectionHeader) -> None:  # noqa: N802
+        section_name = node.type
+        if section_name not in self.section_out_of_order.sections_order:
+            return
+        if section_name in (Token.TESTCASE_HEADER, "TASK HEADER"):
+            # a bit awkward implementation because before RF 6.0 task header used TESTCASE_HEADER type
+            if "task" in node.name.lower():
+                section_name = "TASK HEADER"
+                self.both_tests_and_tasks.check(node, Token.TESTCASE_HEADER in self.sections_by_existence)
+            else:
+                self.both_tests_and_tasks.check(node, "TASK HEADER" in self.sections_by_existence)
+        order_id = self.section_out_of_order.sections_order[section_name]
+        self.section_already_defined.check(node, self.sections_by_existence.get(section_name))
+        if section_name not in self.sections_by_existence:
+            self.sections_by_existence[section_name] = node.lineno
+        self.section_out_of_order.check(node, self.sections_by_order, order_id)
+        self.sections_by_order.append(order_id)

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -6,7 +6,7 @@ import re
 from collections import Counter
 from contextlib import contextmanager
 from itertools import takewhile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from robot.api import Token
 from robot.parsing.model.blocks import Keyword, TestCase
@@ -572,6 +572,20 @@ class VariableNotLeftAlignedRule(Rule):
     )
     deprecated_names = ("1014", "variable-should-be-left-aligned")
 
+    def check(self, node: Section) -> None:
+        if not self.enabled:
+            return
+        for child in node.body:
+            if not child.data_tokens:
+                continue
+            token = child.data_tokens[0]
+            if token.type == Token.VARIABLE and (token.value == "" or token.value.startswith(" ")):
+                if token.value or not child.get_token(Token.ARGUMENT):
+                    pos = len(token.value) - len(token.value.lstrip()) + 1
+                else:
+                    pos = child.get_token(Token.ARGUMENT).col_offset + 1
+                self.report(lineno=token.lineno, col=1, end_col=pos)
+
 
 class MisalignedContinuationRowRule(Rule):
     """
@@ -653,6 +667,52 @@ class SuiteSettingNotLeftAlignedRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.FORMATTED, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("1016", "suite-setting-should-be-left-aligned")
+
+    suite_settings: ClassVar[dict[str, str]] = {
+        "documentation": "Documentation",
+        "suitesetup": "Suite Setup",
+        "suiteteardown": "Suite Teardown",
+        "metadata": "Metadata",
+        "testsetup": "Test Setup",
+        "testteardown": "Test Teardown",
+        "testtemplate": "Test Template",
+        "testtimeout": "Test Timeout",
+        "forcetags": "Force Tags",
+        "defaulttags": "Default Tags",
+        "library": "Library",
+        "resource": "Resource",
+        "variables": "Variables",
+    }
+    non_existing_setting_pattern = re.compile("Non-existing setting '(.*)'.")
+
+    def check(self, node: Section) -> None:
+        if not self.enabled:
+            return
+        for child in node.body:
+            for error in child.errors:
+                if "Non-existing setting" in error:
+                    self.parse_error(child, error)
+
+    def parse_error(self, node: Statement, error: str) -> None:
+        error_match = self.non_existing_setting_pattern.search(error)
+        if not error_match:
+            return
+        setting_error = error_match.group(1)
+        if not setting_error:
+            setting_cand = node.get_token(Token.COMMENT)
+            if setting_cand and setting_cand.value.replace(" ", "").lower() in self.suite_settings:
+                self.report(
+                    node=setting_cand,
+                    col=setting_cand.col_offset + 1,
+                    end_col=setting_cand.end_col_offset + 1,
+                )
+        elif not setting_error[0].strip():  # starts with space/tab
+            suite_sett_cand = setting_error.replace(" ", "").lower()
+            for setting in self.suite_settings:
+                if suite_sett_cand.startswith(setting):
+                    indent = len(setting_error) - len(setting_error.lstrip())
+                    self.report(node=node, col=indent + 1)
+                    break
 
 
 class BadBlockIndentRule(Rule):
@@ -1315,70 +1375,3 @@ class MisalignedContinuation(VisitorChecker):
             elif token.type == search_for:
                 return pos
         return 0  # 0 will ignore first line indent and compare to 2nd line only
-
-
-class LeftAlignedChecker(VisitorChecker):
-    """Checker for left align."""
-
-    variable_not_left_aligned: VariableNotLeftAlignedRule
-    suite_setting_not_left_aligned: SuiteSettingNotLeftAlignedRule
-
-    suite_settings = {
-        "documentation": "Documentation",
-        "suitesetup": "Suite Setup",
-        "suiteteardown": "Suite Teardown",
-        "metadata": "Metadata",
-        "testsetup": "Test Setup",
-        "testteardown": "Test Teardown",
-        "testtemplate": "Test Template",
-        "testtimeout": "Test Timeout",
-        "forcetags": "Force Tags",
-        "defaulttags": "Default Tags",
-        "library": "Library",
-        "resource": "Resource",
-        "variables": "Variables",
-    }
-
-    def visit_VariableSection(self, node: Node) -> None:  # noqa: N802
-        for child in node.body:
-            if not child.data_tokens:
-                continue
-            token = child.data_tokens[0]
-            if token.type == Token.VARIABLE and (token.value == "" or token.value.startswith(" ")):
-                if token.value or not child.get_token(Token.ARGUMENT):
-                    pos = len(token.value) - len(token.value.lstrip()) + 1
-                else:
-                    pos = child.get_token(Token.ARGUMENT).col_offset + 1
-                self.report(self.variable_not_left_aligned, lineno=token.lineno, col=1, end_col=pos)
-
-    def visit_SettingSection(self, node: Node) -> None:  # noqa: N802
-        for child in node.body:
-            for error in child.errors:
-                if "Non-existing setting" in error:
-                    self.parse_error(child, error)
-
-    def parse_error(self, node: Node, error: str) -> None:
-        error_match = re.search("Non-existing setting '(.*)'.", error)
-        if not error_match:
-            return
-        setting_error = error_match.group(1)
-        if not setting_error:
-            setting_cand = node.get_token(Token.COMMENT)
-            if setting_cand and setting_cand.value.replace(" ", "").lower() in self.suite_settings:
-                self.report(
-                    self.suite_setting_not_left_aligned,
-                    node=setting_cand,
-                    col=setting_cand.col_offset + 1,
-                    end_col=setting_cand.end_col_offset + 1,
-                )
-        elif not setting_error[0].strip():  # starts with space/tab
-            suite_sett_cand = setting_error.replace(" ", "").lower()
-            for setting in self.suite_settings:
-                if suite_sett_cand.startswith(setting):
-                    indent = len(setting_error) - len(setting_error.lstrip())
-                    self.report(
-                        self.suite_setting_not_left_aligned,
-                        node=node,
-                        col=indent + 1,
-                    )
-                    break


### PR DESCRIPTION
Wave 5 of the single-visitor migration.

Five separate `VisitorChecker` classes each walked every file to inspect sections:

- `lengths.EmptySectionChecker`
- `lengths.TestCaseNumberChecker`
- `misc.ResourceFileChecker`
- `spacing.LeftAlignedChecker`
- `duplications.SectionHeadersChecker`

They are replaced by a single `SectionsChecker` in `linter/rules/sections.py` that visits each file once and owns eight rules across five categories: `can-be-resource-file`, `empty-section`, `too-many-test-cases`, `variable-not-left-aligned`, `suite-setting-not-left-aligned`, `section-already-defined`, `both-tests-and-tasks` and `section-out-of-order`.

As in previous waves, traversal/data-gathering stays in the visitor and the decision logic moves into `check()` methods on the `Rule` classes.

### Note on MRO dispatch

`ModelVisitor` dispatches `visit_<ClassName>` along the MRO, so a specific `visit_SettingSection` takes priority over and suppresses the generic `visit_Section`. A naive merge would have silently stopped `empty-section` from firing for setting/variable/test-case sections. The merged checker uses a single `visit_Section` with `isinstance` dispatch, which mirrors the previous MRO semantics exactly (including subclasses).

### Validation

- Full `--select ALL` output over the test corpus diffed against the previous revision: **identical**
- Per-rule runs for all eight rules: **identical**
- `robocop list rules --verbose`: **identical**
- Hand-written edge-case suite (comment sections, invalid sections, tasks vs test cases, duplicated sections): **identical**
- `pytest tests`: same results as `main`
- `mypy`: same 7 pre-existing errors
- Runtime checker count: **43 -> 39**

Internal checkers only; no user-facing change.