### PR TITLE
refactor: merge settings checkers into single SettingsChecker

### DIFF
--- a/src/robocop/linter/rules/errors.py
+++ b/src/robocop/linter/rules/errors.py
@@ -102,6 +102,11 @@ class VariablesImportWithArgsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
 
+    def check(self, node: VariablesImport) -> None:
+        if node.name and node.name.endswith((".yaml", ".yml")) and node.get_token(Token.ARGUMENT):
+            eol = node.get_token(Token.EOL) or node
+            self.report(node=node, end_col=eol.end_col_offset)
+
 
 class InvalidContinuationMarkRule(Rule):
     """
@@ -631,14 +636,3 @@ class ParsingErrorChecker(VisitorChecker):
                 lineno=node.lineno,
                 end_col=node.end_col_offset,
             )
-
-
-class VariablesImportErrorChecker(VisitorChecker):  # TODO merge such visitors into one
-    """Checker for syntax error in variables import."""
-
-    variables_import_with_args: VariablesImportWithArgsRule
-
-    def visit_VariablesImport(self, node: VariablesImport) -> None:  # noqa: N802
-        if node.name and node.name.endswith((".yaml", ".yml")) and node.get_token(Token.ARGUMENT):
-            eol = node.get_token(Token.EOL) or node
-            self.report(self.variables_import_with_args, node=node, end_col=eol.end_col_offset)

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from robot.api import Token
-from robot.libraries import STDLIBS
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker
+from robocop.linter.rules import Rule, RuleSeverity
 
 if TYPE_CHECKING:
-    from robot.parsing import File
     from robot.parsing.model.statements import LibraryImport, ResourceImport
 
 
@@ -39,6 +37,16 @@ class WrongImportOrderRule(Rule):
     )
     deprecated_names = ("0911",)
 
+    def check(self, node: LibraryImport, custom_import: LibraryImport) -> None:
+        lib_name = node.get_token(Token.NAME)
+        self.report(
+            builtin_import=node.name,
+            custom_import=custom_import.name,
+            node=node,
+            col=lib_name.col_offset + 1,
+            end_col=lib_name.end_col_offset + 1,
+        )
+
 
 class BuiltinImportsNotSortedRule(Rule):
     """
@@ -63,6 +71,18 @@ class BuiltinImportsNotSortedRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0926",)
+
+    def check(self, node: LibraryImport, previous: LibraryImport | None) -> None:
+        if not previous or node.name >= previous.name:
+            return
+        lib_name = node.get_token(Token.NAME)
+        self.report(
+            builtin_import=node.name,
+            previous_builtin_import=previous.name,
+            node=node,
+            col=lib_name.col_offset + 1,
+            end_col=lib_name.end_col_offset + 1,
+        )
 
 
 class NonBuiltinImportsNotSortedRule(Rule):
@@ -92,6 +112,18 @@ class NonBuiltinImportsNotSortedRule(Rule):
     )
     deprecated_names = ("10101",)
 
+    def check(self, node: LibraryImport, previous: LibraryImport | None) -> None:
+        if previous is None or node.name >= previous.name:
+            return
+        lib_name = node.get_token(Token.NAME)
+        self.report(
+            custom_import=node.name,
+            previous_custom_import=previous.name,
+            node=node,
+            col=lib_name.col_offset + 1,
+            end_col=lib_name.end_col_offset + 1,
+        )
+
 
 class ResourcesImportsNotSortedRule(Rule):
     """
@@ -119,89 +151,14 @@ class ResourcesImportsNotSortedRule(Rule):
     )
     deprecated_names = ("10102",)
 
-
-class SettingsOrderChecker(VisitorChecker):
-    """Checker for settings order."""
-
-    wrong_import_order: WrongImportOrderRule
-    builtin_imports_not_sorted: BuiltinImportsNotSortedRule
-    non_builtin_imports_not_sorted: NonBuiltinImportsNotSortedRule
-    resources_imports_not_sorted: ResourcesImportsNotSortedRule
-
-    def __init__(self) -> None:
-        self.libraries: list[LibraryImport] = []
-        self.non_builtin_libraries: list[LibraryImport] = []
-        self.resources: list[ResourceImport] = []
-        super().__init__()
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        self.libraries = []
-        self.resources = []
-        self.generic_visit(node)
-        built_in_libs: list[LibraryImport] = []
-        non_builtin_libs: list[LibraryImport] = []
-
-        for library in self.libraries:
-            if library.name in STDLIBS:
-                built_in_libs.append(library)
-                if non_builtin_libs:
-                    lib_name = library.get_token(Token.NAME)
-                    self.report(
-                        self.wrong_import_order,
-                        builtin_import=library.name,
-                        custom_import=non_builtin_libs[0].name,
-                        node=library,
-                        col=lib_name.col_offset + 1,
-                        end_col=lib_name.end_col_offset + 1,
-                    )
-            else:
-                non_builtin_libs.append(library)
-        previous = None
-        for library in built_in_libs:
-            if previous and library.name < previous.name:
-                lib_name = library.get_token(Token.NAME)
-                self.report(
-                    self.builtin_imports_not_sorted,
-                    builtin_import=library.name,
-                    previous_builtin_import=previous.name,
-                    node=library,
-                    col=lib_name.col_offset + 1,
-                    end_col=lib_name.end_col_offset + 1,
-                )
-            previous = library
-        previous = None
-        for library in non_builtin_libs:
-            if previous is not None and library.name < previous.name:
-                lib_name = library.get_token(Token.NAME)
-                self.report(
-                    self.non_builtin_imports_not_sorted,
-                    custom_import=library.name,
-                    previous_custom_import=previous.name,
-                    node=library,
-                    col=lib_name.col_offset + 1,
-                    end_col=lib_name.end_col_offset + 1,
-                )
-            previous = library
-        previous = None
-        for resource in self.resources:
-            if previous is not None and resource.name < previous.name:
-                resource_name = resource.get_token(Token.NAME)
-                self.report(
-                    self.resources_imports_not_sorted,
-                    resource_import=resource.name,
-                    previous_resource_import=previous.name,
-                    node=resource,
-                    col=resource_name.col_offset + 1,
-                    end_col=resource_name.end_col_offset + 1,
-                )
-            previous = resource
-
-    def visit_LibraryImport(self, node: LibraryImport) -> None:  # noqa: N802
-        if not node.name:
+    def check(self, node: ResourceImport, previous: ResourceImport | None) -> None:
+        if previous is None or node.name >= previous.name:
             return
-        self.libraries.append(node)
-
-    def visit_ResourceImport(self, node: ResourceImport) -> None:  # noqa: N802
-        if not node.name:
-            return
-        self.resources.append(node)
+        resource_name = node.get_token(Token.NAME)
+        self.report(
+            resource_import=node.name,
+            previous_resource_import=previous.name,
+            node=node,
+            col=resource_name.col_offset + 1,
+            end_col=resource_name.end_col_offset + 1,
+        )

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -520,6 +520,21 @@ class NumberOfReturnedValuesRule(Rule):
             self.check(len(node.args) - 1, node)
 
 
+def report_empty_setting(rule: Rule, node: Statement) -> None:
+    """Report an empty setting that spans the whole statement."""
+    rule.report(node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
+
+
+def report_empty_block_setting(rule: Rule, node: Statement, block_name: str) -> None:
+    """Report an empty setting whose message names the block (test case or keyword) it belongs to."""
+    rule.report(
+        block_name=block_name,
+        node=node,
+        col=node.data_tokens[0].col_offset + 1,
+        end_col=node.end_col_offset,
+    )
+
+
 class EmptyMetadataRule(Rule):
     """
     Metadata settings do not have any value set.
