### PR TITLE
feat: add circular-import project rule (IMP08)

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -131,6 +131,7 @@ Currently available project level rules are:
 - ``unused-library-import`` - no keyword from the imported library is used,
 - ``ambiguous-keyword-name`` - keyword name matches keywords from more than one source,
 - ``keyword-not-found`` - called keyword is not defined anywhere (requires ``--analyze-libraries``),
+- ``circular-import`` - resource file imports, directly or indirectly, the file it is imported in,
 - ``duplicated-variable-in-project`` - the same variable is defined in multiple files visible together.
 
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the

--- a/src/robocop/linter/checkers/imports.py
+++ b/src/robocop/linter/checkers/imports.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections import deque
 from typing import TYPE_CHECKING
 
+from robocop.files import path_relative_to_cwd
 from robocop.linter.rules import ProjectChecker, imports
 from robocop.project.context import KeywordIndex
 from robocop.project.definitions import ImportStatus, ImportType
@@ -147,6 +149,71 @@ class UnusedImportsChecker(ProjectChecker):
         if self._importers is None:
             self._importers = _build_importers(context)
         return self._importers.get(project_file.path.resolve(), [project_file])
+
+
+class CircularImports(ProjectChecker):
+    """Checker reporting resource imports that take part in a circular import."""
+
+    circular_import: imports.CircularImportRule
+
+    def scan_project(
+        self,
+        project_source_file: SourceFile | VirtualSourceFile,
+        config_manager: ConfigManager,  # noqa: ARG002
+        context: ProjectContext,
+    ) -> list[Diagnostic]:
+        self.issues = []
+        for project_file in context.iter_files():
+            own_path = project_file.path.resolve()
+            for imported in project_file.resource_imports():
+                if imported.status != ImportStatus.RESOLVED or imported.path is None:
+                    continue
+                imported_path = imported.path.resolve()
+                if imported_path not in context.files:
+                    continue
+                cycle = _path_back_to(context, imported_path, own_path)
+                if cycle is None:
+                    continue
+                self.report(
+                    self.circular_import,
+                    source=SourceFile(path=project_file.path, config=project_source_file.config),
+                    cycle=" -> ".join(str(path_relative_to_cwd(path)) for path in [own_path, *cycle]),
+                    lineno=imported.location.lineno,
+                    col=imported.location.col,
+                    end_lineno=imported.location.end_lineno,
+                    end_col=imported.location.end_col,
+                )
+        return self.issues
+
+
+def _path_back_to(context: ProjectContext, start: Path, target: Path) -> list[Path] | None:
+    """
+    Find the shortest chain of resource imports leading from the imported file back to the importing one.
+
+    Returns:
+        List of paths from the imported file to the target, or None if the target is not imported back.
+
+    """
+    queue: deque[tuple[Path, list[Path]]] = deque([(start, [start])])
+    seen = {start}
+    while queue:
+        current, chain = queue.popleft()
+        if current == target:
+            return chain
+        project_file = context.files.get(current)
+        if project_file is None:
+            continue
+        for imported in project_file.resource_imports():
+            if imported.status != ImportStatus.RESOLVED or imported.path is None:
+                continue
+            next_path = imported.path.resolve()
+            if next_path == target:
+                return [*chain, next_path]
+            if next_path in seen or next_path not in context.files:
+                continue
+            seen.add(next_path)
+            queue.append((next_path, [*chain, next_path]))
+    return None
 
 
 def _build_importers(context: ProjectContext) -> dict[Path, list[ProjectFile]]:

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -291,3 +291,44 @@ class UnusedLibraryImportRule(Rule):
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
+
+
+class CircularImportRule(Rule):
+    """
+    Resource file is a part of a circular import.
+
+    Reports resource imports that import, directly or indirectly, the file they are used in.
+
+    Example of rule violation:
+
+        # keywords.resource
+        *** Settings ***
+        Resource    helpers.resource
+
+        # helpers.resource
+        *** Settings ***
+        Resource    keywords.resource  # keywords.resource imports this file already
+
+    Robot Framework does not fail on circular imports, but they make it harder to tell where a keyword comes from
+    and often mean that the files should be split differently. Move the shared keywords to a separate resource file
+    imported by both files to break the cycle.
+
+    Every import taking part in the cycle is reported, together with the path leading back to the importing file.
+    A file importing itself is reported as well.
+
+    Imports that could not be resolved are not reported, since it is not known what they point to.
+
+    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
+    analyze the project.
+
+    """
+
+    name = "circular-import"
+    rule_id = "IMP08"
+    message = "Circular import: {cycle}"
+    severity = RuleSeverity.WARNING
+    enabled = False
+    added_in_version = "8.9.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.MODULAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )

