### PR TITLE
refactor: merge test case and keyword checkers into TestCaseKeywordChecker

### DIFF
--- a/src/robocop/linter/rules/documentation.py
+++ b/src/robocop/linter/rules/documentation.py
@@ -2,17 +2,35 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from robot.parsing.model.statements import Documentation
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker
+from robocop.linter.rules import Rule, RuleParam, RuleSeverity
 from robocop.linter.utils.misc import str2bool
 
 if TYPE_CHECKING:
     from robot.parsing.model import File, Keyword, SettingSection, TestCase
+
+
+def report_if_documentation_is_missing(rule: Rule, node: Keyword | TestCase) -> None:
+    """Report ``rule`` if the block does not contain the [Documentation] setting."""
+    if any(isinstance(statement, Documentation) for statement in node.body):
+        return
+    rule.report(
+        name=node.name,
+        node=node,
+        end_col=node.col_offset + len(node.name) + 1,
+        extended_disablers=(node.lineno, node.end_lineno),
+    )
+
+
+def report_if_suite_documentation_is_missing(rule: Rule, node: SettingSection) -> None:
+    """Report ``rule`` if the settings section does not contain the Documentation setting."""
+    if any(isinstance(statement, Documentation) for statement in node.body):
+        return
+    rule.report(node=node)
 
 
 class MissingDocKeywordRule(Rule):
@@ -42,6 +60,11 @@ class MissingDocKeywordRule(Rule):
     )
     deprecated_names = ("0201",)
     fix_suggestion = "Add a [Documentation] setting to the keyword."
+
+    def check(self, node: Keyword) -> None:
+        if not self.enabled:
+            return
+        report_if_documentation_is_missing(self, node)
 
 
 class MissingDocTestCaseRule(Rule):
@@ -84,6 +107,11 @@ class MissingDocTestCaseRule(Rule):
     deprecated_names = ("0202",)
     fix_suggestion = "Add a [Documentation] setting to the test case."
 
+    def check(self, node: TestCase, templated_suite: bool) -> None:
+        if not self.enabled or (templated_suite and self.ignore_templated):
+            return
+        report_if_documentation_is_missing(self, node)
+
 
 class MissingDocTestSuiteRule(Rule):
     """
@@ -106,6 +134,17 @@ class MissingDocTestSuiteRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0203",)
+
+    def check(self, node: SettingSection) -> None:
+        if not self.enabled:
+            return
+        report_if_suite_documentation_is_missing(self, node)
+
+    def check_missing_settings_section(self, node: File) -> None:
+        """Report the rule for a file that does not define the settings section at all."""
+        if not self.enabled:
+            return
+        self.report(node=node, lineno=1, col=1)
 
 
 class MissingDocResourceFileRule(Rule):
@@ -130,71 +169,13 @@ class MissingDocResourceFileRule(Rule):
     )
     deprecated_names = ("0204",)
 
-
-class MissingDocumentationChecker(VisitorChecker):
-    """Checker for missing documentation."""
-
-    missing_doc_keyword: MissingDocKeywordRule
-    missing_doc_test_case: MissingDocTestCaseRule
-    missing_doc_test_suite: MissingDocTestSuiteRule
-    missing_doc_resource_file: MissingDocResourceFileRule
-
-    def __init__(self) -> None:
-        self.is_resource = False
-        self.settings_section_exists = False
-        super().__init__()
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
-        self.check_if_docs_are_present(
-            node, self.missing_doc_keyword, extend_disablers=True
-        )  # TODO: could be self.missing_doc_keyword.check_docs(node)
-
-    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
-        if self.templated_suite and self.missing_doc_test_case.ignore_templated:
+    def check(self, node: SettingSection) -> None:
+        if not self.enabled:
             return
-        self.check_if_docs_are_present(node, self.missing_doc_test_case, extend_disablers=True)
+        report_if_suite_documentation_is_missing(self, node)
 
-    def visit_SettingSection(self, node: SettingSection) -> None:  # noqa: N802
-        self.settings_section_exists = True
-        if self.is_resource:
-            self.check_if_suite_docs_are_present(node, self.missing_doc_resource_file)
-        else:
-            self.check_if_suite_docs_are_present(node, self.missing_doc_test_suite)
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        source = self.source_file.path.name
-        self.is_resource = bool(source) and ".resource" in Path(source).suffix
-        self.settings_section_exists = False
-        self.generic_visit(node)
-        if not self.settings_section_exists:
-            if self.is_resource:
-                self.report(self.missing_doc_resource_file, node=node, lineno=1, col=1)
-            else:
-                self.report(self.missing_doc_test_suite, node=node, lineno=1, col=1)
-
-    def check_if_docs_are_present(  # TODO: could be implemented inside 'MissingDocumentationRule' class
-        self, node: Keyword | TestCase | SettingSection, rule: Rule, extend_disablers: bool
-    ) -> None:
-        # with single visitor: visit_Documentation + check context, at the end of block check if found
-        # TODO indent
-        for statement in node.body:
-            if isinstance(statement, Documentation):
-                break
-        else:
-            extended_disablers = (node.lineno, node.end_lineno) if extend_disablers else None
-            if hasattr(node, "name"):
-                self.report(
-                    rule,
-                    name=node.name,
-                    node=node,
-                    end_col=node.col_offset + len(node.name) + 1,
-                    extended_disablers=extended_disablers,
-                )
-            else:
-                self.report(rule, node=node, end_col=node.end_col_offset, extended_disablers=extended_disablers)
-
-    def check_if_suite_docs_are_present(self, node: SettingSection, rule: Rule) -> None:
-        for statement in node.body:
-            if isinstance(statement, Documentation):
-                return
-        self.report(rule, node=node)
+    def check_missing_settings_section(self, node: File) -> None:
+        """Report the rule for a file that does not define the settings section at all."""
+        if not self.enabled:
+            return
+        self.report(node=node, lineno=1, col=1)

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -77,6 +77,22 @@ class TooLongKeywordRule(Rule):
     deprecated_names = ("0501",)
     fix_suggestion = "Split the keyword into smaller, focused keywords."
 
+    def check(self, node: Keyword) -> bool:
+        """Report the rule and return whether the keyword exceeds the allowed length."""
+        length, node_end_line = check_node_length(node, ignore_docs=self.ignore_docs)
+        if length <= self.max_len:
+            return False
+        self.report(
+            keyword_name=node.name,
+            keyword_length=length,
+            allowed_length=self.max_len,
+            node=node,
+            end_col=node.col_offset + len(node.name) + 1,
+            extended_disablers=(node.lineno, node_end_line),
+            sev_threshold_value=length,
+        )
+        return True
+
 
 class TooFewCallsInKeywordRule(Rule):
     """
