### PR TITLE
feat: add ambiguous-keyword-name project rule (KW06)

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -129,6 +129,7 @@ Currently available project level rules are:
 - ``invalid-argument-count`` - keyword is called with a number of arguments its ``[Arguments]`` do not accept,
 - ``unused-resource-import`` - nothing from the imported resource file is used,
 - ``unused-library-import`` - no keyword from the imported library is used,
+- ``ambiguous-keyword-name`` - keyword name matches keywords from more than one source,
 - ``duplicated-variable-in-project`` - the same variable is defined in multiple files visible together.
 
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the

--- a/src/robocop/linter/checkers/usage.py
+++ b/src/robocop/linter/checkers/usage.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from robot.libraries import STDLIBS
+
+from robocop.files import path_relative_to_cwd
 from robocop.linter.rules import ProjectChecker, usage
 from robocop.linter.utils.misc import normalize_robot_name
 from robocop.project.definitions import usage_name_pattern
@@ -16,7 +19,7 @@ if TYPE_CHECKING:
     from robocop.config.manager import ConfigManager
     from robocop.linter.diagnostics import Diagnostic
     from robocop.project.context import ProjectContext, ProjectFile
-    from robocop.project.definitions import KeywordDefinition
+    from robocop.project.definitions import KeywordDefinition, KeywordUsage
     from robocop.source_file import VirtualSourceFile
 
 
@@ -56,6 +59,119 @@ class UsedKeywordNames:
         elif keyword.normalized_name in self.normalized:
             return True
         return any(pattern.fullmatch(keyword.normalized_name) for pattern in self.dynamic_patterns)
+
+
+class AmbiguousKeywordNames(ProjectChecker):
+    """Reports keyword calls matching keywords defined in more than one place."""
+
+    ambiguous_keyword_name: usage.AmbiguousKeywordNameRule
+
+    def scan_project(
+        self,
+        project_source_file: SourceFile | VirtualSourceFile,
+        config_manager: ConfigManager,  # noqa: ARG002
+        context: ProjectContext,
+    ) -> list[Diagnostic]:
+        self.issues = []
+        for project_file, keyword_usage in context.iter_usages():
+            candidates = self._ambiguous_definitions(context, keyword_usage)
+            if not candidates:
+                continue
+            self.report(
+                self.ambiguous_keyword_name,
+                source=SourceFile(path=project_file.path, config=project_source_file.config),
+                keyword_name=keyword_usage.name,
+                sources=_describe_sources(candidates),
+                lineno=keyword_usage.location.lineno,
+                col=keyword_usage.location.col,
+                end_lineno=keyword_usage.location.end_lineno,
+                end_col=keyword_usage.location.end_col,
+            )
+        return self.issues
+
+    @staticmethod
+    def _ambiguous_definitions(context: ProjectContext, keyword_usage: KeywordUsage) -> list[KeywordDefinition]:
+        """
+        Find definitions the call can refer to, if there is more than one to choose from.
+
+        Returns:
+            List of definitions with the same priority, or an empty list if the call is not ambiguous.
+
+        """
+        if keyword_usage.name_contains_variable:
+            return []
+        index = context.visible_keywords(keyword_usage.location.source)
+        for name in keyword_usage.names_to_check():
+            matches = index.find(name)
+            if not matches:
+                continue
+            # names matched only after removing the resource or library prefix are explicit already
+            direct = [definition for definition in matches if definition.matches(name)]
+            if not direct:
+                return []
+            return _same_priority(_unique(direct), keyword_usage.location.source)
+        return []
+
+
+def _unique(definitions: list[KeywordDefinition]) -> list[KeywordDefinition]:
+    """
+    Remove definitions pointing to the same keyword.
+
+    The same library can be imported by several files, each import providing its own copy of the keywords.
+
+    Returns:
+        List of definitions without duplicates, in the original order.
+
+    """
+    unique: list[KeywordDefinition] = []
+    seen: set[tuple[str, int, str]] = set()
+    for definition in definitions:
+        key = (str(definition.location.source), definition.location.lineno, definition.normalized_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(definition)
+    return unique
+
+
+def _same_priority(definitions: list[KeywordDefinition], source: Path) -> list[KeywordDefinition]:
+    """
+    Return definitions Robot Framework cannot choose between.
+
+    Returns:
+        List of definitions with the same priority, or an empty list if one of them wins.
+
+    """
+    if len(definitions) < 2:
+        return []
+    if any(definition.has_embedded_arguments for definition in definitions):
+        return []  # Robot Framework prefers the most specific match
+    own_file = [definition for definition in definitions if definition.location.source == source]
+    if own_file:
+        return []  # keyword from the same file wins, duplicates in a single file are reported by another rule
+    user_keywords = [definition for definition in definitions if not definition.is_from_library]
+    if user_keywords:
+        return user_keywords if len(user_keywords) > 1 else []
+    custom_libraries = [definition for definition in definitions if definition.library_name not in STDLIBS]
+    if custom_libraries:
+        return custom_libraries if len(custom_libraries) > 1 else []
+    return definitions
+
+
+def _describe_sources(definitions: list[KeywordDefinition]) -> str:
+    """
+    Describe where the matching keywords are defined.
+
+    Returns:
+        Comma separated list of libraries and files defining the keyword.
+
+    """
+    sources = []
+    for definition in definitions:
+        source = definition.library_name or str(path_relative_to_cwd(definition.location.source))
+        if source not in sources:
+            sources.append(source)
+    return ", ".join(sources)
 
 
 class UnusedKeywords(ProjectChecker):

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -49,3 +49,47 @@ class UnusedKeywordRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("10101",)
+
+
+class AmbiguousKeywordNameRule(Rule):
+    """
+    Keyword name matches more than one keyword.
+
+    Reports keyword calls that match keywords defined in more than one place. Robot Framework fails such call
+    with the ``Multiple keywords with name 'X' found`` error, unless the call uses the full name of the keyword.
+
+    Example of rule violation:
+
+        *** Settings ***
+        Resource    login.resource      # defines Login
+        Resource    admin.resource      # defines Login as well
+
+        *** Test Cases ***
+        Test
+            Login    user    password   # it is not known which keyword should be used
+
+    Robot Framework resolves conflicts using the following order, which the rule follows as well:
+
+    - a keyword defined in the file containing the call is always used,
+    - keywords from resource files are used before keywords from libraries,
+    - a keyword from a custom library is used before a keyword from a standard library.
+
+    Calls using the full name of the keyword (``login.Login``) are not reported, since the prefix already
+    selects the keyword. Calls with a name built from a variable are not reported either.
+
+    Keywords defined twice in the same file are reported by the ``duplicated-keyword-name`` rule instead.
+
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
+
+    """
+
+    name = "ambiguous-keyword-name"
+    rule_id = "KW06"
+    message = "Keyword '{keyword_name}' matches keywords from multiple sources: {sources}"
+    severity = RuleSeverity.WARNING
+    enabled = False
+    added_in_version = "8.9.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
+    )