@@ -546,6 +561,10 @@ class EmptyMetadataRule(Rule):
     )
     deprecated_names = ("0511",)
 
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            self.report(node=node, col=node.col_offset + 1)
+
 
 class EmptyDocumentationRule(Rule):
     """Documentation is empty."""
@@ -559,6 +578,10 @@ class EmptyDocumentationRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0512",)
+
+    def check(self, node: Statement, block_name: str) -> None:
+        if not node.value:
+            report_empty_block_setting(self, node, block_name)
 
 
 class EmptyForceTagsRule(Rule):  # TODO: Rename/deprecate and replace with Test Tags
@@ -574,6 +597,10 @@ class EmptyForceTagsRule(Rule):  # TODO: Rename/deprecate and replace with Test 
     )
     deprecated_names = ("0513",)
 
+    def check(self, node: Statement) -> None:
+        if not node.values:
+            report_empty_setting(self, node)
+
 
 class EmptyDefaultTagsRule(Rule):
     """Default Tags are empty."""
@@ -587,6 +614,10 @@ class EmptyDefaultTagsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0514",)
+
+    def check(self, node: Statement) -> None:
+        if not node.values:
+            report_empty_setting(self, node)
 
 
 class EmptyVariablesImport(Rule):
@@ -602,6 +633,10 @@ class EmptyVariablesImport(Rule):
     )
     deprecated_names = ("0515",)
 
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
+
 
 class EmptyResourceImport(Rule):
     """Import resources path is empty."""
@@ -615,6 +650,10 @@ class EmptyResourceImport(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0516",)
+
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
 
 
 class EmptyLibraryImport(Rule):
@@ -630,6 +669,10 @@ class EmptyLibraryImport(Rule):
     )
     deprecated_names = ("0517",)
 
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
+
 
 class EmptySetupRule(Rule):
     """Empty setup."""
@@ -643,6 +686,10 @@ class EmptySetupRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0518",)
+
+    def check(self, node: Statement, block_name: str) -> None:
+        if not node.name:
+            report_empty_block_setting(self, node, block_name)
 
 
 class EmptySuiteSetupRule(Rule):
@@ -658,6 +705,10 @@ class EmptySuiteSetupRule(Rule):
     )
     deprecated_names = ("0519",)
 
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
+
 
 class EmptyTestSetupRule(Rule):
     """Empty Test Setup."""
@@ -671,6 +722,10 @@ class EmptyTestSetupRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0520",)
+
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
 
 
 class EmptyTeardownRule(Rule):
@@ -686,6 +741,10 @@ class EmptyTeardownRule(Rule):
     )
     deprecated_names = ("0521",)
 
+    def check(self, node: Statement, block_name: str) -> None:
+        if not node.name:
+            report_empty_block_setting(self, node, block_name)
+
 
 class EmptySuiteTeardownRule(Rule):
     """Empty Suite Teardown."""
@@ -699,6 +758,10 @@ class EmptySuiteTeardownRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0522",)
+
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
 
 
 class EmptyTestTeardownRule(Rule):
