### PR TITLE
feat: add unused-library-import rule

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -128,6 +128,7 @@ Currently available project level rules are:
 - ``unused-keyword`` - user keyword is never called in the project,
 - ``invalid-argument-count`` - keyword is called with a number of arguments its ``[Arguments]`` do not accept,
 - ``unused-resource-import`` - nothing from the imported resource file is used,
+- ``unused-library-import`` - no keyword from the imported library is used,
 - ``duplicated-variable-in-project`` - the same variable is defined in multiple files visible together.
 
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the

--- a/src/robocop/linter/checkers/imports.py
+++ b/src/robocop/linter/checkers/imports.py
@@ -49,6 +49,7 @@ class UnusedImportsChecker(ProjectChecker):
     """Checker reporting imports that are not used by the importing file."""
 
     unused_resource_import: imports.UnusedResourceImportRule
+    unused_library_import: imports.UnusedLibraryImportRule
 
     def __init__(self) -> None:
         super().__init__()
@@ -89,6 +90,38 @@ class UnusedImportsChecker(ProjectChecker):
                 self.unused_resource_import,
                 source=SourceFile(path=project_file.path, config=project_source_file.config),
                 import_name=imported.name,
+                lineno=imported.location.lineno,
+                col=imported.location.col,
+                end_lineno=imported.location.end_lineno,
+                end_col=imported.location.end_col,
+            )
+        self._check_libraries(project_file, project_source_file, context, used_keywords)
+
+    def _check_libraries(
+        self,
+        project_file: ProjectFile,
+        project_source_file: SourceFile | VirtualSourceFile,
+        context: ProjectContext,
+        used_keywords: set[str],
+    ) -> None:
+        """Report library imports whose keywords are not used."""
+        if context.library_loader is None:
+            return
+        for imported in project_file.library_imports():
+            if imported.status not in (ImportStatus.RESOLVED, ImportStatus.EXTERNAL):
+                continue
+            spec = context.library_loader.load_import(imported)
+            if spec is None or not spec.loaded or not spec.keywords:
+                continue
+            index = KeywordIndex()
+            for keyword in spec.keywords:
+                index.add(keyword)
+            if any(index.find(name) for name in used_keywords):
+                continue
+            self.report(
+                self.unused_library_import,
+                source=SourceFile(path=project_file.path, config=project_source_file.config),
+                import_name=imported.alias or imported.name,
                 lineno=imported.location.lineno,
                 col=imported.location.col,
                 end_lineno=imported.location.end_lineno,

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -242,3 +242,52 @@ class UnusedResourceImportRule(Rule):
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
+
+
+class UnusedLibraryImportRule(Rule):
+    """
+    Imported library is not used.
+
+    Reports library imports whose keywords are never used in the importing file.
+
+    Example of rule violation:
+
+        *** Settings ***
+        Library    Collections  # no keyword from this library is used
+
+        *** Test Cases ***
+        Test
+            Log    message
+
+    Keywords from a library imported in a resource file are available in every file importing that resource,
+    so the import is reported only when none of those files use any of its keywords.
+
+    The library is imported to find out what keywords it provides, which means this rule is only reported when
+    the library analysis is enabled (see the ``analyze-libraries`` option).
+
+    To avoid false positives, imports are not reported when:
+
+    - the library could not be imported, or is excluded with the ``ignored-libraries`` option,
+    - the library provides no keywords, since it may be imported for its side effects, for example to register
+      a listener,
+    - the importing file calls a keyword using a name built from a variable, because such call may come from any
+      library,
+    - the import path or arguments could not be resolved.
+
+    Libraries used only through ``Get Library Instance`` or imported dynamically with ``Import Library`` are
+    reported, since such usage cannot be detected from the source code.
+
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
+
+    """
+
+    name = "unused-library-import"
+    rule_id = "IMP06"
+    message = "Imported library '{import_name}' is not used"
+    severity = RuleSeverity.INFO
+    enabled = False
+    added_in_version = "8.9.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )

--- a/tests/linter/rules/imports/unused_library_import/dynamic.robot
+++ b/tests/linter/rules/imports/unused_library_import/dynamic.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library    Collections
+
+*** Test Cases ***
+Test
+    Run Keyword    ${keyword_name}

--- a/tests/linter/rules/imports/unused_library_import/expected_extended.txt
+++ b/tests/linter/rules/imports/unused_library_import/expected_extended.txt
@@ -1,0 +1,18 @@
+resources${/}keywords.resource:2:12 IMP06 Imported library 'DateTime' is not used
+   |
+ 1 | *** Settings ***
+ 2 | Library    DateTime
+   |            ^^^^^^^^ IMP06
+   |
+
+test.robot:3:12 IMP06 Imported library 'OperatingSystem' is not used
+   |
+ 1 | *** Settings ***
+ 2 | Library    Collections
+ 3 | Library    OperatingSystem
+   |            ^^^^^^^^^^^^^^^ IMP06
+ 4 | Library    String    AS    Str
+ 5 | Library    NotExisting
+   |
+
+Found 2 issues.

--- a/tests/linter/rules/imports/unused_library_import/expected_output.txt
+++ b/tests/linter/rules/imports/unused_library_import/expected_output.txt
@@ -1,0 +1,4 @@
+resources${/}keywords.resource:2:12 [I] IMP06 Imported library 'DateTime' is not used
+test.robot:3:12 [I] IMP06 Imported library 'OperatingSystem' is not used
+
+Found 2 issues.

--- a/tests/linter/rules/imports/unused_library_import/resources/keywords.resource
+++ b/tests/linter/rules/imports/unused_library_import/resources/keywords.resource
@@ -1,0 +1,6 @@
+*** Settings ***
+Library    DateTime
+
+*** Keywords ***
+Keyword From Resource
+    Log    message

--- a/tests/linter/rules/imports/unused_library_import/resources/used_library.resource
+++ b/tests/linter/rules/imports/unused_library_import/resources/used_library.resource
@@ -1,0 +1,6 @@
+*** Settings ***
+Library    Process
+
+*** Keywords ***
+Shared Keyword
+    Run Process    command

--- a/tests/linter/rules/imports/unused_library_import/test.robot
+++ b/tests/linter/rules/imports/unused_library_import/test.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Library    Collections
+Library    OperatingSystem
+Library    String    AS    Str
+Library    NotExisting
+Resource    resources/keywords.resource
+
+*** Test Cases ***
+Test
+    Append To List    ${list}    item
+    Str.Convert To Upper Case    text
+    Keyword From Resource

--- a/tests/linter/rules/imports/unused_library_import/test_rule.py
+++ b/tests/linter/rules/imports/unused_library_import/test_rule.py
@@ -1,0 +1,25 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )
+
+    def test_libraries_are_not_analyzed_when_disabled(self):
+        self.check_rule(src_files=["."], expected_file=None, analyze_libraries=False, exit_code=0)
+
+    def test_ignored_libraries_are_not_reported(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file=None,
+            ignored_library=["OperatingSystem", "DateTime"],
+            exit_code=0,
+        )

--- a/tests/linter/rules/imports/unused_library_import/transitive.robot
+++ b/tests/linter/rules/imports/unused_library_import/transitive.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    resources/used_library.resource
+
+*** Test Cases ***
+Test
+    Shared Keyword


### PR DESCRIPTION
Adds the `unused-library-import` (IMP06) project level rule.

It reports `Library` imports whose keywords are never used by the importing file, or by any file importing it
(library imports are transitive through resource files, the same way resource imports are).

The rule needs to know what keywords a library provides, so it only reports anything when the library analysis
is enabled (`--analyze-libraries`, on by default).

To avoid false positives, nothing is reported when:

- the library could not be imported or is excluded with `--ignored-library`,
- the library provides no keywords (it may be imported for its side effects, for example to register a listener),
- the importing file calls a keyword with a name built from a variable,
- the import path or arguments could not be resolved.

> [!NOTE]
> Based on #1824, review that one first. The diff will shrink once it is merged.