--- a/tests/linter/rules/keywords/ambiguous_keyword_name/expected_extended.txt
+++ b/tests/linter/rules/keywords/ambiguous_keyword_name/expected_extended.txt
@@ -1,0 +1,9 @@
+test.robot:8:5 KW06 Keyword 'Login' matches keywords from multiple sources: resources${/}first.resource, resources${/}second.resource
+   |
+ 6 | *** Test Cases ***
+ 7 | Ambiguous Call
+ 8 |     Login    user    password
+   |     ^^^^^ KW06
+   |
+
+Found 1 issue.

--- a/tests/linter/rules/keywords/ambiguous_keyword_name/expected_output.txt
+++ b/tests/linter/rules/keywords/ambiguous_keyword_name/expected_output.txt
@@ -1,0 +1,3 @@
+test.robot:8:5 [W] KW06 Keyword 'Login' matches keywords from multiple sources: resources${/}first.resource, resources${/}second.resource
+
+Found 1 issue.

--- a/tests/linter/rules/keywords/ambiguous_keyword_name/resources/first.resource
+++ b/tests/linter/rules/keywords/ambiguous_keyword_name/resources/first.resource
@@ -1,0 +1,13 @@
+*** Keywords ***
+Login
+    Log    login from first resource
+
+Only In First
+    Log    message
+
+Defined In File And Resource
+    Log    message
+
+Append To List
+    [Arguments]    ${list}    ${item}
+    Log    keyword with the same name as a library keyword

--- a/tests/linter/rules/keywords/ambiguous_keyword_name/resources/second.resource
+++ b/tests/linter/rules/keywords/ambiguous_keyword_name/resources/second.resource
@@ -1,0 +1,6 @@
+*** Keywords ***
+Login
+    Log    login from second resource
+
+Only In Second
+    Log    message

--- a/tests/linter/rules/keywords/ambiguous_keyword_name/test.robot
+++ b/tests/linter/rules/keywords/ambiguous_keyword_name/test.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Resource    resources/first.resource
+Resource    resources/second.resource
+Library    Collections
+
+*** Test Cases ***
+Ambiguous Call
+    Login    user    password
+
+Not Ambiguous When Prefixed
+    first.Login    user    password
+
+Not Ambiguous When Defined In Single Resource
+    Only In First
+    Only In Second
+
+Not Ambiguous When Name Is Built From Variable
+    ${name}    Set Variable    Login
+    Run Keyword    ${name}
+
+Resource Keyword Wins Over Library
+    Append To List    ${list}    item
+
+Keyword From The File Wins
+    Defined In File And Resource
+
+*** Keywords ***
+Defined In File And Resource
+    Log    keyword from the file itself

--- a/tests/linter/rules/keywords/ambiguous_keyword_name/test_rule.py
+++ b/tests/linter/rules/keywords/ambiguous_keyword_name/test_rule.py
@@ -1,0 +1,14 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )


### PR DESCRIPTION
Adds project rule `ambiguous-keyword-name` (KW06), reporting keyword calls that match keywords from more than one source when Robot Framework's resolution order cannot pick a winner.

Not reported when:
- the keyword is defined in the calling file (covered by duplicated-keyword-name),
- the call is prefixed with a resource/library name,
- a user keyword shadows a library keyword,
- a custom library shadows a standard library keyword,
- any candidate uses embedded arguments,
- the keyword name is built from a variable.

Stacked on #1825.