@@ -714,6 +777,10 @@ class EmptyTestTeardownRule(Rule):
     )
     deprecated_names = ("0523",)
 
+    def check(self, node: Statement) -> None:
+        if not node.name:
+            report_empty_setting(self, node)
+
 
 class EmptyTimeoutRule(Rule):
     """Empty Timeout."""
@@ -727,6 +794,10 @@ class EmptyTimeoutRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0524",)
+
+    def check(self, node: Statement, block_name: str) -> None:
+        if not node.value:
+            report_empty_block_setting(self, node, block_name)
 
 
 class EmptyTestTimeoutRule(Rule):
@@ -742,6 +813,10 @@ class EmptyTestTimeoutRule(Rule):
     )
     deprecated_names = ("0525",)
 
+    def check(self, node: Statement) -> None:
+        if not node.value:
+            report_empty_setting(self, node)
+
 
 class EmptyArgumentsRule(Rule):
     """Empty ``[Arguments]`` setting."""
@@ -755,6 +830,10 @@ class EmptyArgumentsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0526",)
+
+    def check(self, node: Statement, block_name: str) -> None:
+        if not node.values:
+            report_empty_block_setting(self, node, block_name)
 
 
 class TooManyTestCasesRule(Rule):
@@ -815,6 +894,10 @@ class EmptyTestTemplateRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
 
+    def check(self, node: Statement) -> None:
+        if not node.value:
+            report_empty_setting(self, node)
+
 
 class EmptyTemplateRule(Rule):
     """
@@ -848,6 +931,10 @@ class EmptyTemplateRule(Rule):
     )
     deprecated_names = ("0530",)
 
+    def check(self, node: Statement, block_name: str) -> None:
+        if len(node.data_tokens) < 2:
+            report_empty_block_setting(self, node, block_name)
+
 
 class EmptyKeywordTagsRule(Rule):
     """Keyword Tags are empty."""
@@ -862,6 +949,10 @@ class EmptyKeywordTagsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0531",)
+
+    def check(self, node: Statement) -> None:
+        if not node.values:
+            report_empty_setting(self, node)
 
 
 class TooLongVariableNameRule(Rule):
@@ -1090,161 +1181,3 @@ class VariableNameLengthChecker(VisitorChecker):
         if (node.type is Token.EXCEPT) and (variable := node.header.get_token(Token.VARIABLE)):
             self.add_variable_to_scope(variable)
         self.generic_visit(node)  # continue to all branches
-
-
-class EmptySettingsChecker(VisitorChecker):
-    """Checker for detecting empty settings."""
-
-    empty_metadata: EmptyMetadataRule
-    empty_documentation: EmptyDocumentationRule
-    empty_force_tags: EmptyForceTagsRule
-    empty_default_tags: EmptyDefaultTagsRule
-    empty_variables_import: EmptyVariablesImport
-    empty_resource_import: EmptyResourceImport
-    empty_library_import: EmptyLibraryImport
-    empty_setup: EmptySetupRule
-    empty_suite_setup: EmptySuiteSetupRule
-    empty_test_setup: EmptyTestSetupRule
-    empty_teardown: EmptyTeardownRule
-    empty_suite_teardown: EmptySuiteTeardownRule
-    empty_test_teardown: EmptyTestTeardownRule
-    empty_timeout: EmptyTimeoutRule
-    empty_test_timeout: EmptyTestTimeoutRule
-    empty_template: EmptyTemplateRule
-    empty_test_template: EmptyTestTemplateRule
-    empty_arguments: EmptyArgumentsRule
-    empty_keyword_tags: EmptyKeywordTagsRule
-
-    def __init__(self) -> None:
-        self.parent_node_name = ""
-        super().__init__()
-
-    def visit_SettingSection(self, node: Statement) -> None:  # noqa: N802
-        self.parent_node_name = "Test Suite"
-        self.generic_visit(node)
-
-    def visit_TestCaseName(self, node: Statement) -> None:  # noqa: N802
-        if node.name:
-            self.parent_node_name = f"'{node.name}' Test Case"
-        else:
-            self.parent_node_name = ""
-        self.generic_visit(node)
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
-        if node.name:
-            self.parent_node_name = f"'{node.name}' Keyword"
-        else:
-            self.parent_node_name = ""
-        self.generic_visit(node)
-
-    def visit_Metadata(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_metadata, node=node, col=node.col_offset + 1)
-
-    def visit_Documentation(self, node: Documentation) -> None:  # noqa: N802
-        if not node.value:
-            self.report(
-                self.empty_documentation,
-                block_name=self.parent_node_name,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.end_col_offset,
-            )
-
-    def visit_ForceTags(self, node: Statement) -> None:  # noqa: N802
-        if not node.values:
-            self.report(self.empty_force_tags, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_DefaultTags(self, node: Statement) -> None:  # noqa: N802
-        if not node.values:
-            self.report(self.empty_default_tags, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_KeywordTags(self, node: Statement) -> None:  # noqa: N802
-        if not node.values:
-            self.report(self.empty_keyword_tags, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_VariablesImport(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_variables_import, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_ResourceImport(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_resource_import, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_LibraryImport(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_library_import, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_Setup(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(
-                self.empty_setup,
-                block_name=self.parent_node_name,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.end_col_offset,
-            )
-
-    def visit_SuiteSetup(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_suite_setup, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_TestSetup(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_test_setup, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_Teardown(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(
-                self.empty_teardown,
-                block_name=self.parent_node_name,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.end_col_offset,
-            )
-
-    def visit_SuiteTeardown(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_suite_teardown, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_TestTeardown(self, node: Statement) -> None:  # noqa: N802
-        if not node.name:
-            self.report(self.empty_test_teardown, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_TestTemplate(self, node: Statement) -> None:  # noqa: N802
-        if not node.value:
-            self.report(self.empty_test_template, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_Template(self, node: Template) -> None:  # noqa: N802
-        if len(node.data_tokens) < 2:
-            self.report(
-                self.empty_template,
-                block_name=self.parent_node_name,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.end_col_offset,
-            )
-
-    def visit_Timeout(self, node: Statement) -> None:  # noqa: N802
-        if not node.value:
-            self.report(
-                self.empty_timeout,
-                block_name=self.parent_node_name,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.end_col_offset,
-            )
-
-    def visit_TestTimeout(self, node: Statement) -> None:  # noqa: N802
-        if not node.value:
-            self.report(self.empty_test_timeout, node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
-
-    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
-        if not node.values:
-            self.report(
-                self.empty_arguments,
-                block_name=self.parent_node_name,
-                node=node,
-                col=node.data_tokens[0].col_offset + 1,
-                end_col=node.end_col_offset,
-            )

--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from robot.api import Token
 from robot.errors import VariableError
-from robot.parsing.model.blocks import TestCaseSection
 from robot.parsing.model.statements import Arguments
 from robot.variables.search import search_variable
 
@@ -40,6 +39,26 @@ if TYPE_CHECKING:
         Var,
         Variable,
     )
+
+SECTION_NAME_PATTERN = re.compile(r"\*\*\*\s.+\s\*\*\*")
+# Separating alias values since RF 3 uses WITH_NAME instead of WITH NAME
+ALIAS_TOKENS = [Token.WITH_NAME] if ROBOT_VERSION.major < 5 else ["WITH NAME", "AS"]
+ALIAS_TOKENS_VALUES = ["WITH NAME"] if ROBOT_VERSION.major < 5 else ["WITH NAME", "AS"]
+
+
+def library_has_alias(node: LibraryImport) -> bool | None:
+    """
+    Determine whether a library import defines an alias.
+
+    Returns ``None`` when the import should not be inspected at all: for RF < 6, ``AS`` passed as an argument is
+    used to provide the library alias and is not reported.
+    """
+    if ROBOT_VERSION.major < 6:
+        arg_nodes = node.get_tokens(Token.ARGUMENT)
+        if arg_nodes and any(arg.value == "AS" for arg in arg_nodes):
+            return None
+        return bool(node.get_token(*ALIAS_TOKENS))
+    return len(node.get_tokens(Token.NAME)) >= 2
 
 
 class NotAllowedCharInNameRule(Rule):
@@ -279,6 +298,17 @@ class SettingNameNotInTitleCaseRule(Rule):
     )
     deprecated_names = ("0306",)
 
+    def check(self, node: Node, name: str) -> None:
+        if name.istitle() or name.isupper():
+            return
+        col = node.tokens[0].end_col_offset if node.tokens[0].type == "SEPARATOR" else node.col_offset
+        self.report(
+            setting_name=name,
+            node=node,
+            col=col + 1,
+            end_col=col + len(name) + 1,
+        )
+
 
 class SectionNameInvalidRule(Rule):
     """
