### PR TITLE
feat!: run project rules as a part of the check command

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,12 +13,3 @@
   language: python
   files: '.*\.(robot|resource)$'
   minimum_pre_commit_version: "2.9.2"
-
-- id: robocop-check-project
-  name: robocop check project
-  description: "Robot Framework project checker"
-  entry: robocop check-project --force-exclude
-  language: python
-  files: '.*\.(robot|resource)$'
-  pass_filenames: false
-  minimum_pre_commit_version: "2.9.2"

--- a/docs/configuration/configuration_reference.md
+++ b/docs/configuration/configuration_reference.md
@@ -358,8 +358,8 @@ Resource    ${RESOURCE_DIR}/common.resource
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop check-project --variable RESOURCE_DIR:resources
-    robocop check-project -v RESOURCE_DIR:resources -v ENV:qa
+    robocop check --variable RESOURCE_DIR:resources
+    robocop check -v RESOURCE_DIR:resources -v ENV:qa
     ```
 
 === ":material-file-cog-outline: toml"
@@ -389,8 +389,8 @@ Use ``--variablefile`` option to load variables from a Python or YAML file. It i
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop check-project --variablefile config/variables.py
-    robocop check-project -V config/variables.py -V config/environments.yaml
+    robocop check --variablefile config/variables.py
+    robocop check -V config/variables.py -V config/environments.yaml
     ```
 
 === ":material-file-cog-outline: toml"
