### PR TITLE
refactor: merge deprecated statement checker into settings checker

### DIFF
--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -12,7 +12,7 @@ from robot.parsing.model.statements import Arguments
 from robot.variables.search import search_variable
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker, deprecated, variables
+from robocop.linter.rules import Rule, RuleParam, RuleSeverity, VisitorChecker, variables
 from robocop.linter.utils import misc as utils
 from robocop.parsing.string_operations import get_unmasked_string
 from robocop.version_handling import ROBOT_VERSION, TYPE_SUPPORTED
@@ -24,13 +24,11 @@ if TYPE_CHECKING:
     from robot.parsing import File
     from robot.parsing.model.blocks import For, If, InvalidSection, Keyword, TestCase, While
     from robot.parsing.model.statements import (
-        ForceTags,
         KeywordCall,
         KeywordName,
         LibraryImport,
         Node,
         Return,
-        ReturnSetting,
         SectionHeader,
         TestCaseName,
         Var,
@@ -1129,35 +1127,3 @@ class SimilarVariableChecker(VisitorChecker):
                     end_col=token.end_col_offset + 1,
                 )
             self.assigned_variables[normalized].append(name)
-
-
-class DeprecatedStatementChecker(VisitorChecker):
-    """Checker for deprecated statements."""
-
-    deprecated_with_name: deprecated.DeprecatedWithNameRule
-    deprecated_singular_header: deprecated.DeprecatedSingularHeaderRule
-    deprecated_force_tags: deprecated.DeprecatedForceTagsRule
-    deprecated_return_setting: deprecated.DeprecatedReturnSetting
-
-    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
-        self.context.keyword = node
-        self.generic_visit(node)
-        self.context.keyword = None
-
-    def visit_Return(self, node: Return) -> None:  # noqa: N802
-        """For RETURN use visit_ReturnStatement - visit_Return will most likely visit RETURN in the future"""
-        if ROBOT_VERSION.major not in (5, 6):
-            return
-        self.deprecated_return_setting.check(node)
-
-    def visit_ReturnSetting(self, node: ReturnSetting) -> None:  # noqa: N802
-        self.deprecated_return_setting.check(node)
-
-    def visit_ForceTags(self, node: ForceTags) -> None:  # noqa: N802
-        self.deprecated_force_tags.check(node)
-
-    def visit_LibraryImport(self, node: LibraryImport) -> None:  # noqa: N802
-        self.deprecated_with_name.check(node)
-
-    def visit_SectionHeader(self, node: SectionHeader) -> None:  # noqa: N802
-        self.deprecated_singular_header.check(node)

--- a/src/robocop/linter/rules/settings.py
+++ b/src/robocop/linter/rules/settings.py
@@ -8,7 +8,7 @@ from robot.api import Token
 from robot.libraries import STDLIBS
 from robot.parsing.model.blocks import TestCaseSection
 
-from robocop.linter.rules import VisitorChecker, errors, imports, lengths, naming
+from robocop.linter.rules import VisitorChecker, deprecated, errors, imports, lengths, naming
 from robocop.version_handling import ROBOT_VERSION
 
 if TYPE_CHECKING:
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         LibraryImport,
         Node,
         ResourceImport,
+        Return,
         SectionHeader,
         Statement,
         Template,
@@ -64,6 +65,10 @@ class SettingsChecker(VisitorChecker):
     non_builtin_imports_not_sorted: imports.NonBuiltinImportsNotSortedRule
     resources_imports_not_sorted: imports.ResourcesImportsNotSortedRule
     variables_import_with_args: errors.VariablesImportWithArgsRule
+    deprecated_with_name: deprecated.DeprecatedWithNameRule
+    deprecated_singular_header: deprecated.DeprecatedSingularHeaderRule
+    deprecated_force_tags: deprecated.DeprecatedForceTagsRule
+    deprecated_return_setting: deprecated.DeprecatedReturnSetting
 
     def __init__(self) -> None:
         self.parent_node_name = ""
@@ -128,6 +133,7 @@ class SettingsChecker(VisitorChecker):
 
     def visit_SectionHeader(self, node: SectionHeader) -> None:  # noqa: N802
         self.section_name_invalid.check(node)
+        self.deprecated_singular_header.check(node)
 
     def visit_SettingSection(self, node: SettingSection) -> None:  # noqa: N802
         self.parent_node_name = "Test Suite"
@@ -139,7 +145,9 @@ class SettingsChecker(VisitorChecker):
 
     def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
         self.parent_node_name = f"'{node.name}' Keyword" if node.name else ""
+        self.context.keyword = node
         self.generic_visit(node)
+        self.context.keyword = None
 
     def visit_Metadata(self, node: Statement) -> None:  # noqa: N802
         self.empty_metadata.check(node)
@@ -151,6 +159,7 @@ class SettingsChecker(VisitorChecker):
     def visit_ForceTags(self, node: Statement) -> None:  # noqa: N802
         self.empty_force_tags.check(node)
         self.check_setting_name(node)
+        self.deprecated_force_tags.check(node)
 
     visit_TestTags = visit_ForceTags  # noqa: N815
 
@@ -181,6 +190,7 @@ class SettingsChecker(VisitorChecker):
         self.setting_name_not_in_title_case.check(node, node.data_tokens[0].value)
         self.empty_library_alias.check(node)
         self.duplicated_library_alias.check(node)
+        self.deprecated_with_name.check(node)
         if node.name:
             self.libraries.append(node)
 
@@ -230,5 +240,10 @@ class SettingsChecker(VisitorChecker):
 
     def visit_ReturnSetting(self, node: Statement) -> None:  # noqa: N802
         self.check_setting_name(node)
+        self.deprecated_return_setting.check(node)
 
-    visit_Return = visit_ReturnSetting  # noqa: N815
+    def visit_Return(self, node: Return) -> None:  # noqa: N802
+        """For RETURN use visit_ReturnStatement - visit_Return will most likely visit RETURN in the future"""
+        self.check_setting_name(node)
+        if ROBOT_VERSION.major in (5, 6):
+            self.deprecated_return_setting.check(node)


### PR DESCRIPTION
Continues moving the linter towards a single AST visitor (follow-up to #1819).

`DeprecatedStatementChecker` was already a pure dispatcher, and every node type it visited (`SectionHeader`, `LibraryImport`, `ForceTags`, `Return`, `ReturnSetting`, `Keyword`) is already visited by `SettingsChecker`. Its four rules move there, removing one more full walk over every parsed file.

Visitors: **24 -> 23**. Rules unchanged (170, 157 enabled).

Notes:
- `visit_Return` / `visit_ReturnSetting` were an alias in `SettingsChecker`; they are now split so the `ROBOT_VERSION.major in (5, 6)` guard applies only to `visit_Return`, exactly as before.
- `SettingsChecker.visit_Keyword` now maintains `self.context.keyword`, which `deprecated-return-setting` needs to build its fix (via `context.last_data_statement_in_keyword`).

Validation (all byte-identical to the previous revision):
- full \--select ALL\ scan over \	ests/linter/rules\ + \	ests/formatter\ (189296 diagnostics)
- 11 per-rule \--select\ runs covering the 4 moved rules and the settings rules sharing the same visit methods
- \--fix --diff\ runs, both on a dedicated edge-case suite and corpus-wide for \deprecated-return-setting\ / \deprecated-force-tags\ (521 diff lines) — this is the path that depends on \context.keyword\
- edge cases: \WITH NAME\ vs \AS\, singular section headers, \Force Tags\, and \[Return]\ as last statement / duplicated / alongside \RETURN\ / empty
- \pytest tests -q\ and \mypy\ match their baselines