@@ -116,6 +132,21 @@ class TooFewCallsInKeywordRule(Rule):
     )
     deprecated_names = ("0502",)
 
+    def check(self, node: Keyword, keyword_count: int) -> bool:
+        """Report the rule and return whether the keyword has too few keyword calls."""
+        if keyword_count >= self.min_calls:
+            return False
+        self.report(
+            keyword_name=node.name,
+            keyword_count=keyword_count,
+            min_allowed_count=self.min_calls,
+            node=node,
+            end_col=node.col_offset + len(node.name) + 1,
+            extended_disablers=(node.lineno, node.end_lineno),
+            sev_threshold_value=keyword_count,
+        )
+        return True
+
 
 class TooManyCallsInKeywordRule(Rule):
     """
@@ -137,6 +168,21 @@ class TooManyCallsInKeywordRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.FOCUSED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0503",)
+
+    def check(self, node: Keyword, keyword_count: int) -> bool:
+        """Report the rule and return whether the keyword has too many keyword calls."""
+        if keyword_count <= self.max_calls:
+            return False
+        self.report(
+            keyword_name=node.name,
+            keyword_count=keyword_count,
+            max_allowed_count=self.max_calls,
+            node=node,
+            end_col=node.col_offset + len(node.name) + 1,
+            extended_disablers=(node.lineno, node.end_lineno),
+            sev_threshold_value=keyword_count,
+        )
+        return True
 
 
 class TooLongTestCaseRule(Rule):
@@ -163,6 +209,20 @@ class TooLongTestCaseRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.MODULAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0504",)
+
+    def check(self, node: TestCase) -> None:
+        length, node_end_line = check_node_length(node, ignore_docs=self.ignore_docs)
+        if length <= self.max_len:
+            return
+        self.report(
+            test_name=node.name,
+            test_length=length,
+            allowed_length=self.max_len,
+            node=node,
+            end_col=node.col_offset + len(node.name) + 1,
+            extended_disablers=(node.lineno, node_end_line),
+            sev_threshold_value=length,
+        )
 
 
 class TooFewCallsInTestCaseRule(Rule):
@@ -195,6 +255,21 @@ class TooFewCallsInTestCaseRule(Rule):
     )
     deprecated_names = ("0528",)
 
+    def check(self, node: TestCase, keyword_count: int) -> bool:
+        """Report the rule and return whether the test case has too few keyword calls."""
+        if keyword_count >= self.min_calls:
+            return False
+        self.report(
+            test_name=node.name,
+            keyword_count=keyword_count,
+            min_allowed_count=self.min_calls,
+            node=node,
+            sev_threshold_value=keyword_count,
+            extended_disablers=(node.lineno, node.end_lineno),
+            end_col=node.col_offset + len(node.name) + 1,
+        )
+        return True
+
 
 class TooManyCallsInTestCaseRule(Rule):
     """
@@ -219,6 +294,21 @@ class TooManyCallsInTestCaseRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.MODULAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
 
