### PR TITLE
docs: mark project rules in the rules list

### DIFF
--- a/docs/generate_rules_list.py
+++ b/docs/generate_rules_list.py
@@ -42,6 +42,13 @@ Below is the list of all Robocop rules.
 > Rule is disabled by default. Enable it by using ``--select {{ rule_doc.name }}`` option.
 {% endif %}
 
+{% if rule_doc.project_rule %}
+> **Project rule**
+>
+> This rule requires parsing the whole project. Selecting it makes ``robocop check`` analyze the project.
+> See [project checks](linter/linter.md#project-checks) for details.
+{% endif %}
+
 Added: `v{{ rule_doc.robocop_version }}`
 
 Supported RF version `{{ rule_doc.version }}`
@@ -150,6 +157,7 @@ def get_checker_docs() -> tuple[list[tuple], int]:
                 "msg": rule.message,
                 "docs": rule.docs,
                 "enabled": rule.enabled,
+                "project_rule": rule.project_rule,
                 "deprecated": rule.deprecated,
                 "deprecated_names": rule.deprecated_names,
                 "fix_availability": fix_availability,

--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -134,6 +134,12 @@ Currently available project level rules are:
 - ``circular-import`` - resource file imports, directly or indirectly, the file it is imported in,
 - ``duplicated-variable-in-project`` - the same variable is defined in multiple files visible together.
 
+Project rules are marked with the ``[project]`` tag in the [rules list](../rules_list.md) and can be listed with:
+
+```bash
+robocop list rules --filter PROJECT
+```
+
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the
 imports can be resolved:
 

--- a/docs/linter/rules.md
+++ b/docs/linter/rules.md
@@ -55,7 +55,11 @@ ENABLED - print only enabled rules
 DISABLED - print only disabled rules
 DEPRECATED - print only deprecated rules
 STYLE_GUIDE - print only rules directly connected to official Robot Framework style guide
+PROJECT - print only project rules, which require parsing the whole project
 ```
+
+Project rules are marked with the ``[project]`` tag in the rules list. Refer to
+[project checks](linter.md#project-checks) for more details.
 
 ## Rule severity
 

--- a/src/robocop/linter/rules/__init__.py
+++ b/src/robocop/linter/rules/__init__.py
@@ -329,6 +329,8 @@ class Rule:
         default_enabled (bool): (class attribute) store default value of enabled parameter for documentation purpose
         deprecated (bool): (class attribute) deprecated rule. If rule is used in configuration, it will issue a warning
         file_wide_rule (bool): (class attribute) If set, rule is reported for whole file
+        project_rule (bool): (class attribute) If set, rule requires parsing the whole project. Such rule is
+        reported by a ``ProjectChecker`` and makes ``robocop check`` analyze the project when it is selected
         parameters: (class attribute) optional rule parameters
         style_guide_ref (list of str): (class attribute) reference to Robot Framework Style Guide in form of
         '#paragraph' strings
@@ -352,6 +354,7 @@ class Rule:
     default_enabled: bool = True
     deprecated: bool = False
     file_wide_rule: bool = False
+    project_rule: bool = False
     parameters: list[RuleParam] | None = None
     style_guide_ref: list[str] | None = None  # docs only
     sonar_qube_attrs: sonar_qube.SonarQubeAttributes | None = None

--- a/src/robocop/linter/rules/arguments.py
+++ b/src/robocop/linter/rules/arguments.py
@@ -346,12 +346,10 @@ class InvalidArgumentCountRule(Rule):
     - the call expands a list (``@{args}``) or dictionary (``&{kwargs}``) variable,
     - the keyword is used as a test template.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "invalid-argument-count"
+    project_rule = True
     rule_id = "ARG08"
     message = "Keyword '{keyword_name}' expects {expected} but {provided} provided{missing}"
     severity = RuleSeverity.ERROR

--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -304,12 +304,10 @@ class DuplicatedVariableInProjectRule(Rule):
     Only variables defined in the ``*** Variables ***`` section are compared. Variable names are normalized, so
     ``${my var}``, ``${MY_VAR}`` and ``${myvar}`` are treated as the same variable.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "duplicated-variable-in-project"
+    project_rule = True
     rule_id = "DUP11"
     message = "Variable '{name}' is also defined in '{first_source}' (line {first_occurrence_line})"
     severity = RuleSeverity.WARNING

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -186,12 +186,10 @@ class UnresolvedResourceImportRule(Rule):
     If the path contains a variable that cannot be resolved, the import is ignored and not reported. Thanks to that,
     dynamically built paths do not cause false positives.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "unresolved-resource-import"
+    project_rule = True
     rule_id = "IMP07"
     message = "Imported resource file '{import_name}' does not exist"
     severity = RuleSeverity.WARNING
@@ -228,12 +226,10 @@ class UnusedResourceImportRule(Rule):
     - the imported resource defines no keywords and no variables, because it may be imported only for the imports
       it makes itself.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "unused-resource-import"
+    project_rule = True
     rule_id = "IMP05"
     message = "Imported resource file '{import_name}' is not used"
     severity = RuleSeverity.INFO
@@ -277,12 +273,10 @@ class UnusedLibraryImportRule(Rule):
     Libraries used only through ``Get Library Instance`` or imported dynamically with ``Import Library`` are
     reported, since such usage cannot be detected from the source code.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "unused-library-import"
+    project_rule = True
     rule_id = "IMP06"
     message = "Imported library '{import_name}' is not used"
     severity = RuleSeverity.INFO
@@ -318,12 +312,10 @@ class CircularImportRule(Rule):
 
     Imports that could not be resolved are not reported, since it is not known what they point to.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "circular-import"
+    project_rule = True
     rule_id = "IMP08"
     message = "Circular import: {cycle}"
     severity = RuleSeverity.WARNING

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -34,12 +34,10 @@ class UnusedKeywordRule(Rule):
     Keywords are only searched for in the files scanned by Robocop. If the project is a shared library of keywords
     used by other projects, all of its keywords are reported as not used.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "unused-keyword"
+    project_rule = True
     rule_id = "KW04"
     message = "Keyword '{keyword_name}' is not used"
     severity = RuleSeverity.INFO
@@ -84,12 +82,10 @@ class KeywordNotFoundRule(Rule):
 
     Libraries excluded with the ``--ignored-library`` option make all files importing them skipped as well.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "keyword-not-found"
+    project_rule = True
     rule_id = "KW05"
     message = "Keyword '{keyword_name}' not found"
     severity = RuleSeverity.ERROR
@@ -128,12 +124,10 @@ class AmbiguousKeywordNameRule(Rule):
 
     Keywords defined twice in the same file are reported by the ``duplicated-keyword-name`` rule instead.
 
-    This rule is a project level rule: it requires parsing the whole project. Selecting it makes ``robocop check``
-    analyze the project.
-
     """
 
     name = "ambiguous-keyword-name"
+    project_rule = True
     rule_id = "KW06"
     message = "Keyword '{keyword_name}' matches keywords from multiple sources: {sources}"
     severity = RuleSeverity.WARNING

--- a/src/robocop/linter/rules_list.py
+++ b/src/robocop/linter/rules_list.py
@@ -22,6 +22,7 @@ class RuleFilter(str, Enum):
     DISABLED = "DISABLED"
     DEPRECATED = "DEPRECATED"
     STYLE_GUIDE = "STYLE_GUIDE"
+    PROJECT = "PROJECT"
 
 
 def rules_sorted_by_id(rules: dict[str, Rule]) -> list[Rule]:
@@ -60,6 +61,8 @@ def filter_rules_by_category(rules: dict[str, Rule], category: RuleFilter, targe
         rules_by_id = {rule.rule_id: rule for rule in rules.values() if rule.deprecated}
     elif category == RuleFilter.STYLE_GUIDE:
         rules_by_id = {rule.rule_id: rule for rule in rules.values() if not rule.deprecated and rule.style_guide_ref}
+    elif category == RuleFilter.PROJECT:
+        rules_by_id = {rule.rule_id: rule for rule in rules.values() if not rule.deprecated and rule.project_rule}
     else:
         raise ValueError(f"Unrecognized rule category '{category}'")
     return rules_sorted_by_id(rules_by_id)
@@ -87,4 +90,6 @@ def rule_short_description(rule: Rule, target_version: Version) -> Text:
     desc.append(")")
     if rule.fix_availability in (FixAvailability.ALWAYS, FixAvailability.SOMETIMES):
         desc.append(" [fixable]", style="blue")
+    if rule.project_rule:
+        desc.append(" [project]", style="magenta")
     return desc

--- a/tests/linter/cli/test_list_rules.py
+++ b/tests/linter/cli/test_list_rules.py
@@ -89,6 +89,18 @@ def rule_deprecated_disabled() -> Rule:
 
 
 @pytest.fixture
+def rule_project() -> Rule:
+    return get_mocked_rule(
+        rule_id="9993",
+        name="project-rule",
+        message="Project rule",
+        severity=RuleSeverity.WARNING,
+        enabled=False,
+        project_rule=True,
+    )
+
+
+@pytest.fixture
 def rule_disabled_after_4() -> Rule:
     return get_mocked_rule(
         rule_id="9999", name="disabled-in-four", message="This is desc", severity=RuleSeverity.WARNING, version="<4.0"
@@ -256,6 +268,21 @@ class TestListingRules:
             out == "9991 [E]: deprecated-rule: Deprecated rule (deprecated)\n"
             "9992 [I]: deprecated-disabled-rule: Deprecated and disabled rule (deprecated)\n\n"
             "Altogether 2 rules (0 enabled).\n\n"
+            "Visit https://robocop.dev/stable/rules_list/ page for detailed documentation.\n"
+        )
+
+    def test_list_filter_project(self, rule_0101, rule_project, capsys):
+        mocked_config = get_resolved_config(rule_0101, rule_project)
+        resolver_mock = Mock(spec=ConfigResolver)
+        resolver_instance_mock = Mock()
+        resolver_mock.return_value = resolver_instance_mock
+        resolver_instance_mock.resolve_config.return_value = mocked_config
+        with patch("robocop.run.ConfigResolver", resolver_mock):
+            list_rules(filter_category=RuleFilter.PROJECT)
+        out, _ = capsys.readouterr()
+        assert (
+            out == "9993 [W]: project-rule: Project rule (disabled) [project]\n\n"
+            "Altogether 1 rule (0 enabled).\n\n"
             "Visit https://robocop.dev/stable/rules_list/ page for detailed documentation.\n"
         )
 

--- a/tests/project/test_project_rule_metadata.py
+++ b/tests/project/test_project_rule_metadata.py
@@ -1,0 +1,26 @@
+from robocop.linter.rules import ProjectChecker
+from robocop.runtime.resolver import LinterImporter
+
+
+def get_all_rules():
+    importer = LinterImporter()
+    for checker in importer.get_initialized_checkers():
+        for name, rule in checker.rules.items():
+            if name == rule.name:
+                yield checker, rule
+
+
+class TestProjectRuleMetadata:
+    def test_project_rules_are_reported_by_project_checkers(self):
+        for checker, rule in get_all_rules():
+            if rule.project_rule:
+                assert isinstance(checker, ProjectChecker), (
+                    f"Rule {rule.name} is marked as a project rule but {type(checker).__name__} is not a ProjectChecker"
+                )
+
+    def test_rules_of_project_checkers_are_marked(self):
+        for checker, rule in get_all_rules():
+            if isinstance(checker, ProjectChecker):
+                assert rule.project_rule, (
+                    f"Rule {rule.name} is reported by a ProjectChecker and should set project_rule = True"
+                )


### PR DESCRIPTION
Makes project rules visible in the documentation and in the CLI:

- new `Rule.project_rule` attribute,
- generated rules list renders a **Project rule** note with a link to the project checks docs,
- `robocop list rules` tags such rules with `[project]`,
- new `robocop list rules --filter PROJECT`,
- the repeated 'This rule is a project level rule' paragraph was removed from the rule docstrings,
- test asserting that `project_rule` matches rules reported by `ProjectChecker`.

Stacked on #1828.