### PR TITLE
refactor: merge variable statement checkers into single VariablesChecker

### DIFF
--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -37,7 +37,6 @@ from robocop.linter.rules import (
     SeverityThreshold,
     VisitorChecker,
     arguments,
-    typing,
     variables,
 )
 from robocop.linter.utils import misc as utils
@@ -48,8 +47,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from robot.parsing.model import File, Keyword, TestCase
-    from robot.parsing.model.blocks import Block, For, KeywordSection, Try, VariableSection, While
-    from robot.parsing.model.statements import Error, LibraryImport, Node, Var
+    from robot.parsing.model.blocks import Block, For, Try, VariableSection, While
+    from robot.parsing.model.statements import Error, LibraryImport, Node
 
     from robocop.linter.diagnostics import Diagnostic
     from robocop.linter.utils.disablers import DisablersFinder
@@ -297,6 +296,20 @@ class InconsistentAssignmentRule(Rule):
     )
     deprecated_names = ("0909",)
 
+    def check(self, token: Token, expected_sign: str) -> None:
+        if not self.enabled:
+            return
+        sign = utils.AssignmentTypeDetector.get_assignment_sign(token.value)
+        if sign == expected_sign:
+            return
+        self.report(
+            expected_sign=expected_sign,
+            actual_sign=sign,
+            lineno=token.lineno,
+            col=token.col_offset + 1,
+            end_col=token.end_col_offset + 1,
+        )
+
 
 class InconsistentAssignmentInVariablesRule(Rule):
     """
@@ -359,6 +372,24 @@ class InconsistentAssignmentInVariablesRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0910",)
+
+    def check(self, node: VariableSection, expected_sign: str) -> None:
+        if not self.enabled:
+            return
+        for child in node.body:
+            if not isinstance(child, Variable) or child.errors:
+                continue
+            var_token = child.get_token(Token.VARIABLE)
+            sign = utils.AssignmentTypeDetector.get_assignment_sign(var_token.value)
+            if sign == expected_sign:
+                continue
+            self.report(
+                expected_sign=expected_sign,
+                actual_sign=sign,
+                lineno=var_token.lineno,
+                col=var_token.col_offset + 1,
+                end_col=var_token.end_col_offset + 1,
+            )
 
 
 class CanBeResourceFileRule(Rule):
@@ -798,158 +829,6 @@ class DisablerNotUsedRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL,
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
-
-
-class ConsistentAssignmentSignChecker(VisitorChecker):
-    """
-    Checker for inconsistent assignment signs.
-
-    By default, this checker will try to autodetect most common assignment sign (separately for ``*** Variables ***``
-    section and ``*** Test Cases ***``, ``*** Keywords ***`` sections) and report any inconsistent type of sign in
-    particular file.
-
-    To force one type of sign type you can configure two rules:
-
-        robocop check --configure inconsistent-assignment.assignment_sign_type={sign_type}
-        robocop check --configure inconsistent-assignment-in-variables.assignment_sign_type={sign_type}
-
-    You can choose between following signs:
-
-    - 'autodetect' (default),
-    - 'none',
-    - 'equal_sign' (``=``)
-    - 'space_and_equal_sign' (`` =``).
-
-    """
-
-    inconsistent_assignment: InconsistentAssignmentRule
-    inconsistent_assignment_in_variables: InconsistentAssignmentInVariablesRule
-
-    def __init__(self) -> None:
-        self.keyword_expected_sign_type: str | None = None
-        self.variables_expected_sign_type: str | None = None
-        super().__init__()
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        self.keyword_expected_sign_type = self.inconsistent_assignment.assignment_sign_type
-        self.variables_expected_sign_type = self.inconsistent_assignment_in_variables.assignment_sign_type
-        if "autodetect" in [
-            self.keyword_expected_sign_type,
-            self.variables_expected_sign_type,
-        ]:
-            auto_detector = self.auto_detect_assignment_sign(node)
-            if self.keyword_expected_sign_type == "autodetect":
-                self.keyword_expected_sign_type = auto_detector.keyword_most_common
-            if self.variables_expected_sign_type == "autodetect":
-                self.variables_expected_sign_type = auto_detector.variables_most_common
-        self.generic_visit(node)
-
-    def visit_KeywordCall(self, node: KeywordCall) -> KeywordCall | None:  # noqa: N802
-        if self.keyword_expected_sign_type is None or not node.keyword:
-            return None
-        if node.assign:  # if keyword returns any value
-            assign_tokens = node.get_tokens(Token.ASSIGN)
-            self.check_assign_type(
-                assign_tokens[-1],
-                self.keyword_expected_sign_type,
-                self.inconsistent_assignment,
-            )
-        return node
-
-    def visit_VariableSection(self, node: VariableSection) -> VariableSection | None:  # noqa: N802
-        if self.variables_expected_sign_type is None:
-            return None
-        for child in node.body:
-            if not isinstance(child, Variable) or child.errors:
-                continue
-            var_token = child.get_token(Token.VARIABLE)
-            self.check_assign_type(
-                var_token,
-                self.variables_expected_sign_type,
-                self.inconsistent_assignment_in_variables,
-            )
-        return node
-
-    def check_assign_type(self, token: Token, expected: str, issue_name: Rule) -> None:
-        sign = utils.AssignmentTypeDetector.get_assignment_sign(token.value)
-        if sign != expected:
-            self.report(
-                issue_name,
-                expected_sign=expected,
-                actual_sign=sign,
-                lineno=token.lineno,
-                col=token.col_offset + 1,
-                end_col=token.end_col_offset + 1,
-            )
-
-    @staticmethod
-    def auto_detect_assignment_sign(node: File) -> utils.AssignmentTypeDetector:
-        auto_detector = utils.AssignmentTypeDetector()
-        auto_detector.visit(node)
-        return auto_detector
-
-
-class EmptyVariableChecker(VisitorChecker):
-    """Checker for variables without value."""
-
-    empty_variable: variables.EmptyVariableRule
-
-    def __init__(self) -> None:
-        self.visit_var_section = False
-        self.visit_var = False
-        super().__init__()
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        variable_source = self.empty_variable.variable_source
-        self.visit_var_section = "section" in variable_source
-        self.visit_var = "var" in variable_source
-        self.generic_visit(node)
-
-    def visit_VariableSection(self, node: VariableSection) -> None:  # noqa: N802
-        if self.visit_var_section:
-            self.generic_visit(node)
-
-    def visit_KeywordSection(self, node: KeywordSection) -> None:  # noqa: N802
-        if self.visit_var:
-            self.generic_visit(node)
-
-    visit_TestCaseSection = visit_KeywordSection  # noqa: N815
-
-    def visit_Variable(self, node: Variable) -> None:  # noqa: N802
-        if node.errors:
-            return
-        if not node.value:  # catch variable declaration without any value
-            self.report(self.empty_variable, node=node, end_col=node.end_col_offset)
-        for token in node.get_tokens(Token.ARGUMENT):
-            if not token.value or token.value == "\\":
-                self.report(
-                    self.empty_variable,
-                    node=token,
-                    lineno=token.lineno,
-                    col=1,
-                    end_col=token.end_col_offset + 1,
-                )
-
-    def visit_Var(self, node: Var) -> None:  # noqa: N802
-        if node.errors:
-            return
-        if not node.value:  # catch variable declaration without any value
-            first_data = node.data_tokens[0]
-            self.report(
-                self.empty_variable,
-                node=first_data,
-                col=first_data.col_offset + 1,
-                end_col=first_data.end_col_offset + 1,
-            )
-        for token in node.get_tokens(Token.ARGUMENT):
-            if not token.value or token.value == "\\":
-                self.report(
-                    self.empty_variable,
-                    node=token,
-                    lineno=token.lineno,
-                    col=token.col_offset + 1,
-                    end_col=token.end_col_offset + 1,
-                )
 
 
 class IfChecker(VisitorChecker):
@@ -1753,78 +1632,6 @@ class ExpressionsChecker(VisitorChecker):
             )
 
 
-class NonLocalVariableChecker(VisitorChecker):
-    no_global_variable: variables.NoGlobalVariableRule
-    no_suite_variable: variables.NoSuiteVariableRule
-    no_test_variable: variables.NoTestVariableRule
-    set_keyword_with_type: typing.SetKeywordWithTypeRule
-
-    set_variable_keywords = {
-        "setglobalvariable",
-        "setsuitevariable",
-        "settestvariable",
-        "settaskvariable",
-        "setlocalvariable",
-    }
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        keyword_token = node.get_token(Token.KEYWORD)
-        if not keyword_token:
-            return
-
-        keyword_name = utils.normalize_robot_name(keyword_token.value, remove_prefix="builtin.")
-        if keyword_name not in self.set_variable_keywords:
-            return
-
-        self.set_keyword_with_type.check(node)
-
-        if keyword_name == "setglobalvariable":
-            self._report(self.no_global_variable, keyword_token)
-            return
-
-        if keyword_name == "setsuitevariable":
-            self._report(self.no_suite_variable, keyword_token)
-            return
-
-        if keyword_name in ["settestvariable", "settaskvariable"]:
-            self._report(self.no_test_variable, keyword_token)
-            return
-
-    def visit_Var(self, node: Var) -> None:  # noqa: N802
-        """Visit VAR syntax introduced in Robot Framework 7. Is ignored in Robot < 7"""
-        if not node.scope:
-            return
-
-        scope = node.scope.upper()
-        if scope == "LOCAL":
-            return
-
-        option_token = node.get_token(Token.OPTION)
-
-        if scope == "GLOBAL":
-            self._report(self.no_global_variable, option_token)
-            return
-
-        if scope in ["SUITE", "SUITES"]:
-            self._report(self.no_suite_variable, option_token)
-            return
-
-        if scope in ["TEST", "TASK"]:
-            self._report(self.no_test_variable, option_token)
-            return
-
-        # Unexpected scope, or variable-defined scope
-
-    def _report(self, rule: Rule, node: Node) -> None:
-        self.report(
-            rule,
-            node=node,
-            lineno=node.lineno,
-            col=node.col_offset + 1,
-            end_col=node.col_offset + len(node.value) + 1,
-        )
-
-
 class UnusedDiagnosticChecker(AfterRunChecker):
     unused_disabler: DisablerNotUsedRule
 
@@ -1844,144 +1651,3 @@ class UnusedDiagnosticChecker(AfterRunChecker):
                 col=disabler.directive_col_start,
                 end_col=disabler.directive_col_end,
             )
-
-
-class MissingVariableTypeChecker(VisitorChecker):
-    """Checker for variables without type annotations (RF 7.3+)."""
-
-    missing_section_variable_type: typing.MissingSectionVariableTypeRule
-    missing_argument_type: typing.MissingArgumentTypeRule
-    missing_for_loop_variable_type: typing.MissingForLoopVariableTypeRule
-
-    @staticmethod
-    def has_type_annotation(var_name: str) -> bool:
-        """
-        Check if variable has type annotation (contains ': ' followed by type).
-
-        Returns:
-            True if variable has type annotation
-
-        """
-        # Type conversion syntax: ${var: type} - note the space after colon
-        # vs embedded pattern: ${var:pattern} - no space after colon
-        return ": " in var_name
-
-    @staticmethod
-    def is_ignore_variable(var_name: str) -> bool:
-        """
-        Check if variable is an ignore variable like ${_} or ${_name}.
-
-        Args:
-            var_name: Variable name from search_variable().base
-
-        Returns:
-            True if variable should be ignored (starts with underscore)
-
-        """
-        # Strip variable markers like ${, @{, &{, %}
-        name = var_name.lstrip("$@&%{").rstrip("}")
-        # Remove type annotation if present
-        name = utils.remove_variable_type_conversion(name)
-        return name == "_" or name.startswith("_")
-
-    def should_report_missing_type(self, var_name: str) -> bool:
-        """
-        Check if variable should be reported for missing type annotation.
-
-        Args:
-            var_name: Variable name from search_variable()
-
-        Returns:
-            True if variable is missing type annotation and should be reported
-
-        """
-        try:
-            var_match = search_variable(var_name, ignore_errors=True)
-            return (
-                var_match.base
-                and not self.has_type_annotation(var_match.base)
-                and not self.is_ignore_variable(var_match.base)
-            )
-        except VariableError:
-            return False
-
-    def visit_Variable(self, node: Variable) -> None:  # noqa: N802
-        """Check variables in *** Variables *** section."""
-        if node.errors:
-            return
-        token = node.data_tokens[0]
-        if self.should_report_missing_type(token.value):
-            var_match = search_variable(token.value, ignore_errors=True)
-            self.report(
-                self.missing_section_variable_type,
-                variable_name=var_match.match,
-                node=node,
-                lineno=token.lineno,
-                col=token.col_offset + 1,
-                end_col=token.end_col_offset + 1,
-            )
-
-    def visit_Var(self, node: Var) -> None:  # noqa: N802
-        """Check VAR statements."""
-        if node.errors:
-            return
-        variable = node.get_token(Token.VARIABLE)
-        if not variable:
-            return
-        if self.should_report_missing_type(variable.value):
-            var_match = search_variable(variable.value, ignore_errors=True)
-            self.report(
-                self.missing_section_variable_type,
-                variable_name=var_match.match,
-                node=node,
-                lineno=variable.lineno,
-                col=variable.col_offset + 1,
-                end_col=variable.end_col_offset + 1,
-            )
-
-    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
-        """Check assignment expressions (${var} = Keyword)."""
-        # TODO: we already search for variable in unused var checker - we can combine
-        for token in node.get_tokens(Token.ASSIGN):
-            if self.should_report_missing_type(token.value):
-                var_match = search_variable(token.value, ignore_errors=True)
-                self.report(
-                    self.missing_section_variable_type,
-                    variable_name=var_match.match,
-                    node=node,
-                    lineno=token.lineno,
-                    col=token.col_offset + 1,
-                    end_col=token.end_col_offset + 1,
-                )
-
-    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
-        """Check keyword arguments ([Arguments])."""
-        for arg in node.get_tokens(Token.ARGUMENT):
-            # Handle default values: ${arg: type}=default
-            arg_name, _ = utils.split_argument_default_value(arg.value)
-            if self.should_report_missing_type(arg_name):
-                var_match = search_variable(arg_name, ignore_errors=True)
-                self.report(
-                    self.missing_argument_type,
-                    variable_name=var_match.match,
-                    node=node,
-                    lineno=arg.lineno,
-                    col=arg.col_offset + 1,
-                    end_col=arg.col_offset + len(arg_name) + 1,
-                )
-
-    def visit_For(self, node: For) -> None:  # noqa: N802
-        """Check FOR loop variables."""
-        if not node.header.errors:
-            for variable in node.header.get_tokens(Token.VARIABLE):
-                if self.should_report_missing_type(variable.value):
-                    var_match = search_variable(variable.value, ignore_errors=True)
-                    self.report(
-                        self.missing_for_loop_variable_type,
-                        variable_name=var_match.match,
-                        node=node,
-                        lineno=variable.lineno,
-                        col=variable.col_offset + 1,
-                        end_col=variable.end_col_offset + 1,
-                    )
-        self.generic_visit(node)  # Continue to nested loops

--- a/src/robocop/linter/rules/typing.py
+++ b/src/robocop/linter/rules/typing.py
@@ -3,13 +3,43 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from robot.api import Token
+from robot.errors import VariableError
 from robot.variables.search import search_variable
 
 from robocop.linter import sonar_qube
 from robocop.linter.rules import Rule, RuleSeverity
+from robocop.linter.utils.misc import remove_variable_type_conversion, split_argument_default_value
 
 if TYPE_CHECKING:
-    from robot.parsing.model.blocks import KeywordCall
+    from robot.parsing.model.blocks import For, KeywordCall
+    from robot.parsing.model.statements import Arguments, Node
+
+
+def has_type_annotation(var_name: str) -> bool:
+    """
+    Check if variable has type annotation (contains ': ' followed by type).
+
+    Type conversion syntax is ``${var: type}`` - note the space after the colon,
+    as opposed to the embedded pattern ``${var:pattern}`` without the space.
+    """
+    return ": " in var_name
+
+
+def is_ignore_variable(var_name: str) -> bool:
+    """Check if variable is an ignore variable like ``${_}`` or ``${_name}``."""
+    # Strip variable markers like ${, @{, &{, %}
+    name = var_name.lstrip("$@&%{").rstrip("}")
+    name = remove_variable_type_conversion(name)
+    return name == "_" or name.startswith("_")
+
+
+def should_report_missing_type(var_name: str) -> bool:
+    """Check if variable is missing type annotation and should be reported."""
+    try:
+        var_match = search_variable(var_name, ignore_errors=True)
+    except VariableError:
+        return False
+    return bool(var_match.base) and not has_type_annotation(var_match.base) and not is_ignore_variable(var_match.base)
 
 
 class MissingSectionVariableTypeRule(Rule):
@@ -58,6 +88,19 @@ class MissingSectionVariableTypeRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
 
+    def check(self, node: Node, token: Token) -> None:
+        """Check a variable name token from the variables section, a ``VAR`` statement or an assignment."""
+        if not self.enabled or not should_report_missing_type(token.value):
+            return
+        var_match = search_variable(token.value, ignore_errors=True)
+        self.report(
+            variable_name=var_match.match,
+            node=node,
+            lineno=token.lineno,
+            col=token.col_offset + 1,
+            end_col=token.end_col_offset + 1,
+        )
+
 
 class MissingArgumentTypeRule(Rule):
     """