+    def check(self, node: TestCase, keyword_count: int) -> bool:
+        """Report the rule and return whether the test case has too many keyword calls."""
+        if keyword_count <= self.max_calls:
+            return False
+        self.report(
+            test_name=node.name,
+            keyword_count=keyword_count,
+            max_allowed_count=self.max_calls,
+            node=node,
+            sev_threshold_value=keyword_count,
+            extended_disablers=(node.lineno, node.end_lineno),
+            end_col=node.col_offset + len(node.name) + 1,
+        )
+        return True
+
 
 class FileTooLongRule(Rule):
     """File has too many lines."""
@@ -238,6 +328,18 @@ class FileTooLongRule(Rule):
     )
     deprecated_names = ("0506",)
 
+    def check(self, node: File) -> None:
+        if not self.enabled or node.end_lineno <= self.max_lines:
+            return
+        self.report(
+            lines_count=node.end_lineno,
+            max_allowed_count=self.max_lines,
+            node=node,
+            lineno=node.end_lineno,
+            end_col=node.end_col_offset,
+            sev_threshold_value=node.end_lineno,
+        )
+
 
 class TooManyArgumentsRule(Rule):
     """Keyword has too many arguments."""
@@ -254,6 +356,27 @@ class TooManyArgumentsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.FOCUSED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0507",)
+
+    def check(self, node: Keyword) -> None:
+        if not self.enabled:
+            return
+        for child in node.body:
+            if not isinstance(child, Arguments):
+                continue
+            args_number = len(child.values)
+            if args_number > self.max_args:
+                name_token = child.data_tokens[0]
+                self.report(
+                    keyword_name=node.name,
+                    arguments_count=args_number,
+                    max_allowed_count=self.max_args,
+                    node=name_token,
+                    end_lineno=child.end_lineno,
+                    end_col=child.end_col_offset,
+                    extended_disablers=(node.lineno, node.end_lineno),
+                    sev_threshold_value=args_number,
+                )
+            break
 
 
 class LineTooLongRule(Rule):
@@ -789,178 +912,50 @@ def get_documentation_length(node: Node) -> int:
     return doc_len
 
 
+KEYWORD_CALL_ALIKE = tuple(
+    klass
+    for klass in (
+        KeywordCall,
+        TemplateArguments,
+        RETURN_CLASSES.return_class,
+        RETURN_CLASSES.return_setting_class,
+        Break,
+        Continue,
+        Var,
+    )
+    if klass
+)
+
+
+def count_keyword_calls(node: Node) -> int:
+    """Recursively count keyword calls (and alike statements) in the node body."""
+    if isinstance(node, KEYWORD_CALL_ALIKE):
+        return 1
+    if not hasattr(node, "body"):
+        return 0
+    calls = sum(count_keyword_calls(child) for child in node.body)
+    while node and getattr(node, "orelse", None):
+        node = node.orelse
+        calls += sum(count_keyword_calls(child) for child in node.body)
+    while node and getattr(node, "next", None):
+        node = node.next
+        calls += sum(count_keyword_calls(child) for child in node.body)
+    return calls
+
+
+def is_templated_test(node: TestCase, templated_suite: bool) -> bool:
+    if templated_suite:
+        return True
+    if not node.body:
+        return False
+    return any(isinstance(statement, Template) for statement in node.body)
+
+
 @dataclass
 class CachedVariable:
     name: str
     node: Node
     end_col: int
