### PR TITLE
feat: add keyword-not-found project rule (KW05)

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -130,6 +130,7 @@ Currently available project level rules are:
 - ``unused-resource-import`` - nothing from the imported resource file is used,
 - ``unused-library-import`` - no keyword from the imported library is used,
 - ``ambiguous-keyword-name`` - keyword name matches keywords from more than one source,
+- ``keyword-not-found`` - called keyword is not defined anywhere (requires ``--analyze-libraries``),
 - ``duplicated-variable-in-project`` - the same variable is defined in multiple files visible together.
 
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the

--- a/src/robocop/linter/checkers/usage.py
+++ b/src/robocop/linter/checkers/usage.py
@@ -9,7 +9,8 @@ from robot.libraries import STDLIBS
 from robocop.files import path_relative_to_cwd
 from robocop.linter.rules import ProjectChecker, usage
 from robocop.linter.utils.misc import normalize_robot_name
-from robocop.project.definitions import usage_name_pattern
+from robocop.project.context import BUILTIN_LIBRARY
+from robocop.project.definitions import ImportStatus, ImportType, usage_name_pattern
 from robocop.source_file import SourceFile
 
 if TYPE_CHECKING:
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
     from robocop.config.manager import ConfigManager
     from robocop.linter.diagnostics import Diagnostic
     from robocop.project.context import ProjectContext, ProjectFile
-    from robocop.project.definitions import KeywordDefinition, KeywordUsage
+    from robocop.project.definitions import KeywordDefinition, KeywordUsage, ResolvedImport
     from robocop.source_file import VirtualSourceFile
 
 
@@ -59,6 +60,111 @@ class UsedKeywordNames:
         elif keyword.normalized_name in self.normalized:
             return True
         return any(pattern.fullmatch(keyword.normalized_name) for pattern in self.dynamic_patterns)
+
+
+DYNAMIC_IMPORT_KEYWORDS = frozenset({"importlibrary", "importresource"})
+"""Keywords that add keywords to the file at runtime, making static analysis incomplete."""
+
+RESERVED_KEYWORD_NAMES = frozenset({"none"})
+"""Values used in place of a keyword name that do not refer to any keyword."""
+
+
+class KeywordNotFound(ProjectChecker):
+    """Reports keyword calls that do not match any known keyword."""
+
+    keyword_not_found: usage.KeywordNotFoundRule
+
+    def scan_project(
+        self,
+        project_source_file: SourceFile | VirtualSourceFile,
+        config_manager: ConfigManager,  # noqa: ARG002
+        context: ProjectContext,
+    ) -> list[Diagnostic]:
+        self.issues = []
+        if context.library_loader is None:
+            return self.issues  # without libraries almost every call would be reported
+        can_check: dict[Path, bool] = {}
+        for project_file, keyword_usage in context.iter_usages():
+            if not self._is_known(context, keyword_usage) and self._can_be_checked(context, project_file, can_check):
+                self.report(
+                    self.keyword_not_found,
+                    source=SourceFile(path=project_file.path, config=project_source_file.config),
+                    keyword_name=keyword_usage.name,
+                    lineno=keyword_usage.location.lineno,
+                    col=keyword_usage.location.col,
+                    end_lineno=keyword_usage.location.end_lineno,
+                    end_col=keyword_usage.location.end_col,
+                )
+        return self.issues
+
+    @staticmethod
+    def _is_known(context: ProjectContext, keyword_usage: KeywordUsage) -> bool:
+        """
+        Check if the call can be matched to a keyword definition.
+
+        Returns:
+            True if the keyword is defined or cannot be resolved statically.
+
+        """
+        if keyword_usage.name_contains_variable or keyword_usage.normalized_name in RESERVED_KEYWORD_NAMES:
+            return True
+        return bool(context.resolve_keyword(keyword_usage))
+
+    @staticmethod
+    def _can_be_checked(context: ProjectContext, project_file: ProjectFile, cache: dict[Path, bool]) -> bool:
+        """
+        Check if all keywords available in the file are known.
+
+        Returns:
+            True if every import of the file and of its resources was resolved and loaded.
+
+        """
+        resolved = project_file.path.resolve()
+        cached = cache.get(resolved)
+        if cached is not None:
+            return cached
+        can_check = KeywordNotFound._all_imports_known(context, project_file)
+        cache[resolved] = can_check
+        return can_check
+
+    @staticmethod
+    def _all_imports_known(context: ProjectContext, project_file: ProjectFile) -> bool:
+        """
+        Check imports of the file and of all resources it imports.
+
+        Returns:
+            True if nothing is missing from the keywords visible in the file.
+
+        """
+        loader = context.library_loader
+        if loader is None or not loader.load(BUILTIN_LIBRARY).loaded:
+            return False
+        for visible_file in context.imported_files(project_file.path):
+            if any(keyword_usage.normalized_name in DYNAMIC_IMPORT_KEYWORDS for keyword_usage in visible_file.usages):
+                return False
+            if not all(KeywordNotFound._import_known(context, imported) for imported in visible_file.imports):
+                return False
+        return True
+
+    @staticmethod
+    def _import_known(context: ProjectContext, imported: ResolvedImport) -> bool:
+        """
+        Check if the import provides keywords that are known to Robocop.
+
+        Returns:
+            True if the import cannot hide any keyword.
+
+        """
+        if imported.import_type == ImportType.VARIABLES:
+            return True
+        if imported.status not in (ImportStatus.RESOLVED, ImportStatus.EXTERNAL):
+            return False
+        if imported.import_type == ImportType.RESOURCE:
+            return imported.path is not None and imported.path.resolve() in context.files
+        if not imported.args_resolved or context.library_loader is None:
+            return False
+        spec = context.library_loader.load_import(imported)
+        return spec is not None and spec.loaded
 
 
 class AmbiguousKeywordNames(ProjectChecker):

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -51,6 +51,55 @@ class UnusedKeywordRule(Rule):
     deprecated_names = ("10101",)
 
 