@@ -95,6 +138,23 @@ class MissingArgumentTypeRule(Rule):
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
+
+    def check(self, node: Arguments) -> None:
+        if not self.enabled:
+            return
+        for arg in node.get_tokens(Token.ARGUMENT):
+            # Handle default values: ${arg: type}=default
+            arg_name, _ = split_argument_default_value(arg.value)
+            if not should_report_missing_type(arg_name):
+                continue
+            var_match = search_variable(arg_name, ignore_errors=True)
+            self.report(
+                variable_name=var_match.match,
+                node=node,
+                lineno=arg.lineno,
+                col=arg.col_offset + 1,
+                end_col=arg.col_offset + len(arg_name) + 1,
+            )
 
 
 class MissingForLoopVariableTypeRule(Rule):
@@ -135,6 +195,21 @@ class MissingForLoopVariableTypeRule(Rule):
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
+
+    def check(self, node: For) -> None:
+        if not self.enabled or node.header.errors:
+            return
+        for variable in node.header.get_tokens(Token.VARIABLE):
+            if not should_report_missing_type(variable.value):
+                continue
+            var_match = search_variable(variable.value, ignore_errors=True)
+            self.report(
+                variable_name=var_match.match,
+                node=node,
+                lineno=variable.lineno,
+                col=variable.col_offset + 1,
+                end_col=variable.end_col_offset + 1,
+            )
 
 
 class SetKeywordWithTypeRule(Rule):