-
-
-class LengthChecker(VisitorChecker):
-    """
-    Checker for max and min length of keyword or test case. It analyses number of lines and also number of
-    keyword calls (as you can have just few keywords but very long ones or vice versa).
-    """
-
-    too_few_calls_in_keyword: TooFewCallsInKeywordRule
-    too_few_calls_in_test_case: TooFewCallsInTestCaseRule
-    too_many_calls_in_keyword: TooManyCallsInKeywordRule
-    too_many_calls_in_test_case: TooManyCallsInTestCaseRule
-    too_long_keyword: TooLongKeywordRule
-    too_long_test_case: TooLongTestCaseRule
-    file_too_long: FileTooLongRule
-    too_many_arguments: TooManyArgumentsRule
-
-    def __init__(self) -> None:
-        self.keyword_call_alike = tuple(
-            klass
-            for klass in (
-                KeywordCall,
-                TemplateArguments,
-                RETURN_CLASSES.return_class,
-                RETURN_CLASSES.return_setting_class,
-                Break,
-                Continue,
-                Var,
-            )
-            if klass
-        )
-        super().__init__()
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        if node.end_lineno > self.file_too_long.max_lines:
-            self.report(
-                self.file_too_long,
-                lines_count=node.end_lineno,
-                max_allowed_count=self.file_too_long.max_lines,
-                node=node,
-                lineno=node.end_lineno,
-                end_col=node.end_col_offset,
-                sev_threshold_value=node.end_lineno,
-            )
-        super().visit_File(node)
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
-        if node.name.lstrip().startswith("#"):
-            return
-        for child in node.body:
-            if isinstance(child, Arguments):
-                args_number = len(child.values)
-                if args_number > self.too_many_arguments.max_args:
-                    name_token = child.data_tokens[0]
-                    self.report(
-                        self.too_many_arguments,
-                        keyword_name=node.name,
-                        arguments_count=args_number,
-                        max_allowed_count=self.too_many_arguments.max_args,
-                        node=name_token,
-                        end_lineno=child.end_lineno,
-                        end_col=child.end_col_offset,
-                        extended_disablers=(node.lineno, node.end_lineno),
-                        sev_threshold_value=args_number,
-                    )
-                break
-        length, node_end_line = check_node_length(node, ignore_docs=self.too_long_keyword.ignore_docs)
-        if length > self.too_long_keyword.max_len:
-            self.report(
-                self.too_long_keyword,
-                keyword_name=node.name,
-                keyword_length=length,
-                allowed_length=self.too_long_keyword.max_len,
-                node=node,
-                end_col=node.col_offset + len(node.name) + 1,
-                extended_disablers=(node.lineno, node_end_line),
-                sev_threshold_value=length,
-            )
-            return
-        key_calls = self.count_keyword_calls(node)
-        if key_calls < self.too_few_calls_in_keyword.min_calls:
-            self.report(
-                self.too_few_calls_in_keyword,
-                keyword_name=node.name,
-                keyword_count=key_calls,
-                min_allowed_count=self.too_few_calls_in_keyword.min_calls,
-                node=node,
-                end_col=node.col_offset + len(node.name) + 1,
-                extended_disablers=(node.lineno, node.end_lineno),
-                sev_threshold_value=key_calls,
-            )
-        elif key_calls > self.too_many_calls_in_keyword.max_calls:
-            self.report(
-                self.too_many_calls_in_keyword,
-                keyword_name=node.name,
-                keyword_count=key_calls,
-                max_allowed_count=self.too_many_calls_in_keyword.max_calls,
-                node=node,
-                end_col=node.col_offset + len(node.name) + 1,
-                extended_disablers=(node.lineno, node.end_lineno),
-                sev_threshold_value=key_calls,
-            )
-
-    def test_is_templated(self, node: TestCase) -> bool:
-        if self.templated_suite:
-            return True
-        if not node.body:
-            return False
-        return any(isinstance(statement, Template) for statement in node.body)
-
-    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
-        if self.too_long_test_case.ignore_templated and self.test_is_templated(node):
-            return
-        length, node_end_line = check_node_length(node, ignore_docs=self.too_long_test_case.ignore_docs)
-        if length > self.too_long_test_case.max_len:
-            self.report(
-                self.too_long_test_case,
-                test_name=node.name,
-                test_length=length,
-                allowed_length=self.too_long_test_case.max_len,
-                node=node,
-                end_col=node.col_offset + len(node.name) + 1,
-                extended_disablers=(node.lineno, node_end_line),
-                sev_threshold_value=length,
-            )
-        test_is_templated = self.test_is_templated(node)
-        skip_too_many = test_is_templated and self.too_many_calls_in_test_case.ignore_templated
-        skip_too_few = test_is_templated and self.too_few_calls_in_test_case.ignore_templated
-        if skip_too_few and skip_too_many:
-            return
-        key_calls = self.count_keyword_calls(node)  # TODO: could be handled inside rule, at least reporting
-        if not skip_too_many and (key_calls > self.too_many_calls_in_test_case.max_calls):
-            self.report(
-                self.too_many_calls_in_test_case,
-                test_name=node.name,
-                keyword_count=key_calls,
-                max_allowed_count=self.too_many_calls_in_test_case.max_calls,
-                node=node,
-                sev_threshold_value=key_calls,
-                extended_disablers=(node.lineno, node.end_lineno),
-                end_col=node.col_offset + len(node.name) + 1,
-            )
-        elif not skip_too_few and (key_calls < self.too_few_calls_in_test_case.min_calls):
-            self.report(
-                self.too_few_calls_in_test_case,
-                test_name=node.name,
-                keyword_count=key_calls,
-                min_allowed_count=self.too_few_calls_in_test_case.min_calls,
-                node=node,
-                sev_threshold_value=key_calls,
-                extended_disablers=(node.lineno, node.end_lineno),
-                end_col=node.col_offset + len(node.name) + 1,
-            )
-
-    def count_keyword_calls(self, node: Node) -> int:
-        if isinstance(node, self.keyword_call_alike):
-            return 1
-        if not hasattr(node, "body"):
-            return 0
-        calls = sum(self.count_keyword_calls(child) for child in node.body)
-        while node and getattr(node, "orelse", None):
-            node = node.orelse
-            calls += sum(self.count_keyword_calls(child) for child in node.body)
-        while node and getattr(node, "next", None):
-            node = node.next
-            calls += sum(self.count_keyword_calls(child) for child in node.body)
-        return calls
 
 
 class VariableNameLengthChecker(VisitorChecker):