@@ -428,8 +428,8 @@ Resource    common.resource  # stored in the shared/ directory, not next to this
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop check-project --pythonpath shared
-    robocop check-project -P shared -P libs/*
+    robocop check --pythonpath shared
+    robocop check -P shared -P libs/*
     ```
 
 === ":material-file-cog-outline: toml"
@@ -444,11 +444,39 @@ paths in the configuration file are resolved against the configuration file.
 
 ---
 
+#### ``project``
+
+Project level rules require parsing the whole project. Robocop does it automatically whenever at least one project
+level rule is enabled, so this option is only needed to override that decision:
+
+- ``--project`` always runs project level rules (does nothing if none of them is enabled),
+- ``--no-project`` never runs them, even if they are selected in the configuration file.
+
+``--no-project`` is useful when the same configuration file is shared between a fast run (for example a pre-commit
+hook) and a full run in the CI:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --no-project
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop]
+    project = false
+    ```
+
+The project context is always built from the project root, even if only selected paths are linted.
+
+---
+
 #### ``analyze-libraries``
 
-``robocop check-project`` imports Robot Framework libraries to find out what keywords they provide and what
-arguments those keywords accept. **Importing a library executes its code**, which is why it only happens in the
-opt-in ``check-project`` command. Every library is imported once, in a separate process with a timeout, and any
+``robocop check`` imports Robot Framework libraries to find out what keywords they provide and what
+arguments those keywords accept. **Importing a library executes its code**, which is why it only happens when
+project level rules are enabled. Every library is imported once, in a separate process with a timeout, and any
 failure is silently ignored - a library that cannot be imported simply provides no keywords.
 
 Use ``--no-analyze-libraries`` to disable it completely:
@@ -456,7 +484,7 @@ Use ``--no-analyze-libraries`` to disable it completely:
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop check-project --no-analyze-libraries
+    robocop check --no-analyze-libraries
     ```
 
 === ":material-file-cog-outline: toml"
@@ -475,7 +503,7 @@ Maximum time in seconds for importing a single library. Default is ``10``.
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop check-project --load-library-timeout 30
+    robocop check --load-library-timeout 30
     ```
 
 === ":material-file-cog-outline: toml"
@@ -495,7 +523,7 @@ Glob patterns are supported.
 === ":octicons-command-palette-24: cli"
 
     ```bash
-    robocop check-project --ignored-library SeleniumLibrary --ignored-library Custom*
+    robocop check --ignored-library SeleniumLibrary --ignored-library Custom*
     ```
 
 === ":material-file-cog-outline: toml"

--- a/docs/integrations/precommit.md
+++ b/docs/integrations/precommit.md
@@ -12,8 +12,6 @@ repos:
         - id: robocop
         # Run the formatter.
         - id: robocop-format
-        # Run the project checker.
-        - id: robocop-check-project
 ```
 
 Place this file in the root of your project. Follow instructions on the [pre-commit](https://pre-commit.com) website
@@ -22,9 +20,13 @@ to install it.
 It will run both linter and formatter on your modified files when trying to commit changes. If any linter issue is
 found or a file is modified, it will stop the commit.
 
-The ``robocop-check-project`` hook runs the project checker, which analyzes rules that require the whole project
-context. It is filtered to only run on ``.robot`` and ``.resource`` files by default. If you want it to trigger on
-other files as well, override the ``files`` option in your ``.pre-commit-config.yaml``.
+If you select [project level rules](../linter/linter.md#project-checks), the ``robocop`` hook parses the whole project
+on every run, which can be noticeably slower. Add ``--no-project`` to the hook arguments to skip it:
+
+```yaml
+        - id: robocop
+          args: [--force-exclude, --no-project]
+```
 
 ``rev`` is the version of the Robocop, prefixed with ``v``. It matches the release tag created in our repository on each
 release.

--- a/docs/linter/custom_rules.md
+++ b/docs/linter/custom_rules.md
@@ -400,10 +400,11 @@ class CustomChecker(VisitorChecker):
 
 ## Project checks
 
-Project checkers are special kind of checker that can be only run using ``check-project`` command:
+Project checkers are a special kind of checker. They are run by the ``check`` command whenever at least one of
+their rules is enabled:
 
 ```bash
-robocop check-project
+robocop check --select my-project-rule
 ```
 
 They are only run once per whole project, after all files are parsed. Together with the project context, they can be
@@ -493,7 +494,7 @@ Imports are resolved to paths using variables from the ``*** Variables ***`` sec
 variables provided with the ``--variable`` option:
 
 ```bash
-robocop check-project --variable RESOURCE_DIR:resources
+robocop check --variable RESOURCE_DIR:resources
 ```
 
 Every import has a status: ``resolved`` (file exists), ``not_found`` (path was resolved but the file is missing),

--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -91,33 +91,36 @@ option.
 
 ## Project checks
 
-Robocop contains also project level checks that can be used to check the whole project. Use the following command to run
-them:
-
-```bash
-robocop check-project
-```
-
-``check-project`` behaves the same as ``check`` command, but it only runs project level checks.
-
 Project level rules are the rules that cannot be checked by looking at a single file. For example, to know that a
 keyword is not used, Robocop has to know every keyword call in the project. All of them are disabled by default and
 need to be selected:
 
 ```bash
-robocop check-project --select unused-keyword --select invalid-argument-count
+robocop check --select unused-keyword --select invalid-argument-count
 ```
 
-Robocop builds the project context by parsing every source file, resolving ``Resource`` imports and indexing keyword
-definitions, keyword calls and variables.
+They are run by the ``check`` command together with the regular, file level rules. Selecting a project rule is the
+only thing required - whenever at least one of them is enabled, Robocop additionally builds the project context by
+parsing every source file, resolving ``Resource`` imports and indexing keyword definitions, keyword calls and
+variables.
 
-!!! warning "The ``check-project`` command executes code"
+The project context is always built from the project root, even if only selected paths are linted. Thanks to that,
+``robocop check tests/login.robot`` still knows about keywords used in the rest of the project.
 
-    Unlike the ``check`` command, ``check-project`` imports Robot Framework libraries to find out what keywords they
-    provide, and imports Python variable files provided with the ``--variablefile`` option. Both **execute the code**
-    of the imported file. Libraries are imported in a separate process with a timeout, and failures are ignored, so a
-    broken library never breaks the analysis. Library analysis can be disabled with ``--no-analyze-libraries`` and
-    single libraries can be skipped with ``--ignored-library``.
+Project analysis takes noticeably more time than the regular linting. Use ``--no-project`` to skip it without
+changing the configuration file, for example in a fast pre-commit run:
+
+```bash
+robocop check --no-project
+```
+
+!!! warning "Project level rules execute code"
+
+    To find out what keywords libraries provide, Robocop imports them. Python variable files provided with the
+    ``--variablefile`` option are imported as well. Both **execute the code** of the imported file. Libraries are
+    imported in a separate process with a timeout, and failures are ignored, so a broken library never breaks the
+    analysis. Library analysis can be disabled with ``--no-analyze-libraries`` and single libraries can be skipped
+    with ``--ignored-library``.
 
 Currently available project level rules are:
 
@@ -131,15 +134,15 @@ Import paths often contain variables. Provide them with the ``--variable`` or ``
 imports can be resolved:
 
 ```bash
-robocop check-project --variable RESOURCE_DIR:resources
-robocop check-project --variablefile config/variables.py
+robocop check --variable RESOURCE_DIR:resources
+robocop check --variablefile config/variables.py
 ```
 
 If the project relies on the Robot Framework ``--pythonpath`` option to find its resources or libraries, pass the
 same locations to Robocop:
 
 ```bash
-robocop check-project --pythonpath shared --pythonpath libs/*
+robocop check --pythonpath shared --pythonpath libs/*
 ```
 
 See [variables](../configuration/configuration_reference.md#variables),
@@ -150,8 +153,8 @@ Libraries are imported to check the keywords they provide. Every library is impo
 process which is stopped if it takes longer than ``--load-library-timeout`` seconds (10 by default):
 
 ```bash
-robocop check-project --no-analyze-libraries
-robocop check-project --ignored-library SeleniumLibrary --load-library-timeout 30
+robocop check --no-analyze-libraries
+robocop check --ignored-library SeleniumLibrary --load-library-timeout 30
 ```
 
 See [analyze-libraries](../configuration/configuration_reference.md#analyze-libraries),

--- a/src/robocop/config/builder.py
+++ b/src/robocop/config/builder.py
@@ -92,6 +92,7 @@ class ConfigBuilder:
         variables: dict[str, str] = self.variables_from_raw(cli_raw, file_raw)
         variable_files: list[str] = merge_lists(file_raw, cli_raw, "variable_files")
         python_path: list[str] = merge_lists(file_raw, cli_raw, "python_path")
+        project = resolve(cli_raw, file_raw, "project", defaults.PROJECT)
         analyze_libraries = resolve(cli_raw, file_raw, "analyze_libraries", defaults.ANALYZE_LIBRARIES)
         load_library_timeout = resolve(cli_raw, file_raw, "load_library_timeout", defaults.LOAD_LIBRARY_TIMEOUT)
         ignored_libraries: list[str] = merge_lists(file_raw, cli_raw, "ignored_libraries")
@@ -143,6 +144,7 @@ class ConfigBuilder:
             variables=variables,
             variable_files=variable_files,
             python_path=python_path,
+            project=project,
             analyze_libraries=analyze_libraries,
             load_library_timeout=load_library_timeout,
             ignored_libraries=ignored_libraries,

--- a/src/robocop/config/defaults.py
+++ b/src/robocop/config/defaults.py
@@ -30,6 +30,7 @@ SILENT = False
 
 # project checks
 
+PROJECT: bool | None = None  # None: run project checks only if any project rule is enabled
 ANALYZE_LIBRARIES = True
 LOAD_LIBRARY_TIMEOUT = 10
 

--- a/src/robocop/config/manager.py
+++ b/src/robocop/config/manager.py
@@ -129,6 +129,7 @@ class ConfigManager:
         # ignore file filters on paths passed directly
         self.ignore_file_filters = not (force_exclude or self.default_config.force_exclude) and bool(sources)
         self._paths: dict[Path, SourceFile] = {}
+        self._project_paths: dict[Path, SourceFile] | None = None
         self.resolved_paths = False
         self._cache: RobocopCache | None = None
 
@@ -150,6 +151,20 @@ class ConfigManager:
         if not self.resolved_paths:
             self.resolve_paths(self.sources, ignore_file_filters=self.ignore_file_filters)
         yield from self._paths.values()
+
+    @property
+    def project_paths(self) -> Generator[SourceFile, None, None]:
+        """
+        All source files in the project, even if only selected paths are linted.
+
+        Project level checks need to know the whole project - for example a keyword defined in the linted file
+        can be used by a file outside the linted paths. Source files that were already resolved are reused, so
+        their models are only parsed once.
+        """
+        if self._project_paths is None:
+            self._project_paths = {}
+            self.resolve_paths([self.root], target=self._project_paths)
+        yield from self._project_paths.values()
 
     def get_default_config(self, config_path: Path | None, sources: list[str] | None) -> Config:
         """Get the default config either from --config option or from the cli."""
@@ -236,6 +251,7 @@ class ConfigManager:
         self,
         sources: list[Path] | list[str],
         ignore_file_filters: bool = False,
+        target: dict[Path, SourceFile] | None = None,
     ) -> None:
         """
         Find all files to parse and their corresponding configs.
@@ -246,13 +262,16 @@ class ConfigManager:
         Args:
             sources: list of sources from CLI or configuration file.
             ignore_file_filters: force robocop to parse file even if it's excluded in the configuration
+            target: where the resolved source files are stored. Defaults to the linted paths.
 
         """
+        if target is None:
+            target = self._paths
         config: Config | None = None
         for source in sources:
             source_not_resolved = Path(source)
             source = source_not_resolved.resolve()
-            if source in self._paths:
+            if source in target:
                 continue
             if not source.exists():
                 if source_not_resolved.is_symlink():  # i.e. dangling symlink
@@ -269,6 +288,6 @@ class ConfigManager:
                     if self.gitignore_resolver.path_excluded(source_not_resolved, source_gitignore):
                         continue
             if source.is_dir():
-                self.resolve_paths(list(source.iterdir()))
+                self.resolve_paths(list(source.iterdir()), target=target)
             elif source.is_file():
-                self._paths[source] = SourceFile(path=source, config=config)
+                target[source] = self._paths.get(source) or SourceFile(path=source, config=config)

--- a/src/robocop/config/schema.py
+++ b/src/robocop/config/schema.py
@@ -320,6 +320,7 @@ class RawConfig:
     variables: dict[str, str] | None = None
     variable_files: list[str] | None = None
     python_path: list[str] | None = None
+    project: bool | None = None
     analyze_libraries: bool | None = None
     load_library_timeout: int | None = None
     ignored_libraries: list[str] | None = None
@@ -342,6 +343,7 @@ class RawConfig:
             "variables",
             "variable_files",
             "python_path",
+            "project",
             "analyze_libraries",
             "load_library_timeout",
             "ignored_libraries",
@@ -389,6 +391,7 @@ class Config:
     variables: dict[str, str]
     variable_files: list[str]
     python_path: list[str]
+    project: bool | None
     analyze_libraries: bool
     load_library_timeout: int
     ignored_libraries: list[str]
@@ -418,6 +421,7 @@ class Config:
             and self.variables == other.variables
             and self.variable_files == other.variable_files
             and self.python_path == other.python_path
+            and self.project == other.project
             and self.analyze_libraries == other.analyze_libraries
             and self.load_library_timeout == other.load_library_timeout
             and self.ignored_libraries == other.ignored_libraries

--- a/src/robocop/files.py
+++ b/src/robocop/files.py
@@ -12,13 +12,16 @@ def get_relative_path(path: str | Path, parent_path: Path) -> Path:
 
 
 @cache
-def path_relative_to_cwd(path: Path) -> Path:
-    """Return path in relation to cwd path. Results are cached."""
-    cwd = Path.cwd()  # TODO: potentially performance heavy - check
+def _path_relative_to(path: Path, cwd: Path) -> Path:
     try:
         return path.relative_to(cwd)
     except ValueError:  # symlink etc
         return path
+
+
+def path_relative_to_cwd(path: Path) -> Path:
+    """Return path in relation to cwd path. Results are cached per working directory."""
+    return _path_relative_to(path, Path.cwd())
 
 
 def get_common_parent_dirs(sources: list[Path]) -> list[Path]:

--- a/src/robocop/linter/rules/arguments.py
+++ b/src/robocop/linter/rules/arguments.py
@@ -346,7 +346,8 @@ class InvalidArgumentCountRule(Rule):
     - the call expands a list (``@{args}``) or dictionary (``&{kwargs}``) variable,
     - the keyword is used as a test template.
 
-    This rule is a project level rule and is only reported by the ``robocop check-project`` command.
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
 
     """
 

--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -304,7 +304,8 @@ class DuplicatedVariableInProjectRule(Rule):
     Only variables defined in the ``*** Variables ***`` section are compared. Variable names are normalized, so
     ``${my var}``, ``${MY_VAR}`` and ``${myvar}`` are treated as the same variable.
 
-    This rule is a project level rule and is only reported by the ``robocop check-project`` command.
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
 
     """
 

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -186,7 +186,8 @@ class UnresolvedResourceImportRule(Rule):
     If the path contains a variable that cannot be resolved, the import is ignored and not reported. Thanks to that,
     dynamically built paths do not cause false positives.
 
-    This rule is a project level rule and is only reported by the ``robocop check-project`` command.
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
 
     """
 
@@ -227,7 +228,8 @@ class UnusedResourceImportRule(Rule):
     - the imported resource defines no keywords and no variables, because it may be imported only for the imports
       it makes itself.
 
-    This rule is a project level rule and is only reported by the ``robocop check-project`` command.
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
 
     """
 

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -181,7 +181,7 @@ class UnresolvedResourceImportRule(Rule):
     Variables used in the import path are resolved using variables defined in the ``*** Variables ***`` section
     of the importing file and variables provided with the ``--variable`` option::
 
-        robocop check-project --variable RESOURCE_DIR:resources
+        robocop check --variable RESOURCE_DIR:resources
 
     If the path contains a variable that cannot be resolved, the import is ignored and not reported. Thanks to that,
     dynamically built paths do not cause false positives.

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -34,7 +34,8 @@ class UnusedKeywordRule(Rule):
     Keywords are only searched for in the files scanned by Robocop. If the project is a shared library of keywords
     used by other projects, all of its keywords are reported as not used.
 
-    This rule is a project level rule and is only reported by the ``robocop check-project`` command.
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
 
     """
 

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -124,6 +124,7 @@ class RobocopLinter:
             if not source_file.config.linter.diff:  # diff simulate fixes, so it's best to ignore the results
                 self.config_manager.cache.set_linter_entry(source_file.path, source_file.config.hash, diagnostics)
         self.config_manager.cache.save()
+        self.diagnostics.extend(self.run_project_checks())
 
         if not files and not self.config_manager.default_config.silent:
             print("No Robot files were found with the existing configuration.")
@@ -199,23 +200,33 @@ class RobocopLinter:
         return found_diagnostics
 
     def run_project_checks(self) -> list[Diagnostic]:
-        self.diagnostics = []
+        """
+        Run project level checkers on the whole project.
+
+        Project checkers are only run if the project analysis is enabled. By default it happens whenever
+        at least one project rule is enabled. It can be forced or disabled with the ``project`` option.
+
+        Returns:
+            List of diagnostics found by the project checkers.
+
+        """
         config = self.config_manager.default_config
+        if config.project is False:
+            return []
         resolved_config = self.config_resolver.resolve_config(config)
+        if not resolved_config.project_checkers:
+            return []
         project_name = self.config_manager.root.name
-        project_source_file = VirtualSourceFile(Path(project_name), self.config_manager.default_config)
-        if resolved_config.project_checkers:
-            context = self.build_context(config)
-            for checker in resolved_config.project_checkers:
-                checker.issues = []
-                checker.scan_project(project_source_file, self.config_manager, context)
-                self.diagnostics.extend(
-                    [diagnostic for diagnostic in checker.issues if not (diagnostic.severity < config.linter.threshold)]
-                )
-        self.make_reports(run_stats=None)
-        if config.linter.return_result:
-            return self.diagnostics
-        return self.return_with_exit_code(len(self.diagnostics))
+        project_source_file = VirtualSourceFile(Path(project_name), config)
+        context = self.build_context(config)
+        diagnostics: list[Diagnostic] = []
+        for checker in resolved_config.project_checkers:
+            checker.issues = []
+            checker.scan_project(project_source_file, self.config_manager, context)
+            diagnostics.extend(
+                [diagnostic for diagnostic in checker.issues if not (diagnostic.severity < config.linter.threshold)]
+            )
+        return diagnostics
 
     def build_context(self, config: Config) -> ProjectContext:
         """

--- a/src/robocop/project/context.py
+++ b/src/robocop/project/context.py
@@ -332,7 +332,7 @@ def build_project_context(config_manager: ConfigManager, silent: bool = False) -
     global_scope.add_variable_files(config.variable_files, search_paths)
     global_scope.add_command_line(config.variables)
 
-    for source_file in config_manager.paths:
+    for source_file in config_manager.project_paths:
         try:
             model = source_file.model
         except DataError as error:

--- a/src/robocop/project/libraries.py
+++ b/src/robocop/project/libraries.py
@@ -2,7 +2,7 @@
 Importing Robot Framework libraries to find out what keywords they provide.
 
 Unlike the rest of the project analysis, which is based purely on the abstract syntax tree, loading a library
-**executes the library code**. That is why it only happens in the opt-in ``check-project`` command, always in a
+**executes the library code**. That is why it only happens when project level rules are enabled, always in a
 separate process with a timeout, and can be disabled with the ``--no-analyze-libraries`` option.
 
 Libraries that fail to import are not reported as an internal error. Such library simply provides no keywords, so

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -21,7 +21,7 @@ from robocop.runtime.resolver import ConfigResolver
 class CliWithVersion(typer.core.TyperGroup):
     def list_commands(self, ctx: Any) -> list[str]:  # noqa: ARG002
         """Return the list of commands in the set order."""
-        commands = ["check", "check-project", "format", "list", "docs"]
+        commands = ["check", "format", "list", "docs"]
         for command in self.commands:
             if command not in commands:
                 commands.append(command)
@@ -179,13 +179,22 @@ python_path_option = Annotated[
         rich_help_panel="Other",
     ),
 ]
+project_option = Annotated[
+    bool | None,
+    typer.Option(
+        "--project/--no-project",
+        show_default="run project rules if any is enabled",
+        help="Run project level rules. They require parsing the whole project and are enabled by selecting them.",
+        rich_help_panel="Project analysis",
+    ),
+]
 analyze_libraries_option = Annotated[
     bool | None,
     typer.Option(
         "--analyze-libraries/--no-analyze-libraries",
         show_default="--analyze-libraries",
         help="Import Robot Framework libraries to check keywords they provide. Importing a library executes its code.",
-        rich_help_panel="Other",
+        rich_help_panel="Project analysis",
     ),
 ]
 load_library_timeout_option = Annotated[
@@ -195,7 +204,7 @@ load_library_timeout_option = Annotated[
         show_default="10",
         metavar="SECONDS",
         help="Maximum time for importing a single library.",
-        rich_help_panel="Other",
+        rich_help_panel="Project analysis",
     ),
 ]
 ignored_libraries_option = Annotated[
@@ -205,7 +214,7 @@ ignored_libraries_option = Annotated[
         show_default=False,
         metavar="NAME",
         help="Library that should not be imported. Supports glob patterns, for example --ignored-library Selenium* .",
-        rich_help_panel="Other",
+        rich_help_panel="Project analysis",
     ),
 ]
 verbose_option = Annotated[
@@ -430,13 +439,25 @@ def check_files(
         ),
     ] = False,
     root: project_root_option = None,
+    variable: variable_option = None,
+    variable_file: variable_file_option = None,
+    python_path: python_path_option = None,
+    project: project_option = None,
+    analyze_libraries: analyze_libraries_option = None,
+    load_library_timeout: load_library_timeout_option = None,
+    ignored_library: ignored_libraries_option = None,
     verbose: verbose_option = None,
     silent: silent_option = None,
     cache: cache_option = None,
     clear_cache: clear_cache_option = False,
     cache_dir: cache_dir_option = None,
 ) -> list[Diagnostic]:
-    """Lint Robot Framework files."""
+    """
+    Lint Robot Framework files.
+
+    Project level rules (such as unused-keyword) are run whenever any of them is enabled. They require parsing
+    the whole project, which is done from the project root even if only selected paths are linted.
+    """
     if gitlab:
         if not reports:
             reports = []
@@ -470,6 +491,13 @@ def check_files(
         file_filters=file_filters,
         cache=cache_config,
         language=language,
+        variables=parser.parse_variables(variable),
+        variable_files=variable_file,
+        python_path=python_path,
+        project=project,
+        analyze_libraries=analyze_libraries,
+        load_library_timeout=load_library_timeout,
+        ignored_libraries=ignored_library,
         silent=silent,
         verbose=verbose,
         target_version=target_version,
@@ -490,130 +518,16 @@ def check_files(
     return runner.run()
 
 
-@app.command(name="check-project")
-def check_project(
-    sources: sources_argument = None,
-    select: select_rules_option = None,
-    extend_select: extend_select_rules_option = None,
-    ignore: ignore_rules_option = None,
-    target_version: linter_target_version_option = None,
-    threshold: linter_threshold_option = None,
-    include: include_option = None,
-    default_include: default_include_option = None,
-    exclude: exclude_option = None,
-    default_exclude: default_exclude_option = None,
-    force_exclude: force_exclude_option = False,
-    configuration_file: config_option = None,
-    configure: linter_configure_option = None,
-    reports: reports_option = None,
-    issue_format: Annotated[
-        str | None,
-        typer.Option("--issue-format", show_default=defaults.DEFAULT_ISSUE_FORMAT, rich_help_panel="Other"),
-    ] = None,
-    language: language_option = None,
-    custom_rules: Annotated[
-        list[str] | None,
-        typer.Option("--custom-rules", help="Load custom rules", show_default=False, rich_help_panel="Selecting rules"),
-    ] = None,
-    ignore_git_dir: ignore_git_dir_option = False,
-    ignore_file_config: ignore_file_config_option = False,
-    skip_gitignore: Annotated[
-        bool | None, typer.Option(help="Do not skip files listed in .gitignore files", rich_help_panel="File discovery")
-    ] = False,
-    persistent: Annotated[
-        bool | None,
-        typer.Option(
-            help="Use this flag to save Robocop reports in cache directory for later comparison.",
-            rich_help_panel="Reports",
-        ),
-    ] = None,
-    compare: Annotated[
-        bool | None,
-        typer.Option(
-            help="Compare reports results with previous results (saved with --persistent)", rich_help_panel="Reports"
-        ),
-    ] = None,
-    gitlab: Annotated[
-        bool | None,
-        typer.Option(
-            help="Generate Gitlab Code Quality report. Equivalent of --reports gitlab",
-            rich_help_panel="Reports",
-        ),
-    ] = False,
-    exit_zero: Annotated[
-        bool | None,
-        typer.Option(
-            help="Always exit with 0 unless Robocop terminates abnormally.",
-            show_default="--no-exit-zero",
-            rich_help_panel="Other",
-        ),
-    ] = None,
-    return_result: Annotated[
-        bool,
-        typer.Option(
-            help="Return check results as list of Diagnostic messages instead of exiting from the application.",
-            hidden=True,
-        ),
-    ] = False,
-    root: project_root_option = None,
-    variable: variable_option = None,
-    variable_file: variable_file_option = None,
-    python_path: python_path_option = None,
-    analyze_libraries: analyze_libraries_option = None,
-    load_library_timeout: load_library_timeout_option = None,
-    ignored_library: ignored_libraries_option = None,
-    verbose: verbose_option = None,
-    silent: silent_option = None,
-) -> list[Diagnostic]:
-    """Analyse the whole project using project level checkers."""
-    if gitlab:
-        if not reports:
-            reports = []
-        reports.append("gitlab")
-    linter_config = schema.RawLinterConfig(
-        configure=configure,
-        select=select,
-        extend_select=extend_select,
-        ignore=ignore,
-        issue_format=issue_format,
-        threshold=threshold,
-        custom_rules=custom_rules,
-        reports=reports,
-        persistent=persistent,
-        compare=compare,
-        exit_zero=exit_zero,
-        return_result=return_result,
+@app.command(name="check-project", hidden=True, deprecated=True)
+def check_project() -> None:
+    """Fail with a message pointing to the ``check`` command."""
+    print(
+        "The 'check-project' command was removed. Project level rules are now run by the 'check' command "
+        "whenever any of them is enabled:\n\n"
+        "    robocop check --select unused-keyword\n\n"
+        "Use --no-project to skip project level analysis."
     )
-    file_filters = schema.RawFileFiltersOptions(
-        include=include, default_include=default_include, exclude=exclude, default_exclude=default_exclude
-    )
-    overwrite_config = schema.RawConfig(
-        linter=linter_config,
-        formatter=None,
-        file_filters=file_filters,
-        language=language,
-        variables=parser.parse_variables(variable),
-        variable_files=variable_file,
-        python_path=python_path,
-        analyze_libraries=analyze_libraries,
-        load_library_timeout=load_library_timeout,
-        ignored_libraries=ignored_library,
-        verbose=verbose,
-        silent=silent,
-        target_version=target_version,
-    )
-    config_manager = manager.ConfigManager(
-        sources=sources,
-        config=configuration_file,
-        root=root,
-        ignore_git_dir=ignore_git_dir,
-        ignore_file_config=ignore_file_config,
-        skip_gitignore=skip_gitignore,
-        force_exclude=force_exclude,
-        overwrite_config=overwrite_config,
-    )
-    runner = RobocopLinter(config_manager)
-    return runner.run_project_checks()
+    raise typer.Exit(code=2)
 
 
 @app.command(name="format")

--- a/tests/linter/rules/arguments/invalid_argument_count/test_rule.py
+++ b/tests/linter/rules/arguments/invalid_argument_count/test_rule.py
@@ -6,7 +6,10 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_rule(self):
         self.check_rule(
-            src_files=["test.robot", "keywords.resource"], expected_file="expected_output.txt", project_check=True
+            src_files=["test.robot", "keywords.resource"],
+            expected_file="expected_output.txt",
+            exclude=["library"],
+            project_check=True,
         )
 
     def test_extended(self):
@@ -14,6 +17,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot", "keywords.resource"],
             expected_file="expected_extended.txt",
             output_format="extended",
+            exclude=["library"],
             project_check=True,
         )
 

--- a/tests/linter/rules/keywords/unused_keyword/test_rule.py
+++ b/tests/linter/rules/keywords/unused_keyword/test_rule.py
@@ -11,3 +11,10 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(
             src_files=["."], expected_file="expected_extended.txt", output_format="extended", project_check=True
         )
+
+    def test_run_without_project_flag(self):
+        """Project rules are run whenever they are enabled, even without the --project flag."""
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", issue_format="end_col")
+
+    def test_no_project(self):
+        self.check_rule(src_files=["."], expected_file=None, project=False, exit_code=0)

--- a/tests/linter/utils/__init__.py
+++ b/tests/linter/utils/__init__.py
@@ -16,7 +16,7 @@ import pytest
 import typer
 from rich.console import Console
 
-from robocop.run import check_files, check_project
+from robocop.run import check_files
 from robocop.version_handling import ROBOT_VERSION, VersionSpecifier
 from tests import working_directory
 from tests.formatter import display_file_diff
@@ -113,11 +113,10 @@ class RuleAcceptance:
     ) -> str | None:
         if not self.enabled_in_version(test_on_version):
             pytest.skip(f"Test enabled only for RF {test_on_version}")
+        test_fn = check_files
+        kwargs["cache"] = False
         if project_check:
-            test_fn = check_project
-        else:
-            test_fn = check_files
-            kwargs["cache"] = False
+            kwargs["project"] = True
         test_data = test_dir or self.test_class_dir
         sort_lines = output_format == "simple"
         issue_format = self.get_issue_format(issue_format)

--- a/tests/project/test_project_run.py
+++ b/tests/project/test_project_run.py
@@ -1,0 +1,71 @@
+"""Tests for running project level rules as a part of the ``check`` command."""
+
+from __future__ import annotations
+
+import pytest
+
+from robocop.run import check_files
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "test.robot").write_text(
+        "*** Test Cases ***\nTest\n    Used Keyword\n\n"
+        "*** Keywords ***\nUsed Keyword\n    Log    message\n\nNot Used Keyword\n    Log    message\n"
+    )
+    return tmp_path
+
+
+def run(source, select, **kwargs):
+    return check_files(
+        sources=[source],
+        select=select,
+        root=source,
+        ignore_file_config=True,
+        return_result=True,
+        cache=False,
+        silent=True,
+        **kwargs,
+    )
+
+
+def rule_names(diagnostics):
+    return sorted({diagnostic.rule.name for diagnostic in diagnostics})
+
+
+class TestProjectRulesInCheck:
+    def test_project_rule_is_run_when_selected(self, project):
+        assert rule_names(run(project, ["unused-keyword"])) == ["unused-keyword"]
+
+    def test_project_and_file_rules_are_reported_together(self, project):
+        assert rule_names(run(project, ["unused-keyword", "missing-doc-test-case"])) == [
+            "missing-doc-test-case",
+            "unused-keyword",
+        ]
+
+    def test_project_rules_are_not_run_when_not_selected(self, project):
+        assert rule_names(run(project, ["missing-doc-test-case"])) == ["missing-doc-test-case"]
+
+    def test_no_project_skips_project_rules(self, project):
+        assert run(project, ["unused-keyword"], project=False) == []
+
+    def test_no_project_keeps_file_rules(self, project):
+        diagnostics = run(project, ["unused-keyword", "missing-doc-test-case"], project=False)
+        assert rule_names(diagnostics) == ["missing-doc-test-case"]
+
+    def test_project_flag_does_not_enable_disabled_rules(self, project):
+        assert rule_names(run(project, ["missing-doc-test-case"], project=True)) == ["missing-doc-test-case"]
+
+    def test_project_context_is_built_from_root(self, project):
+        """Only one file is linted, but the context still knows about the whole project."""
+        (project / "resource.resource").write_text("*** Keywords ***\nResource Keyword\n    Log    message\n")
+        diagnostics = check_files(
+            sources=[project / "test.robot"],
+            select=["unused-keyword"],
+            root=project,
+            ignore_file_config=True,
+            return_result=True,
+            cache=False,
+            silent=True,
+        )
+        assert len(diagnostics) == 2


### PR DESCRIPTION
Project level rules are no longer run by a separate command.

`robocop check` now runs them together with the file level rules whenever at least one project rule is enabled.
Project rules are disabled by default, so selecting them is the opt-in.

### Why

Until now a full analysis required two runs (`check` + `check-project`) that shared the same configuration file.
That meant files parsed twice, two report artifacts that cannot be merged (sonarqube/gitlab/sarif), two exit codes
and two CI steps. It also made a shared `select`/`ignore` list ambiguous.

### Changes

- removed the `check-project` command and the `robocop-check-project` pre-commit hook
- added `--project` / `--no-project` to force or skip the project analysis without changing the configuration
- moved `--pythonpath`, `--variablefile`, `--analyze-libraries`, `--load-library-timeout` and `--ignored-library`
  to the `check` command (new `Project analysis` help panel)
- the project context is now built from the **project root**, even if only selected paths are linted
  (`ConfigManager.project_paths`). Previously the context only contained the linted sources, which caused false
  positives such as unused keywords when linting a subset of the project.
- fixed `path_relative_to_cwd` cache not taking the working directory into account

### Breaking change

`robocop check-project` was removed. Use `robocop check` with the project rules selected.
Invoking the old command prints a message with the migration instructions.

Part of the project rules work. Follow-up PRs add the remaining rules.