--- a/src/robocop/linter/rules/variable_statements.py
+++ b/src/robocop/linter/rules/variable_statements.py
@@ -1,0 +1,145 @@
+"""Checker for rules triggered by variable definitions and assignments."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robot.api import Token
+
+from robocop.linter.rules import VisitorChecker, misc, typing, variables
+from robocop.linter.utils import misc as utils
+
+if TYPE_CHECKING:
+    from robot.parsing.model import File
+    from robot.parsing.model.blocks import For, KeywordSection, VariableSection
+    from robot.parsing.model.statements import Arguments, KeywordCall, Var, Variable
+
+
+class VariablesChecker(VisitorChecker):
+    """Checker for rules reported for variable definitions, assignments and their scopes."""
+
+    empty_variable: variables.EmptyVariableRule
+    no_global_variable: variables.NoGlobalVariableRule
+    no_suite_variable: variables.NoSuiteVariableRule
+    no_test_variable: variables.NoTestVariableRule
+    set_keyword_with_type: typing.SetKeywordWithTypeRule
+    missing_section_variable_type: typing.MissingSectionVariableTypeRule
+    missing_argument_type: typing.MissingArgumentTypeRule
+    missing_for_loop_variable_type: typing.MissingForLoopVariableTypeRule
+    inconsistent_assignment: misc.InconsistentAssignmentRule
+    inconsistent_assignment_in_variables: misc.InconsistentAssignmentInVariablesRule
+
+    set_variable_keywords = {
+        "setglobalvariable",
+        "setsuitevariable",
+        "settestvariable",
+        "settaskvariable",
+        "setlocalvariable",
+    }
+
+    def __init__(self) -> None:
+        self.keyword_expected_sign_type: str | None = None
+        self.variables_expected_sign_type: str | None = None
+        self.check_empty_variable = True
+        super().__init__()
+
+    def visit_File(self, node: File) -> None:  # noqa: N802
+        self.check_empty_variable = True
+        self.detect_assignment_sign(node)
+        self.generic_visit(node)
+
+    def detect_assignment_sign(self, node: File) -> None:
+        """Find the most common assignment sign in the file if the rules are set to autodetect it."""
+        self.keyword_expected_sign_type = self.inconsistent_assignment.assignment_sign_type
+        self.variables_expected_sign_type = self.inconsistent_assignment_in_variables.assignment_sign_type
+        if "autodetect" not in (self.keyword_expected_sign_type, self.variables_expected_sign_type):
+            return
+        auto_detector = utils.AssignmentTypeDetector()
+        auto_detector.visit(node)
+        if self.keyword_expected_sign_type == "autodetect":
+            self.keyword_expected_sign_type = auto_detector.keyword_most_common
+        if self.variables_expected_sign_type == "autodetect":
+            self.variables_expected_sign_type = auto_detector.variables_most_common
+
+    def visit_VariableSection(self, node: VariableSection) -> None:  # noqa: N802
+        if self.variables_expected_sign_type is not None:
+            self.inconsistent_assignment_in_variables.check(node, self.variables_expected_sign_type)
+        # ``empty-variable`` is only reported here when the variables section is one of its configured sources
+        self.check_empty_variable = "section" in self.empty_variable.variable_source
+        self.generic_visit(node)
+        self.check_empty_variable = True
+
+    def visit_KeywordSection(self, node: KeywordSection) -> None:  # noqa: N802
+        # ``empty-variable`` is only reported here when the VAR syntax is one of its configured sources
+        self.check_empty_variable = "var" in self.empty_variable.variable_source
+        self.generic_visit(node)
+        self.check_empty_variable = True
+
+    visit_TestCaseSection = visit_KeywordSection  # noqa: N815
+
+    def visit_Variable(self, node: Variable) -> None:  # noqa: N802
+        if self.check_empty_variable:
+            self.empty_variable.check_variable(node)
+        if node.errors:
+            return
+        self.missing_section_variable_type.check(node, node.data_tokens[0])
+
+    def visit_Var(self, node: Var) -> None:  # noqa: N802
+        """Visit VAR syntax introduced in Robot Framework 7. Is ignored in Robot < 7."""
+        if self.check_empty_variable:
+            self.empty_variable.check_var(node)
+        self.check_var_scope(node)
+        if node.errors:
+            return
+        variable = node.get_token(Token.VARIABLE)
+        if variable:
+            self.missing_section_variable_type.check(node, variable)
+
+    def check_var_scope(self, node: Var) -> None:
+        if not node.scope:
+            return
+        scope = node.scope.upper()
+        if scope == "LOCAL":
+            return
+        option_token = node.get_token(Token.OPTION)
+        if scope == "GLOBAL":
+            self.no_global_variable.check(option_token)
+        elif scope in ("SUITE", "SUITES"):
+            self.no_suite_variable.check(option_token)
+        elif scope in ("TEST", "TASK"):
+            self.no_test_variable.check(option_token)
+        # Unexpected scope, or variable-defined scope
+
+    def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
+        self.check_assignment_sign(node)
+        for token in node.get_tokens(Token.ASSIGN):
+            self.missing_section_variable_type.check(node, token)
+        self.check_set_variable_keyword(node)
+
+    def check_assignment_sign(self, node: KeywordCall) -> None:
+        if self.keyword_expected_sign_type is None or not node.keyword or not node.assign:
+            return
+        assign_tokens = node.get_tokens(Token.ASSIGN)
+        self.inconsistent_assignment.check(assign_tokens[-1], self.keyword_expected_sign_type)
+
+    def check_set_variable_keyword(self, node: KeywordCall) -> None:
+        keyword_token = node.get_token(Token.KEYWORD)
+        if not keyword_token:
+            return
+        keyword_name = utils.normalize_robot_name(keyword_token.value, remove_prefix="builtin.")
+        if keyword_name not in self.set_variable_keywords:
+            return
+        self.set_keyword_with_type.check(node)
+        if keyword_name == "setglobalvariable":
+            self.no_global_variable.check(keyword_token)
+        elif keyword_name == "setsuitevariable":
+            self.no_suite_variable.check(keyword_token)
+        elif keyword_name in ("settestvariable", "settaskvariable"):
+            self.no_test_variable.check(keyword_token)
+
+    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
+        self.missing_argument_type.check(node)
+
+    def visit_For(self, node: For) -> None:  # noqa: N802
+        self.missing_for_loop_variable_type.check(node)
+        self.generic_visit(node)  # Continue to nested loops

--- a/src/robocop/linter/rules/variables.py
+++ b/src/robocop/linter/rules/variables.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from robot.api import Token
+
 from robocop.linter import sonar_qube
 from robocop.linter.rules import Rule, RuleParam, RuleSeverity
+
+if TYPE_CHECKING:
+    from robot.parsing.model.statements import Node, Var, Variable
 
 
 def comma_separated_list(value: str) -> list[str]:
     return value.split(",")
+
+
+def report_non_local_scope(rule: Rule, node: Node) -> None:
+    """Report a variable scope rule on the token that defines the scope."""
+    if not rule.enabled:
+        return
+    rule.report(
+        node=node,
+        lineno=node.lineno,
+        col=node.col_offset + 1,
+        end_col=node.col_offset + len(node.value) + 1,
+    )
 
 
 class EmptyVariableRule(Rule):
@@ -70,6 +89,36 @@ class EmptyVariableRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0912",)
+
+    def check_variable(self, node: Variable) -> None:
+        """Check variable defined in the ``*** Variables ***`` section."""
+        if not self.enabled or node.errors:
+            return
+        if not node.value:  # catch variable declaration without any value
+            self.report(node=node, end_col=node.end_col_offset)
+        for token in node.get_tokens(Token.ARGUMENT):
+            if not token.value or token.value == "\\":
+                self.report(node=token, lineno=token.lineno, col=1, end_col=token.end_col_offset + 1)
+
+    def check_var(self, node: Var) -> None:
+        """Check variable defined with the ``VAR`` syntax."""
+        if not self.enabled or node.errors:
+            return
+        if not node.value:  # catch variable declaration without any value
+            first_data = node.data_tokens[0]
+            self.report(
+                node=first_data,
+                col=first_data.col_offset + 1,
+                end_col=first_data.end_col_offset + 1,
+            )
+        for token in node.get_tokens(Token.ARGUMENT):
+            if not token.value or token.value == "\\":
+                self.report(
+                    node=token,
+                    lineno=token.lineno,
+                    col=token.col_offset + 1,
+                    end_col=token.end_col_offset + 1,
+                )
 
 
 class UnusedVariableRule(Rule):
@@ -221,6 +270,9 @@ class NoGlobalVariableRule(Rule):
     )
     deprecated_names = ("0929",)
 
+    def check(self, node: Node) -> None:
+        report_non_local_scope(self, node)
+
 
 class NoSuiteVariableRule(Rule):
     """