--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -21,6 +21,7 @@ from robocop.version_handling import ROBOT_VERSION, TYPE_SUPPORTED
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from pathlib import Path
 
     from robot.parsing import File
     from robot.parsing.model.blocks import For, If, InvalidSection, Keyword, TestCase, While
@@ -74,6 +75,45 @@ class NotAllowedCharInNameRule(Rule):
     )
     deprecated_names = ("0301",)
     fix_suggestion = "Remove the not allowed character from the name."
+
+    def check(self, node: TestCaseName | KeywordName, name_of_node: str, is_keyword: bool = False) -> None:
+        """
+        Search if regex pattern found from node name.
+
+        Skips embedded variables from keyword name.
+        """
+        if not self.enabled:
+            return
+        node_name = node.name
+        robot_vars = utils.find_robot_vars(node_name) if is_keyword else []
+        start_pos = 0
+        for variable in robot_vars:
+            # Loop and skip variables:
+            # Search pattern from start_pos to variable starting position
+            # example `Keyword With ${em.bedded} Two ${second.Argument} Argument`
+            # is split to:
+            #   1. `Keyword With `
+            #   2. ` Two `
+            #   3. ` Argument` - last part is searched in finditer part after this loop
+            tmp_node_name = node_name[start_pos : variable[0]]
+            match = self.pattern.search(tmp_node_name)
+            if match:
+                self.report(
+                    character=match.group(),
+                    block_name=f"'{node_name}' {name_of_node}",
+                    node=node,
+                    col=node.col_offset + match.start(0) + 1,
+                    end_col=node.col_offset + match.end(0) + 1,
+                )
+            start_pos = variable[1]
+        for not_allowed_char in self.pattern.finditer(node_name, start_pos):
+            self.report(
+                character=not_allowed_char.group(),
+                block_name=f"'{node_name}' {name_of_node}",
+                node=node,
+                col=node.col_offset + not_allowed_char.start(0) + 1,
+                end_col=node.col_offset + not_allowed_char.end(0) + 1,
+            )
 
 
 class WrongCaseInKeywordNameRule(Rule):
@@ -295,6 +335,20 @@ class NotCapitalizedTestCaseTitleRule(Rule):
     )
     deprecated_names = ("0308",)
 
+    def check(self, node: TestCase) -> None:
+        if not self.enabled:
+            return
+        for char in node.name:
+            if not char.isalpha():
+                continue
+            if not char.isupper():
+                self.report(
+                    test_name=node.name,
+                    node=node,
+                    end_col=node.col_offset + len(node.name) + 1,
+                )
+            break
+
 
 class SectionVariableNotUppercaseRule(Rule):
     """
@@ -409,6 +463,11 @@ class TestCaseNameIsEmptyRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.IDENTIFIABLE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("0313",)
+
+    def check(self, node: TestCase) -> None:
+        if not self.enabled:
+            return
+        self.report(node=node)
 
 
 class EmptyLibraryAliasRule(Rule):
@@ -534,6 +593,20 @@ class NotAllowedCharInFilenameRule(Rule):
     )
     deprecated_names = ("0320",)
 
+    def check(self, node: File, source_path: Path) -> None:
+        if not self.enabled:
+            return
+        suite_name = source_path.stem
+        if "__init__" in suite_name:
+            suite_name = source_path.parent.name
+        for match in self.pattern.finditer(suite_name):
+            self.report(
+                character=match.group(),
+                block_name="suite",
+                node=node,
+                col=node.col_offset + match.start(0) + 1,
+            )
+
 
 class InvalidSectionRule(Rule):
     """
@@ -657,74 +730,6 @@ SET_VARIABLE_VARIANTS = {
     "setsuitevariable",
     "setglobalvariable",
 }