@@ -307,6 +337,18 @@ class SectionNameInvalidRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.IDENTIFIABLE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0307",)
+
+    def check(self, node: SectionHeader) -> None:
+        name = node.data_tokens[0].value
+        if SECTION_NAME_PATTERN.match(name) and (name.istitle() or name.isupper()):
+            return
+        valid_name = f"*** {node.name.title()} ***"
+        self.report(
+            section_title_case=valid_name,
+            section_upper_case=valid_name.upper(),
+            node=node,
+            end_col=node.col_offset + len(name) + 1,
+        )
 
 
 class NotCapitalizedTestCaseTitleRule(Rule):
@@ -498,6 +540,14 @@ class EmptyLibraryAliasRule(Rule):
     )
     deprecated_names = ("0314",)
 
+    def check(self, node: LibraryImport) -> None:
+        if library_has_alias(node) is not False:
+            return
+        for arg in node.get_tokens(Token.ARGUMENT):
+            if arg.value and arg.value in ALIAS_TOKENS_VALUES:
+                col = arg.col_offset + 1
+                self.report(node=arg, col=col, end_col=col + len(arg.value))
+
 
 class DuplicatedLibraryAliasRule(Rule):
     """
@@ -520,6 +570,14 @@ class DuplicatedLibraryAliasRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0315",)
+
+    def check(self, node: LibraryImport) -> None:
+        if library_has_alias(node) is not True:
+            return
+        if node.alias.replace(" ", "") != node.name.replace(" ", ""):  # New Name == NewName
+            return
+        name_token = node.get_tokens(Token.NAME)[-1]
+        self.report(node=name_token, col=name_token.col_offset + 1, end_col=name_token.end_col_offset + 1)
 
 
 class BddWithoutKeywordCallRule(Rule):
@@ -636,6 +694,18 @@ class InvalidSectionRule(Rule):
     )
     deprecated_names = ("0325",)
 
+    def check(self, node: InvalidSection) -> None:
+        invalid_header = node.header.get_token(Token.INVALID_HEADER)
+        if "Resource file with" in invalid_header.error:
+            return
+        if invalid_header:
+            self.report(
+                invalid_section=node.header.data_tokens[0].value,
+                node=node,
+                col=node.header.col_offset + 1,
+                end_col=node.header.end_col_offset,
+            )
+
 
 class MixedTaskTestSettingsRule(Rule):
     """