@@ -274,6 +326,9 @@ class NoSuiteVariableRule(Rule):
     )
     deprecated_names = ("0930",)
 
+    def check(self, node: Node) -> None:
+        report_non_local_scope(self, node)
+
 
 class NoTestVariableRule(Rule):
     """
@@ -326,6 +381,9 @@ class NoTestVariableRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0931",)
+
+    def check(self, node: Node) -> None:
+        report_non_local_scope(self, node)
 
 
 class NonLocalVariablesShouldBeUppercaseRule(Rule):


### PR DESCRIPTION
Continues the single-visitor migration (wave 8). Merges four AST visitors that all walked variable-related statements into one `VariablesChecker` in the new `src/robocop/linter/rules/variable_statements.py`:

- `misc.ConsistentAssignmentSignChecker`
- `misc.EmptyVariableChecker`
- `misc.NonLocalVariableChecker`
- `misc.MissingVariableTypeChecker`

The new checker owns 10 rules spanning three categories, and the decision logic moved into `check()` methods on the rules themselves, matching the pattern used by the previously merged checkers.

| | |
|---|---|
| variables | `empty-variable`, `no-global-variable`, `no-suite-variable`, `no-test-variable` |
| typing | `set-keyword-with-type`, `missing-section-variable-type`, `missing-argument-type`, `missing-for-loop-variable-type` |
| misc | `inconsistent-assignment`, `inconsistent-assignment-in-variables` |

### Traversal gating restructure

The `empty-variable` `variable_source` parameter previously gated *traversal*: the old checker only called `generic_visit` on a section when that source was enabled. Since the merged visitor must always descend for the other rules, the gating moved to a `check_empty_variable` flag consulted in `visit_Variable` / `visit_Var`. `Variable` statements only appear in `*** Variables ***` and `VAR` only in keyword/test bodies, so this is behaviourally equivalent.

`NonLocalVariableChecker.visit_Var` had no `node.errors` guard (unlike the other two visitors); this is preserved by calling the scope check before the errors guard.

### Validation

No user-visible change. Verified byte-identical output against the previous revision for:

- a full `--select ALL` scan of `tests/linter/rules` + `tests/formatter` (189296 lines)
- `robocop list rules --verbose`
- per-rule runs for all 10 rules (the three `missing-*-type` rules are disabled by default, so these runs are what covers them)
- 8 configured variants of the gating parameters (`variable_source` = section / var / both, `assignment_sign_type` = equal_sign / none / space_and_equal_sign for both sign rules)
- a hand-written edge-case suite (empty/backslash/multiline variables, `VAR` with every `scope=` incl. a dynamic one, `Set * Variable` keywords, typed variables, ignore variables, `[Arguments]` with defaults, nested `FOR`, and a `VAR` inside a variables section)

`pytest` and `mypy` match their baselines exactly.

Checker count: **33 -> 30**.
