### PR TITLE
feat: add unresolved-library-import project rule

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -128,6 +128,7 @@ next run does not have to import them again.
 Currently available project level rules are:
 
 - ``unresolved-resource-import`` - imported resource file does not exist,
+- ``unresolved-library-import`` - imported library cannot be imported,
 - ``unused-keyword`` - user keyword is never called in the project,
 - ``invalid-argument-count`` - keyword is called with a number of arguments its ``[Arguments]`` do not accept,
 - ``unused-resource-import`` - nothing from the imported resource file is used,

--- a/src/robocop/linter/checkers/imports.py
+++ b/src/robocop/linter/checkers/imports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -16,14 +17,38 @@ if TYPE_CHECKING:
 
     from robocop.config.manager import ConfigManager
     from robocop.linter.diagnostics import Diagnostic
+    from robocop.linter.rules import Rule
     from robocop.project.context import ProjectContext, ProjectFile
+    from robocop.project.definitions import ResolvedImport
     from robocop.source_file import VirtualSourceFile
+
+NOT_IMPORTED_LIBRARIES = frozenset({"Remote"})
+"""Libraries that are never imported, since importing them requires a running service."""
+
+IMPORT_ERROR_PREFIX = re.compile(r"^(?:\w+: )?Importing (?:test )?library '[^']*' failed: ")
+
+
+def _import_error(error: str | None) -> str:
+    """
+    Make the error returned by the library import shorter.
+
+    Robot Framework prefixes the error with the name of the library, which is already a part of the reported
+    message.
+
+    Returns:
+        Error without the redundant prefix.
+
+    """
+    if not error:
+        return "Unknown error"
+    return IMPORT_ERROR_PREFIX.sub("", error)
 
 
 class ProjectImportsChecker(ProjectChecker):
     """Checker for imports that can only be validated with the whole project context."""
 
     unresolved_resource_import: imports.UnresolvedResourceImportRule
+    unresolved_library_import: imports.UnresolvedLibraryImportRule
 
     def scan_project(
         self,
@@ -33,18 +58,58 @@ class ProjectImportsChecker(ProjectChecker):
     ) -> list[Diagnostic]:
         self.issues = []
         for project_file, imported in context.iter_imports():
-            if imported.import_type != ImportType.RESOURCE or imported.status != ImportStatus.NOT_FOUND:
-                continue
-            self.report(
-                self.unresolved_resource_import,
-                source=SourceFile(path=project_file.path, config=project_source_file.config),
-                import_name=imported.resolved_name,
-                lineno=imported.location.lineno,
-                col=imported.location.col,
-                end_lineno=imported.location.end_lineno,
-                end_col=imported.location.end_col,
-            )
+            if imported.import_type == ImportType.RESOURCE:
+                if imported.status == ImportStatus.NOT_FOUND:
+                    self._report_import(self.unresolved_resource_import, project_file, imported, project_source_file)
+            elif imported.import_type == ImportType.LIBRARY:
+                self._check_library(project_file, imported, project_source_file, context)
         return self.issues
+
+    def _check_library(
+        self,
+        project_file: ProjectFile,
+        imported: ResolvedImport,
+        project_source_file: SourceFile | VirtualSourceFile,
+        context: ProjectContext,
+    ) -> None:
+        """Report library import that Robot Framework would not be able to import."""
+        if imported.status == ImportStatus.UNRESOLVABLE or not imported.args_resolved:
+            return
+        if imported.resolved_name in NOT_IMPORTED_LIBRARIES:
+            return
+        loader = context.library_loader
+        if loader is not None and loader.is_ignored(imported.resolved_name):
+            return
+        if imported.status == ImportStatus.NOT_FOUND:
+            error = "File does not exist"
+        else:
+            if loader is None:
+                return
+            spec = loader.load_import(imported)
+            if spec is None or spec.loaded:
+                return
+            error = _import_error(spec.error)
+        self._report_import(self.unresolved_library_import, project_file, imported, project_source_file, error=error)
+
+    def _report_import(
+        self,
+        rule: Rule,
+        project_file: ProjectFile,
+        imported: ResolvedImport,
+        project_source_file: SourceFile | VirtualSourceFile,
+        error: str = "",
+    ) -> None:
+        """Report the import using the location of the import statement."""
+        self.report(
+            rule,
+            source=SourceFile(path=project_file.path, config=project_source_file.config),
+            import_name=imported.resolved_name,
+            error=error,
+            lineno=imported.location.lineno,
+            col=imported.location.col,
+            end_lineno=imported.location.end_lineno,
+            end_col=imported.location.end_col,
+        )
 
 
 class UnusedImportsChecker(ProjectChecker):