@@ -658,6 +728,26 @@ class MixedTaskTestSettingsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0326",)
+
+    def check(self, node: Node, name: str, task_section: bool | None) -> None:
+        name_normalized = name.lower()
+        end_col = node.col_offset + 1 + len(name)
+        if "test" in name_normalized and task_section:
+            self.report(
+                setting="Task " + name.split()[1],
+                task_or_test="task",
+                tasks_or_tests="Tasks",
+                node=node,
+                end_col=end_col,
+            )
+        elif "task" in name_normalized and not task_section:
+            self.report(
+                setting="Test " + name.split()[1],
+                task_or_test="test",
+                tasks_or_tests="Test Cases",
+                node=node,
+                end_col=end_col,
+            )
 
 
 class WrongCaseInKeywordCallRule(Rule):
@@ -889,140 +979,6 @@ class KeywordNamingChecker(VisitorChecker):
             end_col=node.col_offset + 1 + len(keyword_name),
         )
         return True
-
-
-class SettingsNamingChecker(VisitorChecker):
-    """Checker for settings and sections naming violations."""
-
-    setting_name_not_in_title_case: SettingNameNotInTitleCaseRule
-    section_name_invalid: SectionNameInvalidRule
-    empty_library_alias: EmptyLibraryAliasRule
-    duplicated_library_alias: DuplicatedLibraryAliasRule
-    invalid_section: InvalidSectionRule
-    mixed_task_test_settings: MixedTaskTestSettingsRule
-
-    ALIAS_TOKENS = [Token.WITH_NAME] if ROBOT_VERSION.major < 5 else ["WITH NAME", "AS"]
-    # Separating alias values since RF 3 uses WITH_NAME instead of WITH NAME
-    ALIAS_TOKENS_VALUES = ["WITH NAME"] if ROBOT_VERSION.major < 5 else ["WITH NAME", "AS"]
-
-    def __init__(self) -> None:
-        self.section_name_pattern = re.compile(r"\*\*\*\s.+\s\*\*\*")
-        self.task_section: bool | None = None
-        super().__init__()
-
-    def visit_InvalidSection(self, node: InvalidSection) -> None:  # noqa: N802
-        name = node.header.data_tokens[0].value
-        invalid_header = node.header.get_token(Token.INVALID_HEADER)
-        if "Resource file with" in invalid_header.error:
-            return
-        if invalid_header:
-            self.report(
-                self.invalid_section,
-                invalid_section=name,
-                node=node,
-                col=node.header.col_offset + 1,
-                end_col=node.header.end_col_offset,
-            )
-
-    def visit_SectionHeader(self, node: SectionHeader) -> None:  # noqa: N802
-        name = node.data_tokens[0].value
-        if not self.section_name_pattern.match(name) or not (name.istitle() or name.isupper()):
-            valid_name = f"*** {node.name.title()} ***"
-            self.report(
-                self.section_name_invalid,
-                section_title_case=valid_name,
-                section_upper_case=valid_name.upper(),
-                node=node,
-                end_col=node.col_offset + len(name) + 1,
-            )
-
-    def visit_File(self, node: File) -> None:  # noqa: N802
-        self.task_section = None
-        for section in node.sections:
-            if isinstance(section, TestCaseSection):
-                if (ROBOT_VERSION.major < 6 and "task" in section.header.name.lower()) or (
-                    ROBOT_VERSION.major >= 6 and section.header.type == Token.TASK_HEADER
-                ):
-                    self.task_section = True
-                else:
-                    self.task_section = False
-                break
-        super().visit_File(node)
-
-    def visit_Setup(self, node: Setup) -> None:  # noqa: N802
-        self.check_setting_name(node.data_tokens[0].value, node)
-        self.check_settings_consistency(node.data_tokens[0].value, node)
-
-    visit_SuiteSetup = visit_TestSetup = visit_Teardown = visit_SuiteTeardown = visit_TestTeardown = (  # noqa: N815
-        visit_TestTimeout  # noqa: N815
-    ) = visit_TestTemplate = visit_TestTags = visit_ForceTags = visit_DefaultTags = visit_ResourceImport = (  # noqa: N815
-        visit_VariablesImport  # noqa: N815
-    ) = visit_Documentation = visit_Tags = visit_Timeout = visit_Template = visit_Arguments = visit_ReturnSetting = (  # noqa: N815
-        visit_Return  # noqa: N815
-    ) = visit_Setup
-
-    def visit_LibraryImport(self, node: LibraryImport) -> None:  # noqa: N802
-        self.check_setting_name(node.data_tokens[0].value, node)
-        if ROBOT_VERSION.major < 6:
-            arg_nodes = node.get_tokens(Token.ARGUMENT)
-            # ignore cases where 'AS' is used to provide library alias for RF < 5
-            if arg_nodes and any(arg.value == "AS" for arg in arg_nodes):
-                return
-            with_name = bool(node.get_token(*self.ALIAS_TOKENS))
-        else:
-            with_name = len(node.get_tokens(Token.NAME)) >= 2
-        if not with_name:
-            for arg in node.get_tokens(Token.ARGUMENT):
-                if arg.value and arg.value in self.ALIAS_TOKENS_VALUES:
-                    col = arg.col_offset + 1
-                    self.report(
-                        self.empty_library_alias, node=arg, col=arg.col_offset + 1, end_col=col + len(arg.value)
-                    )
-        elif node.alias.replace(" ", "") == node.name.replace(" ", ""):  # New Name == NewName
-            name_token = node.get_tokens(Token.NAME)[-1]
-            self.report(
-                self.duplicated_library_alias,
-                node=name_token,
-                col=name_token.col_offset + 1,
-                end_col=name_token.end_col_offset + 1,
-            )
-
-    def check_setting_name(self, name: str, node: Node) -> None:
-        if not (name.istitle() or name.isupper()):
-            col = node.tokens[0].end_col_offset if node.tokens[0].type == "SEPARATOR" else node.col_offset
-            self.report(
-                self.setting_name_not_in_title_case,
-                setting_name=name,
-                node=node,
-                col=col + 1,
-                end_col=col + len(name) + 1,
-            )
-
-    def check_settings_consistency(self, name: str, node: Node) -> None:
-        name_normalized = name.lower()
-        # if there is no task/test section, determine by first setting in the file
-        if self.task_section is None and ("test" in name_normalized or "task" in name_normalized):
-            self.task_section = "task" in name_normalized
-        if "test" in name_normalized and self.task_section:
-            end_col = node.col_offset + 1 + len(name)
-            self.report(
-                self.mixed_task_test_settings,
-                setting="Task " + name.split()[1],
-                task_or_test="task",
-                tasks_or_tests="Tasks",
-                node=node,
-                end_col=end_col,
-            )
-        elif "task" in name_normalized and not self.task_section:
-            end_col = node.col_offset + 1 + len(name)
-            self.report(
-                self.mixed_task_test_settings,
-                setting="Test " + name.split()[1],
-                task_or_test="test",
-                tasks_or_tests="Test Cases",
-                node=node,
-                end_col=end_col,
-            )
 
 
 class VariableNamingChecker(VisitorChecker):