-
-
-class InvalidCharactersInNameChecker(VisitorChecker):
-    """Checker for invalid characters in suite, test case or keyword name."""
-
-    not_allowed_char_in_filename: NotAllowedCharInFilenameRule
-    not_allowed_char_in_name: NotAllowedCharInNameRule
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        suite_name = self.source_file.path.stem
-        if "__init__" in suite_name:
-            suite_name = self.source_file.path.parent.name
-        for match in self.not_allowed_char_in_filename.pattern.finditer(suite_name):
-            self.report(
-                self.not_allowed_char_in_filename,
-                character=match.group(),
-                block_name="suite",
-                node=node,
-                col=node.col_offset + match.start(0) + 1,
-            )
-        super().visit_File(node)
-
-    def check_if_pattern_in_node_name(
-        self, node: TestCaseName | KeywordName, name_of_node: str, is_keyword: bool = False
-    ) -> None:
-        """
-        Search if regex pattern found from node name.
-        Skips embedded variables from keyword name
-        """
-        node_name = node.name
-        robot_vars = utils.find_robot_vars(node_name) if is_keyword else []
-        start_pos = 0
-        for variable in robot_vars:
-            # Loop and skip variables:
-            # Search pattern from start_pos to variable starting position
-            # example `Keyword With ${em.bedded} Two ${second.Argument} Argument`
-            # is split to:
-            #   1. `Keyword With `
-            #   2. ` Two `
-            #   3. ` Argument` - last part is searched in finditer part after this loop
-            tmp_node_name = node_name[start_pos : variable[0]]
-            match = self.not_allowed_char_in_name.pattern.search(tmp_node_name)
-            if match:
-                self.report(
-                    self.not_allowed_char_in_name,
-                    character=match.group(),
-                    block_name=f"'{node_name}' {name_of_node}",
-                    node=node,
-                    col=node.col_offset + match.start(0) + 1,
-                    end_col=node.col_offset + match.end(0) + 1,
-                )
-            start_pos = variable[1]
-
-        for not_allowed_char in self.not_allowed_char_in_name.pattern.finditer(node_name, start_pos):
-            self.report(
-                self.not_allowed_char_in_name,
-                character=not_allowed_char.group(),
-                block_name=f"'{node.name}' {name_of_node}",
-                node=node,
-                col=node.col_offset + not_allowed_char.start(0) + 1,
-                end_col=node.col_offset + not_allowed_char.end(0) + 1,
-            )
-
-    def visit_TestCaseName(self, node: TestCaseName) -> None:  # noqa: N802
-        self.check_if_pattern_in_node_name(node, "test case")
-
-    def visit_KeywordName(self, node: KeywordName) -> None:  # noqa: N802
-        self.check_if_pattern_in_node_name(node, "keyword", is_keyword=True)
 
 
 def uppercase_error_msg(name: str) -> str:
@@ -1018,29 +1023,6 @@ class SettingsNamingChecker(VisitorChecker):
                 node=node,
                 end_col=end_col,
             )
-
-
-class TestCaseNamingChecker(VisitorChecker):
-    """Checker for test case naming violations."""
-
-    not_capitalized_test_case_title: NotCapitalizedTestCaseTitleRule
-    test_case_name_is_empty: TestCaseNameIsEmptyRule
-
-    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.test_case_name_is_empty, node=node)
-        else:
-            for c in node.name:
-                if not c.isalpha():
-                    continue
-                if not c.isupper():
-                    self.report(
-                        self.not_capitalized_test_case_title,
-                        test_name=node.name,
-                        node=node,
-                        end_col=node.col_offset + len(node.name) + 1,
-                    )
-                break
 
 
 class VariableNamingChecker(VisitorChecker):

--- a/src/robocop/linter/rules/order.py
+++ b/src/robocop/linter/rules/order.py
@@ -3,14 +3,38 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from robot.api import Token
-from robot.parsing.model.blocks import Keyword, TestCase
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker
+from robocop.linter.rules import Rule, RuleParam, RuleSeverity
 
 if TYPE_CHECKING:
-    from robot.parsing import File
+    from robot.parsing.model.blocks import Keyword, TestCase
     from robot.parsing.model.statements import SectionHeader
+
+
+def report_out_of_order_settings(rule: Rule, node: Keyword | TestCase) -> None:
+    """Report ``rule`` for every setting or body item that breaks the expected order."""
+    expected_order = rule.sections_order
+    max_order_indicator = -1
+    for subnode in node.body:
+        try:
+            subnode_type = subnode.type
+        except AttributeError:
+            continue
+        if subnode_type not in expected_order:
+            continue
+        this_node_expected_order = expected_order.index(subnode_type)
+        if this_node_expected_order < max_order_indicator:
+            error_node = subnode.data_tokens[0]
+            rule.report(
+                section_name=subnode_type,
+                recommended_order=", ".join(expected_order),
+                node=error_node,
+                col=error_node.col_offset + 1,
+                end_col=error_node.end_col_offset + 1,
+            )
+        else:
+            max_order_indicator = this_node_expected_order
 
 
 def parse_order_comma_sep_list(value: str, mapping: dict[str, Any]) -> list[str]:
@@ -137,6 +161,11 @@ class TestCaseSectionOutOfOrderRule(Rule):
     )
     deprecated_names = ("0927",)
 