--- a/src/robocop/linter/rules/arguments.py
+++ b/src/robocop/linter/rules/arguments.py
@@ -354,7 +354,7 @@ class InvalidArgumentCountRule(Rule):
     message = "Keyword '{keyword_name}' expects {expected} but {provided} provided{missing}"
     severity = RuleSeverity.ERROR
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )

--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -312,7 +312,7 @@ class DuplicatedVariableInProjectRule(Rule):
     message = "Variable '{name}' is also defined in '{first_source}' (line {first_occurrence_line})"
     severity = RuleSeverity.WARNING
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )

--- a/src/robocop/linter/rules/imports.py
+++ b/src/robocop/linter/rules/imports.py
@@ -194,7 +194,7 @@ class UnresolvedResourceImportRule(Rule):
     message = "Imported resource file '{import_name}' does not exist"
     severity = RuleSeverity.WARNING
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
@@ -234,7 +234,7 @@ class UnusedResourceImportRule(Rule):
     message = "Imported resource file '{import_name}' is not used"
     severity = RuleSeverity.INFO
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
@@ -281,7 +281,7 @@ class UnusedLibraryImportRule(Rule):
     message = "Imported library '{import_name}' is not used"
     severity = RuleSeverity.INFO
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
@@ -320,7 +320,53 @@ class CircularImportRule(Rule):
     message = "Circular import: {cycle}"
     severity = RuleSeverity.WARNING
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.MODULAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+
+
+class UnresolvedLibraryImportRule(Rule):
+    """
+    Imported library could not be imported.
+
+    Reports library imports that Robot Framework would not be able to import during the execution.
+
+    Example of rule violation:
+
+        *** Settings ***
+        Library    libs/does_not_exist.py  # file is not found next to the importing file
+        Library    NotInstalledLibrary  # module is not installed and is not found in the search paths
+
+    Library imports pointing to a file are always validated. Imports using a module name are only validated when
+    Robocop imports the libraries, which it does by default and which can be disabled with the
+    ``--no-analyze-libraries`` option::
+
+        robocop check --no-analyze-libraries
+
+    Extra directories with the libraries can be provided with the ``--pythonpath`` option::
+
+        robocop check --pythonpath libs
+
+    Following imports are never reported, since it is not known if they can be imported:
+
+    - imports with a name or arguments containing a variable that cannot be resolved,
+    - libraries excluded from the analysis with the ``--ignored-library`` option,
+    - the ``Remote`` library, which connects to the remote server already during the import.
+
+    Libraries that require a running service or a special environment can be excluded from the analysis::
+
+        robocop check --ignored-library CustomServiceLibrary
+
+    """
+
+    name = "unresolved-library-import"
+    project_rule = True
+    rule_id = "IMP09"
+    message = "Imported library '{import_name}' could not be imported: {error}"
+    severity = RuleSeverity.WARNING
+    enabled = False
+    added_in_version = "9.0.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -90,7 +90,7 @@ class KeywordNotFoundRule(Rule):
     message = "Keyword '{keyword_name}' not found"
     severity = RuleSeverity.ERROR
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
@@ -132,7 +132,7 @@ class AmbiguousKeywordNameRule(Rule):
     message = "Keyword '{keyword_name}' matches keywords from multiple sources: {sources}"
     severity = RuleSeverity.WARNING
     enabled = False
-    added_in_version = "8.9.0"
+    added_in_version = "9.0.0"
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )

