### PR TITLE
feat: cache imported library keywords between runs

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -122,6 +122,9 @@ robocop check --no-project
     analysis. Library analysis can be disabled with ``--no-analyze-libraries`` and single libraries can be skipped
     with ``--ignored-library``.
 
+Keywords of the successfully imported libraries are stored in the [cache](../user_guide/intro.md#caching), so the
+next run does not have to import them again.
+
 Currently available project level rules are:
 
 - ``unresolved-resource-import`` - imported resource file does not exist,

--- a/docs/user_guide/intro.md
+++ b/docs/user_guide/intro.md
@@ -127,6 +127,10 @@ If the file was not modified since the last run and Robocop configuration did no
 results. Previous diagnostic messages are retained, and formatting of not modified files is skipped.
 Use [``--no-cache``](../configuration/configuration_reference.md#cache-dir) to disable caching.
 
+Keywords of the libraries imported during the [project checks](../linter/linter.md#project-checks) are cached as
+well. Such library is not imported again as long as its source file, the Python interpreter and the Robot Framework
+version stay the same. Libraries that are a part of the analyzed project are always imported again.
+
 ## Values
 
 Original *RoboCop* - a fictional cybernetic police officer - was the following three prime directives

--- a/src/robocop/cache.py
+++ b/src/robocop/cache.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import msgpack
@@ -18,8 +19,6 @@ from robocop.config import defaults
 from robocop.source_file import SourceFile
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic
     from robocop.runtime.resolved_config import ResolvedConfig
@@ -196,6 +195,48 @@ class FormatterCacheEntry:
         )
 
 
+@dataclass(frozen=True)
+class LibraryCacheEntry:
+    """Immutable cache entry with the keywords of an imported library."""
+
+    metadata: FileMetadata
+    environment_hash: str
+    source: str
+    response: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary representation of the library cache entry.
+
+        """
+        return {
+            "mtime": self.metadata.mtime,
+            "size": self.metadata.size,
+            "environment_hash": self.environment_hash,
+            "source": self.source,
+            "response": self.response,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LibraryCacheEntry:
+        """
+        Create from dictionary loaded from cache.
+
+        Returns:
+            LibraryCacheEntry: The library cache entry object.
+
+        """
+        return cls(
+            metadata=FileMetadata(mtime=data["mtime"], size=data["size"]),
+            environment_hash=data["environment_hash"],
+            source=data["source"],
+            response=data["response"],
+        )
+
+
 @dataclass
 class CacheData:
     """Mutable container for cache data."""
@@ -203,6 +244,7 @@ class CacheData:
     robocop_version: str = field(default_factory=lambda: __version__)
     linter: dict[str, LinterCacheEntry] = field(default_factory=dict)
     formatter: dict[str, FormatterCacheEntry] = field(default_factory=dict)
+    libraries: dict[str, LibraryCacheEntry] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -216,6 +258,7 @@ class CacheData:
             "robocop_version": self.robocop_version,
             "linter": {path: entry.to_dict() for path, entry in self.linter.items()},
             "formatter": {path: entry.to_dict() for path, entry in self.formatter.items()},
+            "libraries": {key: entry.to_dict() for key, entry in self.libraries.items()},
         }
 
     @classmethod
@@ -231,6 +274,7 @@ class CacheData:
             robocop_version=data.get("robocop_version", ""),
             linter={path: LinterCacheEntry.from_dict(entry) for path, entry in data.get("linter", {}).items()},
             formatter={path: FormatterCacheEntry.from_dict(entry) for path, entry in data.get("formatter", {}).items()},
+            libraries={key: LibraryCacheEntry.from_dict(entry) for key, entry in data.get("libraries", {}).items()},
         )
 
 
@@ -500,6 +544,59 @@ class RobocopCache:
         )
         str_path = self._normalize_path(path)
         self.data.formatter[str_path] = entry
+        self._dirty = True
+
+    # Library cache methods
+
+    def get_library_entry(self, key: str, environment_hash: str) -> dict[str, Any] | None:
+        """
+        Get the cached response of the library import if it is still valid.
+
+        The entry is invalidated when the library source file changes or when the environment used to import it
+        (Python interpreter, Robot Framework version) is different.
+
+        Args:
+            key: Key identifying the library import (name and arguments).
+            environment_hash: Hash of the environment used to import libraries.
+
+        Returns:
+            Cached worker response if valid, None otherwise.
+
+        """
+        if not self.enabled:
+            return None
+        entry = self.data.libraries.get(key)
+        if entry is None:
+            return None
+        if not self._is_entry_valid(Path(entry.source), entry.metadata, environment_hash, entry.environment_hash):
+            del self.data.libraries[key]
+            self._dirty = True
+            return None
+        return entry.response
+
+    def set_library_entry(self, key: str, environment_hash: str, source: Path, response: dict[str, Any]) -> None:
+        """
+        Store the response of the library import in the cache.
+
+        Args:
+            key: Key identifying the library import (name and arguments).
+            environment_hash: Hash of the environment used to import libraries.
+            source: Source file of the imported library, used to invalidate the entry.
+            response: Response returned by the library import process.
+
+        """
+        if not self.enabled:
+            return
+        try:
+            metadata = FileMetadata.from_path(source)
+        except OSError:
+            return
+        self.data.libraries[key] = LibraryCacheEntry(
+            metadata=metadata,
+            environment_hash=environment_hash,
+            source=str(source),
+            response=response,
+        )
         self._dirty = True
 
 

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -125,6 +125,7 @@ class RobocopLinter:
                 self.config_manager.cache.set_linter_entry(source_file.path, source_file.config.hash, diagnostics)
         self.config_manager.cache.save()
         self.diagnostics.extend(self.run_project_checks())
+        self.config_manager.cache.save()  # project analysis may cache imported libraries
 
         if not files and not self.config_manager.default_config.silent:
             print("No Robot files were found with the existing configuration.")

--- a/src/robocop/project/_libdoc_worker.py
+++ b/src/robocop/project/_libdoc_worker.py
@@ -78,7 +78,12 @@ def load_library(request: dict[str, Any]) -> dict[str, Any]:
         from robot.libdocpkg import LibraryDocumentation  # noqa: PLC0415
 
         library = LibraryDocumentation(name)
-        return {"status": "ok", "name": library.name, "keywords": _keywords(library)}
+        return {
+            "status": "ok",
+            "name": library.name,
+            "source": str(library.source) if library.source else None,
+            "keywords": _keywords(library),
+        }
     except BaseException as error:  # noqa: BLE001 - importing a library executes arbitrary code
         message = f"{type(error).__name__}: {error}".strip()
         return {

--- a/src/robocop/project/context.py
+++ b/src/robocop/project/context.py
@@ -327,6 +327,8 @@ def build_project_context(config_manager: ConfigManager, silent: bool = False) -
             search_paths=search_paths,
             timeout=config.load_library_timeout,
             ignored_libraries=config.ignored_libraries,
+            cache=config_manager.cache if config.cache.enabled else None,
+            project_root=config_manager.root,
         )
     global_scope = VariableScope()
     global_scope.add_variable_files(config.variable_files, search_paths)

--- a/src/robocop/project/libraries.py
+++ b/src/robocop/project/libraries.py
@@ -18,6 +18,8 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
+from functools import cache
+from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -27,6 +29,7 @@ from robocop.project.definitions import ArgumentsSpec, KeywordDefinition, Locati
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from robocop.cache import RobocopCache
     from robocop.project.definitions import ResolvedImport
 
 WORKER_MODULE = "robocop.project._libdoc_worker"
@@ -140,11 +143,18 @@ class LibraryLoader:
 
     Every library is imported only once, even if it is used in several files. Libraries imported with different
     arguments are treated as different libraries, since the arguments may change the provided keywords.
+
+    Successful imports are also stored in the persistent Robocop cache, so that the library does not have to be
+    imported again in the next run. Cached results are only used for libraries installed outside of the analyzed
+    project and are invalidated when the library source file, the Python interpreter or the Robot Framework
+    version changes.
     """
 
     search_paths: list[Path] = field(default_factory=list)
     timeout: int = DEFAULT_TIMEOUT
     ignored_libraries: list[str] = field(default_factory=list)
+    cache: RobocopCache | None = None
+    project_root: Path | None = None
     _cache: dict[tuple[str, tuple[str, ...]], LibrarySpec] = field(default_factory=dict, init=False)
 
     def load(self, request: LibraryRequest) -> LibrarySpec:
@@ -217,7 +227,7 @@ class LibraryLoader:
         """
         if self.is_ignored(request.name):
             return LibrarySpec(name=request.name, error="Library is excluded from the analysis")
-        response = self._run_worker(request)
+        response = self._import_library(request)
         if response.get("status") != "ok":
             return LibrarySpec(name=request.name, error=response.get("error", "Unknown error"))
         fallback_source = request.source or Path(request.name)
@@ -225,6 +235,43 @@ class LibraryLoader:
             _keyword_definition(keyword, request.name, fallback_source) for keyword in response.get("keywords", [])
         )
         return LibrarySpec(name=request.name, keywords=keywords)
+
+    def _import_library(self, request: LibraryRequest) -> dict[str, Any]:
+        """
+        Import the library, reusing the result stored in the persistent cache when it is still valid.
+
+        Returns:
+            Response describing the library keywords or the failure.
+
+        """
+        cache_key = _persistent_cache_key(request)
+        if self.cache is not None:
+            cached = self.cache.get_library_entry(cache_key, environment_hash())
+            if cached is not None:
+                return cached
+        response = self._run_worker(request)
+        if self.cache is not None and response.get("status") == "ok":
+            source = response.get("source")
+            if source and self._can_be_cached(Path(source)):
+                self.cache.set_library_entry(cache_key, environment_hash(), Path(source), response)
+        return response
+
+    def _can_be_cached(self, source: Path) -> bool:
+        """
+        Check if the imported library can be stored in the persistent cache.
+
+        Libraries that are a part of the analyzed project are not cached, since they change together with the
+        rest of the sources and a change in any of their modules would not be detected.
+
+        Returns:
+            True if the library can be stored between the runs.
+
+        """
+        if not source.is_file():
+            return False
+        if self.project_root is None:
+            return True
+        return self.project_root.resolve() not in source.resolve().parents
 
     def _run_worker(self, request: LibraryRequest) -> dict[str, Any]:
         """
@@ -268,6 +315,35 @@ class LibraryLoader:
             return response
 
 
+def _persistent_cache_key(request: LibraryRequest) -> str:
+    """
+    Build the key identifying the library import in the persistent cache.
+
+    Returns:
+        Key built from the library name or path and its arguments.
+
+    """
+    name = str(request.source) if request.source else request.name
+    return "::".join([name, *request.args])
+
+
+@cache
+def environment_hash() -> str:
+    """
+    Describe the environment the libraries are imported in.
+
+    Libraries imported with a different Python interpreter or a different Robot Framework version may provide
+    different keywords, so the cached results cannot be reused.
+
+    Returns:
+        Hash of the Python interpreter and the Robot Framework version.
+
+    """
+    from robot.version import VERSION as RF_VERSION  # noqa: PLC0415
+
+    return sha256(f"{sys.executable}|{sys.version}|{RF_VERSION}".encode()).hexdigest()
+
+
 def replace_library_name(keyword: KeywordDefinition, library_name: str) -> KeywordDefinition:
     """
     Return a copy of the keyword that belongs to a library imported under a different name.
@@ -290,6 +366,8 @@ def build_library_loader(
     search_paths: Iterable[Path] | None = None,
     timeout: int = DEFAULT_TIMEOUT,
     ignored_libraries: Iterable[str] | None = None,
+    cache: RobocopCache | None = None,
+    project_root: Path | None = None,
 ) -> LibraryLoader:
     """
     Create the loader used to import libraries during the project analysis.
@@ -302,4 +380,6 @@ def build_library_loader(
         search_paths=list(search_paths or []),
         timeout=timeout,
         ignored_libraries=list(ignored_libraries or []),
+        cache=cache,
+        project_root=project_root,
     )

--- a/tests/project/test_libraries.py
+++ b/tests/project/test_libraries.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import os
+import time
+
 import pytest
 
+from robocop.cache import RobocopCache
 from robocop.config.manager import ConfigManager
 from robocop.config.schema import RawConfig
 from robocop.project.context import build_project_context
@@ -167,3 +171,53 @@ class TestLibrariesInProjectContext:
         )
         context = build_context(project)
         assert context.visible_keywords(project / "test.robot").find("Own Keyword")
+
+
+class TestPersistentLibraryCache:
+    def test_library_is_read_from_cache_in_next_run(self, library_dir, tmp_path, monkeypatch):
+        cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        loader = build_library_loader(search_paths=[library_dir], cache=cache)
+        assert keyword_names(loader.load(LibraryRequest(name="MyLibrary"))) == ["Custom Keyword"]
+        cache.save()
+
+        next_cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        next_loader = build_library_loader(search_paths=[library_dir], cache=next_cache)
+        monkeypatch.setattr(
+            LibraryLoader,
+            "_run_worker",
+            lambda *args, **kwargs: pytest.fail("Library should be read from the cache"),  # noqa: ARG005
+        )
+        assert keyword_names(next_loader.load(LibraryRequest(name="MyLibrary"))) == ["Custom Keyword"]
+
+    def test_modified_library_is_imported_again(self, library_dir, tmp_path):
+        cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        loader = build_library_loader(search_paths=[library_dir], cache=cache)
+        loader.load(LibraryRequest(name="MyLibrary"))
+        cache.save()
+
+        library = library_dir / "MyLibrary.py"
+        library.write_text("def other_keyword():\n    pass\n")
+        os.utime(library, (time.time() + 10, time.time() + 10))
+
+        next_cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        next_loader = build_library_loader(search_paths=[library_dir], cache=next_cache)
+        assert keyword_names(next_loader.load(LibraryRequest(name="MyLibrary"))) == ["Other Keyword"]
+
+    def test_failed_import_is_not_cached(self, library_dir, tmp_path):
+        cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        loader = build_library_loader(search_paths=[library_dir], cache=cache)
+        assert not loader.load(LibraryRequest(name="BrokenLibrary")).loaded
+        assert not cache.data.libraries
+
+    def test_project_libraries_are_not_cached(self, library_dir, tmp_path):
+        cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        loader = build_library_loader(search_paths=[library_dir], cache=cache, project_root=library_dir)
+        assert loader.load(LibraryRequest(name="MyLibrary")).loaded
+        assert not cache.data.libraries
+
+    def test_cache_is_not_used_when_environment_changes(self, library_dir, tmp_path):
+        cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
+        loader = build_library_loader(search_paths=[library_dir], cache=cache)
+        loader.load(LibraryRequest(name="MyLibrary"))
+        key = next(iter(cache.data.libraries))
+        assert cache.get_library_entry(key, "other-environment") is None


### PR DESCRIPTION
Project checks import libraries in a separate process, which is the slowest part of the analysis. This PR stores successful imports in the existing Robocop cache (`.robocop_cache`).

- worker returns the library source path,
- new `libraries` section in the cache, keyed by the import name/path and arguments,
- entries are invalidated by the library source mtime/size and by a hash of the Python interpreter and Robot Framework version,
- libraries located inside the analyzed project are never cached, since a change in any of their modules would not be detected,
- failed imports are not cached,
- honours `--no-cache`.

Stacked on #1829.