+    def check(self, node: TestCase) -> None:
+        if not self.enabled:
+            return
+        report_out_of_order_settings(self, node)
+
 
 class KeywordSectionOutOfOrderRule(Rule):
     """
@@ -194,6 +223,11 @@ class KeywordSectionOutOfOrderRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0928",)
+
+    def check(self, node: Keyword) -> None:
+        if not self.enabled:
+            return
+        report_out_of_order_settings(self, node)
 
 
 class SectionOutOfOrderRule(Rule):
@@ -276,49 +310,3 @@ class SectionOutOfOrderRule(Rule):
             if mapped_name not in order_str:
                 order_str.append(mapped_name)
         return " > ".join(order_str)
-
-
-class TestAndKeywordOrderChecker(VisitorChecker):
-    test_case_section_out_of_order: TestCaseSectionOutOfOrderRule
-    keyword_section_out_of_order: KeywordSectionOutOfOrderRule
-
-    def __init__(self) -> None:
-        self.rules_by_node_type: dict[type[Keyword | TestCase], Rule] = {}
-        self.expected_order: dict[type[Keyword | TestCase], list[str]] = {}
-        super().__init__()
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        self.rules_by_node_type = {
-            Keyword: self.keyword_section_out_of_order,
-            TestCase: self.test_case_section_out_of_order,
-        }
-        self.expected_order = {
-            Keyword: self.keyword_section_out_of_order.sections_order,
-            TestCase: self.test_case_section_out_of_order.sections_order,
-        }
-        self.generic_visit(node)
-
-    def check_order(self, node: Keyword | TestCase) -> None:
-        max_order_indicator = -1
-        for subnode in node.body:
-            try:
-                subnode_type = subnode.type
-            except AttributeError:
-                continue
-            if subnode_type not in self.expected_order[type(node)]:
-                continue
-            this_node_expected_order = self.expected_order[type(node)].index(subnode.type)
-            if this_node_expected_order < max_order_indicator:
-                error_node = subnode.data_tokens[0]
-                self.report(
-                    self.rules_by_node_type[type(node)],
-                    section_name=subnode_type,
-                    recommended_order=", ".join(self.expected_order[type(node)]),
-                    node=error_node,
-                    col=error_node.col_offset + 1,
-                    end_col=error_node.end_col_offset + 1,
-                )
-            else:
-                max_order_indicator = this_node_expected_order
-
-    visit_Keyword = visit_TestCase = check_order  # noqa: N815

--- a/src/robocop/linter/rules/test_case_keyword.py
+++ b/src/robocop/linter/rules/test_case_keyword.py
@@ -1,0 +1,102 @@
+"""Checker for rules triggered by test case and keyword definitions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robocop.linter.rules import VisitorChecker, documentation, lengths, naming, order
+from robocop.linter.rules.lengths import count_keyword_calls, is_templated_test
+
+if TYPE_CHECKING:
+    from robot.parsing.model import File, Keyword, SettingSection, TestCase
+    from robot.parsing.model.statements import KeywordName, TestCaseName
+
+
+class TestCaseKeywordChecker(VisitorChecker):
+    """Checker for rules reported for the whole test case or keyword definition."""
+
+    missing_doc_keyword: documentation.MissingDocKeywordRule
+    missing_doc_test_case: documentation.MissingDocTestCaseRule
+    missing_doc_test_suite: documentation.MissingDocTestSuiteRule
+    missing_doc_resource_file: documentation.MissingDocResourceFileRule
+    file_too_long: lengths.FileTooLongRule
+    too_long_keyword: lengths.TooLongKeywordRule
+    too_few_calls_in_keyword: lengths.TooFewCallsInKeywordRule
+    too_many_calls_in_keyword: lengths.TooManyCallsInKeywordRule
+    too_long_test_case: lengths.TooLongTestCaseRule
+    too_few_calls_in_test_case: lengths.TooFewCallsInTestCaseRule
+    too_many_calls_in_test_case: lengths.TooManyCallsInTestCaseRule
+    too_many_arguments: lengths.TooManyArgumentsRule
+    not_allowed_char_in_filename: naming.NotAllowedCharInFilenameRule
+    not_allowed_char_in_name: naming.NotAllowedCharInNameRule
+    not_capitalized_test_case_title: naming.NotCapitalizedTestCaseTitleRule
+    test_case_name_is_empty: naming.TestCaseNameIsEmptyRule
+    test_case_section_out_of_order: order.TestCaseSectionOutOfOrderRule
+    keyword_section_out_of_order: order.KeywordSectionOutOfOrderRule
+
+    def __init__(self) -> None:
+        self.is_resource = False
+        self.settings_section_exists = False
+        super().__init__()
+
+    def visit_File(self, node: File) -> None:  # noqa: N802
+        path = self.source_file.path
+        self.is_resource = bool(path.name) and ".resource" in path.suffix
+        self.settings_section_exists = False
+        self.file_too_long.check(node)
+        self.not_allowed_char_in_filename.check(node, path)
+        self.generic_visit(node)
+        if not self.settings_section_exists:
+            if self.is_resource:
+                self.missing_doc_resource_file.check_missing_settings_section(node)
+            else:
+                self.missing_doc_test_suite.check_missing_settings_section(node)
+
+    def visit_SettingSection(self, node: SettingSection) -> None:  # noqa: N802
+        self.settings_section_exists = True
+        if self.is_resource:
+            self.missing_doc_resource_file.check(node)
+        else:
+            self.missing_doc_test_suite.check(node)
+
+    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
+        self.missing_doc_keyword.check(node)
+        self.keyword_section_out_of_order.check(node)
+        if not node.name.lstrip().startswith("#"):
+            self.too_many_arguments.check(node)
+            # a keyword that is already reported as too long is not additionally reported for the number of calls
+            if not self.too_long_keyword.check(node):
+                keyword_count = count_keyword_calls(node)
+                if not self.too_few_calls_in_keyword.check(node, keyword_count):
+                    self.too_many_calls_in_keyword.check(node, keyword_count)
+        self.generic_visit(node)
+
+    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
+        self.missing_doc_test_case.check(node, self.templated_suite)
+        self.test_case_section_out_of_order.check(node)
+        if node.name:
+            self.not_capitalized_test_case_title.check(node)
+        else:
+            self.test_case_name_is_empty.check(node)
+        self.check_test_case_length(node)
+        self.generic_visit(node)
+
+    def check_test_case_length(self, node: TestCase) -> None:
+        templated = is_templated_test(node, self.templated_suite)
+        if templated and self.too_long_test_case.ignore_templated:
+            return
+        self.too_long_test_case.check(node)
+        skip_too_many = templated and self.too_many_calls_in_test_case.ignore_templated
+        skip_too_few = templated and self.too_few_calls_in_test_case.ignore_templated
+        if skip_too_many and skip_too_few:
+            return
+        keyword_count = count_keyword_calls(node)
+        reported = not skip_too_many and self.too_many_calls_in_test_case.check(node, keyword_count)
+        if not reported and not skip_too_few:
+            self.too_few_calls_in_test_case.check(node, keyword_count)
+
+    def visit_TestCaseName(self, node: TestCaseName) -> None:  # noqa: N802
+        self.not_allowed_char_in_name.check(node, "test case")
+
+    def visit_KeywordName(self, node: KeywordName) -> None:  # noqa: N802
+        self.not_allowed_char_in_name.check(node, "keyword", is_keyword=True)