--- a/src/robocop/linter/rules/settings.py
+++ b/src/robocop/linter/rules/settings.py
@@ -1,0 +1,234 @@
+"""Checker for rules triggered by settings: their names, values and order."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robot.api import Token
+from robot.libraries import STDLIBS
+from robot.parsing.model.blocks import TestCaseSection
+
+from robocop.linter.rules import VisitorChecker, errors, imports, lengths, naming
+from robocop.version_handling import ROBOT_VERSION
+
+if TYPE_CHECKING:
+    from robot.parsing import File
+    from robot.parsing.model.blocks import InvalidSection, Keyword, SettingSection
+    from robot.parsing.model.statements import (
+        Arguments,
+        LibraryImport,
+        Node,
+        ResourceImport,
+        SectionHeader,
+        Statement,
+        Template,
+        VariablesImport,
+    )
+
+
+class SettingsChecker(VisitorChecker):
+    """
+    Checker for rules reported for the suite, test case and keyword settings.
+
+    Handles settings from three angles at once: whether the setting has a value, whether its name follows the
+    naming conventions and whether the imports are placed in the recommended order.
+    """
+
+    empty_metadata: lengths.EmptyMetadataRule
+    empty_documentation: lengths.EmptyDocumentationRule
+    empty_force_tags: lengths.EmptyForceTagsRule
+    empty_default_tags: lengths.EmptyDefaultTagsRule
+    empty_keyword_tags: lengths.EmptyKeywordTagsRule
+    empty_variables_import: lengths.EmptyVariablesImport
+    empty_resource_import: lengths.EmptyResourceImport
+    empty_library_import: lengths.EmptyLibraryImport
+    empty_setup: lengths.EmptySetupRule
+    empty_suite_setup: lengths.EmptySuiteSetupRule
+    empty_test_setup: lengths.EmptyTestSetupRule
+    empty_teardown: lengths.EmptyTeardownRule
+    empty_suite_teardown: lengths.EmptySuiteTeardownRule
+    empty_test_teardown: lengths.EmptyTestTeardownRule
+    empty_timeout: lengths.EmptyTimeoutRule
+    empty_test_timeout: lengths.EmptyTestTimeoutRule
+    empty_template: lengths.EmptyTemplateRule
+    empty_test_template: lengths.EmptyTestTemplateRule
+    empty_arguments: lengths.EmptyArgumentsRule
+    setting_name_not_in_title_case: naming.SettingNameNotInTitleCaseRule
+    section_name_invalid: naming.SectionNameInvalidRule
+    empty_library_alias: naming.EmptyLibraryAliasRule
+    duplicated_library_alias: naming.DuplicatedLibraryAliasRule
+    invalid_section: naming.InvalidSectionRule
+    mixed_task_test_settings: naming.MixedTaskTestSettingsRule
+    wrong_import_order: imports.WrongImportOrderRule
+    builtin_imports_not_sorted: imports.BuiltinImportsNotSortedRule
+    non_builtin_imports_not_sorted: imports.NonBuiltinImportsNotSortedRule
+    resources_imports_not_sorted: imports.ResourcesImportsNotSortedRule
+    variables_import_with_args: errors.VariablesImportWithArgsRule
+
+    def __init__(self) -> None:
+        self.parent_node_name = ""
+        self.task_section: bool | None = None
+        self.libraries: list[LibraryImport] = []
+        self.resources: list[ResourceImport] = []
+        super().__init__()
+
+    def visit_File(self, node: File) -> None:  # noqa: N802
+        self.task_section = None
+        for section in node.sections:
+            if isinstance(section, TestCaseSection):
+                if (ROBOT_VERSION.major < 6 and "task" in section.header.name.lower()) or (
+                    ROBOT_VERSION.major >= 6 and section.header.type == Token.TASK_HEADER
+                ):
+                    self.task_section = True
+                else:
+                    self.task_section = False
+                break
+        self.libraries = []
+        self.resources = []
+        self.generic_visit(node)
+        self.check_import_order()
+
+    def check_import_order(self) -> None:
+        built_in_libs: list[LibraryImport] = []
+        non_builtin_libs: list[LibraryImport] = []
+        for library in self.libraries:
+            if library.name in STDLIBS:
+                built_in_libs.append(library)
+                if non_builtin_libs:
+                    self.wrong_import_order.check(library, non_builtin_libs[0])
+            else:
+                non_builtin_libs.append(library)
+        previous: LibraryImport | None = None
+        for library in built_in_libs:
+            self.builtin_imports_not_sorted.check(library, previous)
+            previous = library
+        previous = None
+        for library in non_builtin_libs:
+            self.non_builtin_imports_not_sorted.check(library, previous)
+            previous = library
+        previous_resource: ResourceImport | None = None
+        for resource in self.resources:
+            self.resources_imports_not_sorted.check(resource, previous_resource)
+            previous_resource = resource
+
+    def check_setting_name(self, node: Node) -> None:
+        """Validate the name of the setting and its consistency with the test/task terminology used in the file."""
+        name = node.data_tokens[0].value
+        self.setting_name_not_in_title_case.check(node, name)
+        # if there is no task/test section, determine by first setting in the file
+        name_normalized = name.lower()
+        if self.task_section is None and ("test" in name_normalized or "task" in name_normalized):
+            self.task_section = "task" in name_normalized
+        self.mixed_task_test_settings.check(node, name, self.task_section)
+
+    def visit_InvalidSection(self, node: InvalidSection) -> None:  # noqa: N802
+        # deliberately not descending: the header would otherwise be reported as an invalid section name as well,
+        # and the body of an invalid section only ever holds comments
+        self.invalid_section.check(node)
+
+    def visit_SectionHeader(self, node: SectionHeader) -> None:  # noqa: N802
+        self.section_name_invalid.check(node)
+
+    def visit_SettingSection(self, node: SettingSection) -> None:  # noqa: N802
+        self.parent_node_name = "Test Suite"
+        self.generic_visit(node)
+
+    def visit_TestCaseName(self, node: Statement) -> None:  # noqa: N802
+        self.parent_node_name = f"'{node.name}' Test Case" if node.name else ""
+        self.generic_visit(node)
+
+    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
+        self.parent_node_name = f"'{node.name}' Keyword" if node.name else ""
+        self.generic_visit(node)
+
+    def visit_Metadata(self, node: Statement) -> None:  # noqa: N802
+        self.empty_metadata.check(node)
+
+    def visit_Documentation(self, node: Statement) -> None:  # noqa: N802
+        self.empty_documentation.check(node, self.parent_node_name)
+        self.check_setting_name(node)
+
+    def visit_ForceTags(self, node: Statement) -> None:  # noqa: N802
+        self.empty_force_tags.check(node)
+        self.check_setting_name(node)
+
+    visit_TestTags = visit_ForceTags  # noqa: N815
+
+    def visit_DefaultTags(self, node: Statement) -> None:  # noqa: N802
+        self.empty_default_tags.check(node)
+        self.check_setting_name(node)
+
+    def visit_KeywordTags(self, node: Statement) -> None:  # noqa: N802
+        # keyword tags are deliberately not passed to check_setting_name to keep the previous behaviour
+        self.empty_keyword_tags.check(node)
+
+    def visit_Tags(self, node: Statement) -> None:  # noqa: N802
+        self.check_setting_name(node)
+
+    def visit_VariablesImport(self, node: VariablesImport) -> None:  # noqa: N802
+        self.empty_variables_import.check(node)
+        self.check_setting_name(node)
+        self.variables_import_with_args.check(node)
+
+    def visit_ResourceImport(self, node: ResourceImport) -> None:  # noqa: N802
+        self.empty_resource_import.check(node)
+        self.check_setting_name(node)
+        if node.name:
+            self.resources.append(node)
+
+    def visit_LibraryImport(self, node: LibraryImport) -> None:  # noqa: N802
+        self.empty_library_import.check(node)
+        self.setting_name_not_in_title_case.check(node, node.data_tokens[0].value)
+        self.empty_library_alias.check(node)
+        self.duplicated_library_alias.check(node)
+        if node.name:
+            self.libraries.append(node)
+
+    def visit_Setup(self, node: Statement) -> None:  # noqa: N802
+        self.empty_setup.check(node, self.parent_node_name)
+        self.check_setting_name(node)
+
+    def visit_SuiteSetup(self, node: Statement) -> None:  # noqa: N802
+        self.empty_suite_setup.check(node)
+        self.check_setting_name(node)
+
+    def visit_TestSetup(self, node: Statement) -> None:  # noqa: N802
+        self.empty_test_setup.check(node)
+        self.check_setting_name(node)
+
+    def visit_Teardown(self, node: Statement) -> None:  # noqa: N802
+        self.empty_teardown.check(node, self.parent_node_name)
+        self.check_setting_name(node)
+
+    def visit_SuiteTeardown(self, node: Statement) -> None:  # noqa: N802
+        self.empty_suite_teardown.check(node)
+        self.check_setting_name(node)
+
+    def visit_TestTeardown(self, node: Statement) -> None:  # noqa: N802
+        self.empty_test_teardown.check(node)
+        self.check_setting_name(node)
+
+    def visit_Timeout(self, node: Statement) -> None:  # noqa: N802
+        self.empty_timeout.check(node, self.parent_node_name)
+        self.check_setting_name(node)
+
+    def visit_TestTimeout(self, node: Statement) -> None:  # noqa: N802
+        self.empty_test_timeout.check(node)
+        self.check_setting_name(node)
+
+    def visit_Template(self, node: Template) -> None:  # noqa: N802
+        self.empty_template.check(node, self.parent_node_name)
+        self.check_setting_name(node)
+
+    def visit_TestTemplate(self, node: Statement) -> None:  # noqa: N802
+        self.empty_test_template.check(node)
+        self.check_setting_name(node)
+
+    def visit_Arguments(self, node: Arguments) -> None:  # noqa: N802
+        self.empty_arguments.check(node, self.parent_node_name)
+        self.check_setting_name(node)
+
+    def visit_ReturnSetting(self, node: Statement) -> None:  # noqa: N802
+        self.check_setting_name(node)
+
+    visit_Return = visit_ReturnSetting  # noqa: N815


### PR DESCRIPTION
Continues the single-visitor migration (wave 9). Merges four AST visitors that all walked suite, test case and keyword settings into one `SettingsChecker` in the new `src/robocop/linter/rules/settings.py`:

- `lengths.EmptySettingsChecker`
- `naming.SettingsNamingChecker`
- `imports.SettingsOrderChecker`
- `errors.VariablesImportErrorChecker`

The new checker owns 30 rules spanning four categories, and the decision logic moved into `check()` methods on the rules themselves, matching the pattern used by the previously merged checkers.

| category | rules |
|---|---|
| lengths | the 19 `empty-*` setting rules (`empty-metadata`, `empty-documentation`, `empty-force-tags`, `empty-default-tags`, `empty-keyword-tags`, `empty-variables-import`, `empty-resource-import`, `empty-library-import`, `empty-setup`, `empty-suite-setup`, `empty-test-setup`, `empty-teardown`, `empty-suite-teardown`, `empty-test-teardown`, `empty-timeout`, `empty-test-timeout`, `empty-template`, `empty-test-template`, `empty-arguments`) |
| naming | `setting-name-not-in-title-case`, `section-name-invalid`, `empty-library-alias`, `duplicated-library-alias`, `invalid-section`, `mixed-task-test-settings` |
| imports | `wrong-import-order`, `builtin-imports-not-sorted`, `non-builtin-imports-not-sorted`, `resources-imports-not-sorted` |
| errors | `variables-import-with-args` |

### Behaviours that were implicit in having separate visitors

Two things only worked because the visitors were separate, and are now explicit:

**`visit_InvalidSection` must not descend.** The naming checker reported `invalid-section` and stopped; the empty-settings checker had no such visitor and descended. Descending in the merged visitor reaches the section *header* and reports `section-name-invalid` on top of `invalid-section` — this actually showed up as 2 extra diagnostics during validation. The merged visitor keeps the naming behaviour; the body of an invalid section only ever holds `Comment`/`EmptyLine` statements, so the empty-settings rules lose nothing.

**`Keyword Tags` stays exempt from `setting-name-not-in-title-case`.** Only the empty-settings checker defined `visit_KeywordTags`, and `KeywordTags` is a *sibling* of `Tags` under `MultiValue` rather than a subclass, so the naming checker's `visit_Tags` never applied to it. Verified the full MRO of every statement class in the merged dispatch table — all are flat siblings, so no `visit_*` method shadows another.

Shared per-file state (the block name used in `empty-*` messages, the test/task section flag, and the collected imports) stays in the visitor; the rules receive it as arguments.

### Validation

No user-visible change. Verified byte-identical output against the previous revision for:

- a full `--select ALL` scan of `tests/linter/rules` + `tests/formatter` (189296 lines)
- `robocop list rules --verbose`
- per-rule runs for all 30 rules (`non-builtin-imports-not-sorted` and `resources-imports-not-sorted` are disabled by default, so these runs are what covers them)
- a hand-written edge-case suite covering empty variants of every setting, lowercase setting names, library aliases (`AS` with no value / duplicated / spaced), unsorted builtin, custom and resource imports, YAML variables imports with arguments, `*** Tasks ***` vs `*** Test Cases ***` settings consistency (including a file where the first setting decides), an invalid section in a non-English file, and a resource file

`pytest` and `mypy` match their baselines exactly.

Checker count: **30 -> 27**.