--- a/tests/linter/rules/imports/unresolved_library_import/expected_extended.txt
+++ b/tests/linter/rules/imports/unresolved_library_import/expected_extended.txt
@@ -1,0 +1,21 @@
+test.robot:4:13 IMP09 Imported library 'libs/missing.py' could not be imported: File does not exist
+   |
+ 2 | Library     Collections
+ 3 | Library     libs/MyLibrary.py
+ 4 | Library     libs/missing.py
+   |             ^^^^^^^^^^^^^^^ IMP09
+ 5 | Library     NotInstalledLibrary
+ 6 | Library     ${LIB_DIR}/MyLibrary.py
+   |
+
+test.robot:5:13 IMP09 Imported library 'NotInstalledLibrary' could not be imported: ModuleNotFoundError: No module named 'NotInstalledLibrary'
+   |
+ 3 | Library     libs/MyLibrary.py
+ 4 | Library     libs/missing.py
+ 5 | Library     NotInstalledLibrary
+   |             ^^^^^^^^^^^^^^^^^^^ IMP09
+ 6 | Library     ${LIB_DIR}/MyLibrary.py
+ 7 | Library     ${UNDEFINED_DIR}/other.py
+   |
+
+Found 2 issues.

--- a/tests/linter/rules/imports/unresolved_library_import/expected_output.txt
+++ b/tests/linter/rules/imports/unresolved_library_import/expected_output.txt
@@ -1,0 +1,4 @@
+test.robot:4:13 [W] IMP09 Imported library 'libs/missing.py' could not be imported: File does not exist
+test.robot:5:13 [W] IMP09 Imported library 'NotInstalledLibrary' could not be imported: ModuleNotFoundError: No module named 'NotInstalledLibrary'
+
+Found 2 issues.

--- a/tests/linter/rules/imports/unresolved_library_import/expected_output_not_imported.txt
+++ b/tests/linter/rules/imports/unresolved_library_import/expected_output_not_imported.txt
@@ -1,0 +1,3 @@
+test.robot:4:13 [W] IMP09 Imported library 'libs/missing.py' could not be imported: File does not exist
+
+Found 1 issue.

--- a/tests/linter/rules/imports/unresolved_library_import/libs/MyLibrary.py
+++ b/tests/linter/rules/imports/unresolved_library_import/libs/MyLibrary.py
@@ -1,0 +1,5 @@
+"""Library used to test that existing library imports are not reported."""
+
+
+def my_keyword():
+    pass

--- a/tests/linter/rules/imports/unresolved_library_import/test.robot
+++ b/tests/linter/rules/imports/unresolved_library_import/test.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Library     Collections
+Library     libs/MyLibrary.py
+Library     libs/missing.py
+Library     NotInstalledLibrary
+Library     ${LIB_DIR}/MyLibrary.py
+Library     ${UNDEFINED_DIR}/other.py
+Library     Remote    http://127.0.0.1:9999
+
+*** Variables ***
+${LIB_DIR}      libs
+
+*** Test Cases ***
+Test
+    My Keyword

--- a/tests/linter/rules/imports/unresolved_library_import/test_rule.py
+++ b/tests/linter/rules/imports/unresolved_library_import/test_rule.py
@@ -1,0 +1,30 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+
+    def test_libraries_not_imported(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_output_not_imported.txt",
+            analyze_libraries=False,
+            project_check=True,
+        )
+
+    def test_ignored_library(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_output_not_imported.txt",
+            ignored_library=["NotInstalled*"],
+            project_check=True,
+        )
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )


### PR DESCRIPTION
Adds `unresolved-library-import` (`IMP09`), a project rule reporting library imports that Robot Framework would not be able to import.

Two cases are reported:

- path based import pointing to a file that does not exist - detected statically, works also with `--no-analyze-libraries`,
- module based import that fails to be imported - the error returned by the import is included in the message, for example `ModuleNotFoundError: No module named ''SeleniumLibrary''`.

Never reported, to avoid false positives:

- imports with a name or arguments containing a variable that cannot be resolved,
- libraries excluded with `--ignored-library`,
- the `Remote` library, which connects to the remote server already during the import.

The reported error is stripped of the `Importing library ''X'' failed:` prefix, which duplicates the rule message. The remaining text comes from Python and is identical on RF 5.0 - 7.4.

### Additional fix

The project rules merged for the upcoming release declared `added_in_version = "8.9.0"`, but the release is a major one (`9.0.0`, see the release-please PR #1811) because `check-project` was removed. All of them are corrected to `9.0.0`.

### Validation

- `uv run ruff format .`, `uv run ruff check .` - clean
- `uv run mypy --config-file=pyproject.toml .\src\robocop\` - 7 pre-existing errors, no new ones
- `uv run pytest tests -q` - 2053 passed, 77 skipped