### PR DESCRIPTION
Wave 6 of the single-visitor migration.

Five separate `VisitorChecker` classes each walked every file to inspect test case and keyword definitions:

- `documentation.MissingDocumentationChecker`
- `lengths.LengthChecker`
- `naming.InvalidCharactersInNameChecker`
- `naming.TestCaseNamingChecker`
- `order.TestAndKeywordOrderChecker`

They are replaced by a single `TestCaseKeywordChecker` in `linter/rules/test_case_keyword.py` that visits each file once and owns 18 rules across four categories:

| Category | Rules |
| --- | --- |
| documentation | `missing-doc-keyword`, `missing-doc-test-case`, `missing-doc-suite`, `missing-doc-resource-file` |
| lengths | `file-too-long`, `too-long-keyword`, `too-few-calls-in-keyword`, `too-many-calls-in-keyword`, `too-long-test-case`, `too-few-calls-in-test-case`, `too-many-calls-in-test-case`, `too-many-arguments` |
| naming | `not-allowed-char-in-filename`, `not-allowed-char-in-name`, `not-capitalized-test-case-title`, `test-case-name-is-empty` |
| order | `test-case-section-out-of-order`, `keyword-section-out-of-order` |

As in previous waves, traversal and data gathering stay in the visitor while the decision logic moves into `check()` methods on the `Rule` classes.

### Preserving cross-rule flow control

Some of these rules were coupled through control flow in the old checker: a keyword already reported as `too-long-keyword` was never additionally checked for the number of calls, and the too-many/too-few call pairs used an `elif`. Because `report()` silently no-ops for a disabled rule, that flow control applied even when the suppressing rule was disabled. The relevant `check()` methods therefore return a boolean describing whether the condition matched (rather than whether anything was reported), so the behaviour is identical for every combination of enabled rules.

`count_keyword_calls` and the templated-test detection became module-level helpers in `lengths.py`, so the visitor gathers the data once and passes it to the rules.

### Validation

- Full `--select ALL` output over the test corpus diffed against the previous revision: **identical** (189296 lines)
- Per-rule runs for all 18 rules: **identical** (these also exercise the disabled-rule flow control, since each run leaves the other 17 rules disabled)
- Eight configured variants diffed: `ignore_templated`, `ignore_docs`, custom `pattern` for both naming rules, custom `sections_order` for both order rules, and lowered length thresholds: **all identical**
- `robocop list rules --verbose`: **identical**
- `pytest tests`: same results as `main`
- `mypy`: same 7 pre-existing errors
- Runtime checker count: **39 -> 35**

Internal checkers only; no user-facing change.