+class KeywordNotFoundRule(Rule):
+    """
+    Keyword is not defined anywhere.
+
+    Reports keyword calls that do not match any keyword defined in the file, in the imported resource files or in
+    the imported libraries. Robot Framework fails such call with the ``No keyword with name 'X' found`` error.
+
+    Example of rule violation:
+
+        *** Settings ***
+        Resource    login.resource   # defines Login
+
+        *** Test Cases ***
+        Test
+            Login    user    password
+            Logout                    # Logout is not defined anywhere
+
+    Keywords come from libraries more often than not, so this rule requires the library analysis and is only
+    executed together with the ``--analyze-libraries`` option::
+
+        robocop check --select keyword-not-found --analyze-libraries
+
+    To avoid false positives, calls are not reported when the keywords available in the file are not fully known:
+
+    - the keyword name is built from a variable,
+    - any import of the file or of the resources it imports could not be resolved,
+    - any imported library could not be imported, for example because it is not installed or its arguments could
+      not be resolved,
+    - the file or any of the imported resources imports libraries or resources dynamically, using the
+      ``Import Library`` or ``Import Resource`` keywords.
+
+    Libraries excluded with the ``--ignored-library`` option make all files importing them skipped as well.
+
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
+
+    """
+
+    name = "keyword-not-found"
+    rule_id = "KW05"
+    message = "Keyword '{keyword_name}' not found"
+    severity = RuleSeverity.ERROR
+    enabled = False
+    added_in_version = "8.9.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
+    )
+
+
 class AmbiguousKeywordNameRule(Rule):
     """
     Keyword name matches more than one keyword.

--- a/tests/linter/rules/keywords/keyword_not_found/dynamic_import.robot
+++ b/tests/linter/rules/keywords/keyword_not_found/dynamic_import.robot
@@ -1,0 +1,4 @@
+*** Test Cases ***
+Test
+    Import Library    Collections
+    Keyword Imported At Runtime

--- a/tests/linter/rules/keywords/keyword_not_found/expected_extended.txt
+++ b/tests/linter/rules/keywords/keyword_not_found/expected_extended.txt
@@ -1,0 +1,17 @@
+test.robot:15:5 KW05 Keyword 'Logout' not found
+    |
+ 13 |
+ 14 | Missing Keyword
+ 15 |     Logout
+    |     ^^^^^^ KW05
+    |
+
+test.robot:22:34 KW05 Keyword 'Not Defined Anywhere' not found
+    |
+ 20 |
+ 21 | Missing Keyword In Run Keyword
+ 22 |     Run Keyword If    ${True}    Not Defined Anywhere
+    |                                  ^^^^^^^^^^^^^^^^^^^^ KW05
+    |
+
+Found 2 issues.

--- a/tests/linter/rules/keywords/keyword_not_found/expected_output.txt
+++ b/tests/linter/rules/keywords/keyword_not_found/expected_output.txt
@@ -1,0 +1,4 @@
+test.robot:15:5 [E] KW05 Keyword 'Logout' not found
+test.robot:22:34 [E] KW05 Keyword 'Not Defined Anywhere' not found
+
+Found 2 issues.

--- a/tests/linter/rules/keywords/keyword_not_found/missing_library.robot
+++ b/tests/linter/rules/keywords/keyword_not_found/missing_library.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library    NonExistingLibrary
+
+*** Test Cases ***
+Test
+    Keyword From Library That Could Not Be Imported

--- a/tests/linter/rules/keywords/keyword_not_found/missing_resource.robot
+++ b/tests/linter/rules/keywords/keyword_not_found/missing_resource.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    does_not_exist.resource
+
+*** Test Cases ***
+Test
+    Keyword From Resource That Was Not Found

--- a/tests/linter/rules/keywords/keyword_not_found/resources/keywords.resource
+++ b/tests/linter/rules/keywords/keyword_not_found/resources/keywords.resource
@@ -1,0 +1,6 @@
+*** Keywords ***
+Login
+    Log    login
+
+Keyword With ${embedded} Argument
+    Log    ${embedded}

--- a/tests/linter/rules/keywords/keyword_not_found/test.robot
+++ b/tests/linter/rules/keywords/keyword_not_found/test.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Resource    resources/keywords.resource
+Library     Collections
+Test Setup    NONE
+
+*** Test Cases ***
+Defined Keywords
+    Login
+    Keyword With Some Argument
+    Append To List    ${list}    item
+    Log    message
+    Local Keyword
+
+Missing Keyword
+    Logout
+
+Keyword Built From Variable
+    ${name}    Set Variable    Login
+    Run Keyword    ${name}
+
+Missing Keyword In Run Keyword
+    Run Keyword If    ${True}    Not Defined Anywhere
+
+*** Keywords ***
+Local Keyword
+    Log    message

--- a/tests/linter/rules/keywords/keyword_not_found/test_rule.py
+++ b/tests/linter/rules/keywords/keyword_not_found/test_rule.py
@@ -1,0 +1,26 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )
+
+    def test_not_reported_without_library_analysis(self):
+        self.check_rule(src_files=["."], expected_file=None, analyze_libraries=False, exit_code=0)
+
+    def test_not_reported_when_library_is_ignored(self):
+        self.check_rule(
+            src_files=["test.robot"],
+            expected_file=None,
+            ignored_library=["Collections"],
+            exit_code=0,
+            project_check=True,
+        )


### PR DESCRIPTION
Adds project rule `keyword-not-found` (KW05): reports keyword calls that do not match any keyword defined in the file, in the imported resource files or in the imported libraries.

Requires library analysis (`--analyze-libraries`, enabled by default). To avoid false positives the call is not reported when the available keywords are not fully known:
- keyword name is built from a variable,
- any import of the file or of its resources could not be resolved or loaded,
- library arguments could not be resolved,
- the file or its resources use `Import Library` / `Import Resource`,
- the library was excluded with `--ignored-library`.

Stacked on #1826.