--- a/tests/linter/rules/imports/circular_import/expected_extended.txt
+++ b/tests/linter/rules/imports/circular_import/expected_extended.txt
@@ -1,0 +1,29 @@
+first.resource:2:13 IMP08 Circular import: first.resource -> second.resource -> third.resource -> first.resource
+   |
+ 1 | *** Settings ***
+ 2 | Resource    second.resource
+   |             ^^^^^^^^^^^^^^^ IMP08
+   |
+
+itself.resource:2:13 IMP08 Circular import: itself.resource -> itself.resource
+   |
+ 1 | *** Settings ***
+ 2 | Resource    itself.resource
+   |             ^^^^^^^^^^^^^^^ IMP08
+   |
+
+second.resource:2:13 IMP08 Circular import: second.resource -> third.resource -> first.resource -> second.resource
+   |
+ 1 | *** Settings ***
+ 2 | Resource    third.resource
+   |             ^^^^^^^^^^^^^^ IMP08
+   |
+
+third.resource:2:13 IMP08 Circular import: third.resource -> first.resource -> second.resource -> third.resource
+   |
+ 1 | *** Settings ***
+ 2 | Resource    first.resource
+   |             ^^^^^^^^^^^^^^ IMP08
+   |
+
+Found 4 issues.

--- a/tests/linter/rules/imports/circular_import/expected_output.txt
+++ b/tests/linter/rules/imports/circular_import/expected_output.txt
@@ -1,0 +1,6 @@
+first.resource:2:13 [W] IMP08 Circular import: first.resource -> second.resource -> third.resource -> first.resource
+itself.resource:2:13 [W] IMP08 Circular import: itself.resource -> itself.resource
+second.resource:2:13 [W] IMP08 Circular import: second.resource -> third.resource -> first.resource -> second.resource
+third.resource:2:13 [W] IMP08 Circular import: third.resource -> first.resource -> second.resource -> third.resource
+
+Found 4 issues.

--- a/tests/linter/rules/imports/circular_import/first.resource
+++ b/tests/linter/rules/imports/circular_import/first.resource
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    second.resource
+
+*** Keywords ***
+Keyword From First
+    Log    message

--- a/tests/linter/rules/imports/circular_import/itself.resource
+++ b/tests/linter/rules/imports/circular_import/itself.resource
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    itself.resource
+
+*** Keywords ***
+Keyword From Itself
+    Log    message

--- a/tests/linter/rules/imports/circular_import/no_cycle/shared.resource
+++ b/tests/linter/rules/imports/circular_import/no_cycle/shared.resource
@@ -1,0 +1,3 @@
+*** Keywords ***
+Shared Keyword
+    Log    message

--- a/tests/linter/rules/imports/circular_import/no_cycle/test.robot
+++ b/tests/linter/rules/imports/circular_import/no_cycle/test.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    shared.resource
+
+*** Test Cases ***
+Test
+    Shared Keyword

--- a/tests/linter/rules/imports/circular_import/second.resource
+++ b/tests/linter/rules/imports/circular_import/second.resource
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    third.resource
+
+*** Keywords ***
+Keyword From Second
+    Log    message

--- a/tests/linter/rules/imports/circular_import/test.robot
+++ b/tests/linter/rules/imports/circular_import/test.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Resource    first.resource
+Resource    does_not_exist.resource
+
+*** Test Cases ***
+Test
+    Keyword From First

--- a/tests/linter/rules/imports/circular_import/test_rule.py
+++ b/tests/linter/rules/imports/circular_import/test_rule.py
@@ -1,0 +1,23 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )
+
+    def test_no_cycle(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file=None,
+            exit_code=0,
+            project_check=True,
+            test_dir=self.test_class_dir / "no_cycle",
+        )

--- a/tests/linter/rules/imports/circular_import/third.resource
+++ b/tests/linter/rules/imports/circular_import/third.resource
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource    first.resource
+
+*** Keywords ***
+Keyword From Third
+    Log    message


### PR DESCRIPTION
Adds project rule `circular-import` (IMP08): reports resource imports that import, directly or indirectly, the file they are used in, including a file importing itself.

The message contains the chain leading back to the importing file, e.g. `first.resource -> second.resource -> third.resource -> first.resource`. Unresolved imports are not reported.

Stacked on #1827.