### PR TITLE
feat!: cache project analysis data between runs

### DIFF
--- a/docs/user_guide/intro.md
+++ b/docs/user_guide/intro.md
@@ -131,6 +131,11 @@ Keywords of the libraries imported during the [project checks](../linter/linter.
 well. Such library is not imported again as long as its source file, the Python interpreter and the Robot Framework
 version stay the same. Libraries that are a part of the analyzed project are always imported again.
 
+[Project checks](../linter/linter.md#project-checks) parse every file in the project. Keyword definitions, keyword
+calls, variables and imports found in a file are cached too, so the next run only parses the files that were modified
+since the last run. This part of the cache is invalidated when the file changes, and also when the ``--language``
+option or the Robot Framework version is different.
+
 ## Values
 
 Original *RoboCop* - a fictional cybernetic police officer - was the following three prime directives

--- a/src/robocop/cache.py
+++ b/src/robocop/cache.py
@@ -237,6 +237,45 @@ class LibraryCacheEntry:
         )
 
 
+@dataclass(frozen=True)
+class ProjectCacheEntry:
+    """Immutable cache entry with the data collected from a single source file."""
+
+    metadata: FileMetadata
+    config_hash: str
+    collected: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary representation of the project cache entry.
+
+        """
+        return {
+            "mtime": self.metadata.mtime,
+            "size": self.metadata.size,
+            "config_hash": self.config_hash,
+            "collected": self.collected,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProjectCacheEntry:
+        """
+        Create from dictionary loaded from cache.
+
+        Returns:
+            ProjectCacheEntry: The project cache entry object.
+
+        """
+        return cls(
+            metadata=FileMetadata(mtime=data["mtime"], size=data["size"]),
+            config_hash=data["config_hash"],
+            collected=data["collected"],
+        )
+
+
 @dataclass
 class CacheData:
     """Mutable container for cache data."""
@@ -245,6 +284,7 @@ class CacheData:
     linter: dict[str, LinterCacheEntry] = field(default_factory=dict)
     formatter: dict[str, FormatterCacheEntry] = field(default_factory=dict)
     libraries: dict[str, LibraryCacheEntry] = field(default_factory=dict)
+    project: dict[str, ProjectCacheEntry] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -259,6 +299,7 @@ class CacheData:
             "linter": {path: entry.to_dict() for path, entry in self.linter.items()},
             "formatter": {path: entry.to_dict() for path, entry in self.formatter.items()},
             "libraries": {key: entry.to_dict() for key, entry in self.libraries.items()},
+            "project": {path: entry.to_dict() for path, entry in self.project.items()},
         }
 
     @classmethod
@@ -275,6 +316,7 @@ class CacheData:
             linter={path: LinterCacheEntry.from_dict(entry) for path, entry in data.get("linter", {}).items()},
             formatter={path: FormatterCacheEntry.from_dict(entry) for path, entry in data.get("formatter", {}).items()},
             libraries={key: LibraryCacheEntry.from_dict(entry) for key, entry in data.get("libraries", {}).items()},
+            project={path: ProjectCacheEntry.from_dict(entry) for path, entry in data.get("project", {}).items()},
         )
 
 
@@ -596,6 +638,55 @@ class RobocopCache:
             environment_hash=environment_hash,
             source=str(source),
             response=response,
+        )
+        self._dirty = True
+
+    # Project cache methods
+
+    def get_project_entry(self, path: Path, config_hash: str) -> dict[str, Any] | None:
+        """
+        Get the data collected from the source file if it is still valid.
+
+        Args:
+            path: Absolute path to the source file.
+            config_hash: Hash of the configuration that affects parsing and collecting.
+
+        Returns:
+            Cached collected data if valid, None otherwise.
+
+        """
+        if not self.enabled:
+            return None
+        str_path = self._normalize_path(path)
+        entry = self.data.project.get(str_path)
+        if entry is None:
+            return None
+        if not self._is_entry_valid(path, entry.metadata, config_hash, entry.config_hash):
+            del self.data.project[str_path]
+            self._dirty = True
+            return None
+        return entry.collected
+
+    def set_project_entry(self, path: Path, config_hash: str, collected: dict[str, Any]) -> None:
+        """
+        Store the data collected from the source file in the cache.
+
+        Args:
+            path: Absolute path to the source file.
+            config_hash: Hash of the configuration that affects parsing and collecting.
+            collected: Serialized data collected from the file.
+
+        """
+        if not self.enabled:
+            return
+        try:
+            metadata = FileMetadata.from_path(path)
+        except OSError:
+            return
+        self.data.project[self._normalize_path(path)] = ProjectCacheEntry(
+            metadata=metadata,
+            config_hash=config_hash,
+            collected=collected,
         )
         self._dirty = True
 

--- a/src/robocop/project/collector.py
+++ b/src/robocop/project/collector.py
@@ -50,7 +50,6 @@ class RawImport:
     import_type: ImportType
     name: str
     location: Location
-    node: Statement
     args: tuple[str, ...] = ()
     """Arguments of the ``Library`` import."""
     alias: str | None = None
@@ -131,7 +130,6 @@ class ProjectFileCollector(ModelVisitor):  # type: ignore[misc]
                 name=node.name,
                 normalized_name=normalize_robot_name(node.name),
                 location=self._location(node.header, name_length=len(node.name)),
-                node=node,
                 arguments=self._keyword_arguments(node),
                 embedded=embedded.name if embedded is not None else None,
                 is_private=self._is_private(node),
@@ -188,7 +186,6 @@ class ProjectFileCollector(ModelVisitor):  # type: ignore[misc]
                 import_type=import_type,
                 name=name_token.value,
                 location=location,
-                node=node,
                 args=tuple(getattr(node, "args", ()) or ()),
                 alias=getattr(node, "alias", None),
             )

--- a/src/robocop/project/context.py
+++ b/src/robocop/project/context.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
-    from robot.conf import Languages
+    from robot.api import Languages  # RF 6.0
 
     from robocop.cache import RobocopCache
     from robocop.config.manager import ConfigManager

--- a/src/robocop/project/context.py
+++ b/src/robocop/project/context.py
@@ -8,6 +8,7 @@ files in the project together with keyword definitions, keyword usages, variable
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from robot.errors import DataError
@@ -17,7 +18,9 @@ from robocop.project.collector import ProjectFileCollector
 from robocop.project.definitions import ImportStatus, ImportType, KeywordDefinition
 from robocop.project.imports import ImportResolver, build_search_paths
 from robocop.project.libraries import LibraryRequest, build_library_loader
+from robocop.project.serialization import collected_file_from_dict, collected_file_to_dict
 from robocop.project.variables import VariableScope
+from robocop.version_handling import ROBOT_VERSION
 
 BUILTIN_LIBRARY = LibraryRequest(name="BuiltIn")
 """BuiltIn library is always available, without being imported."""
@@ -26,6 +29,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
+    from robot.conf import Languages
+
+    from robocop.cache import RobocopCache
     from robocop.config.manager import ConfigManager
     from robocop.project.collector import CollectedFile
     from robocop.project.definitions import KeywordUsage, ResolvedImport, VariableDefinition
@@ -308,6 +314,46 @@ class ProjectContext:
                 yield project_file, imported
 
 
+def collection_hash(languages: Languages | None) -> str:
+    """
+    Describe the configuration that affects parsing and collecting data from a source file.
+
+    Only the language and the Robot Framework version change what is collected. Options such as selected rules or
+    command line variables are applied later, on the already collected data.
+
+    Returns:
+        Hash used to invalidate the cached data collected from the source files.
+
+    """
+    codes = ":".join(sorted(str(getattr(language, "code", language)) for language in languages or []))
+    return sha256(f"{codes}|{ROBOT_VERSION}".encode()).hexdigest()
+
+
+def collect_file(source_file: SourceFile, cache: RobocopCache | None, config_hash: str) -> CollectedFile:
+    """
+    Collect keywords, usages, variables and imports from a single source file.
+
+    The result is stored in the cache, so that the file does not have to be parsed again in the next run.
+
+    Raises:
+        DataError: If the file cannot be parsed.
+
+    Returns:
+        CollectedFile with everything found in the file.
+
+    """
+    if cache is not None:
+        cached = cache.get_project_entry(source_file.path, config_hash)
+        if cached is not None:
+            collected = collected_file_from_dict(cached, source_file.path)
+            if collected is not None:
+                return collected
+    collected = ProjectFileCollector(source_file.path).collect(source_file.model)
+    if cache is not None:
+        cache.set_project_entry(source_file.path, config_hash, collected_file_to_dict(collected))
+    return collected
+
+
 def build_project_context(config_manager: ConfigManager, silent: bool = False) -> ProjectContext:
     """
     Parse all source files in the project and build the shared context.
@@ -322,26 +368,27 @@ def build_project_context(config_manager: ConfigManager, silent: bool = False) -
     context = ProjectContext(root=config_manager.root)
     config = config_manager.default_config
     search_paths = build_search_paths(config.python_path, config_manager.root)
+    cache = config_manager.cache if config.cache.enabled else None
     if config.analyze_libraries:
         context.library_loader = build_library_loader(
             search_paths=search_paths,
             timeout=config.load_library_timeout,
             ignored_libraries=config.ignored_libraries,
-            cache=config_manager.cache if config.cache.enabled else None,
+            cache=cache,
             project_root=config_manager.root,
         )
     global_scope = VariableScope()
     global_scope.add_variable_files(config.variable_files, search_paths)
     global_scope.add_command_line(config.variables)
+    config_hash = collection_hash(config.languages)
 
     for source_file in config_manager.project_paths:
         try:
-            model = source_file.model
+            collected = collect_file(source_file, cache, config_hash)
         except DataError as error:
             if not silent:
                 print(f"Failed to parse {source_file.path} with an error: {error}. Skipping file")
             continue
-        collected = ProjectFileCollector(source_file.path).collect(model)
         context.files[source_file.path.resolve()] = ProjectFile(source_file=source_file, collected=collected)
 
     for project_file in context.files.values():

--- a/src/robocop/project/definitions.py
+++ b/src/robocop/project/definitions.py
@@ -18,9 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from robot.parsing.model.blocks import Keyword
-    from robot.parsing.model.statements import LibraryImport, ResourceImport, Statement, VariablesImport
-
 
 def parse_embedded_arguments(name: str) -> EmbeddedArguments | None:
     """
@@ -249,7 +246,6 @@ class KeywordDefinition:
     name: str
     normalized_name: str
     location: Location
-    node: Keyword | None = None
     arguments: ArgumentsSpec = field(default_factory=ArgumentsSpec)
     embedded: re.Pattern[str] | None = None
     is_private: bool = False
@@ -370,7 +366,6 @@ class ResolvedImport:
     status: ImportStatus
     location: Location
     path: Path | None = None
-    node: LibraryImport | ResourceImport | VariablesImport | Statement | None = None
     error: str | None = None
     args: tuple[str, ...] = ()
     """Arguments of the ``Library`` import, with variables resolved."""

--- a/src/robocop/project/serialization.py
+++ b/src/robocop/project/serialization.py
@@ -1,0 +1,211 @@
+"""
+Serialization of the data collected from a single source file.
+
+The data is stored in the cache between the runs, so that the project context does not have to parse every file
+again when nothing changed. Only plain types are used, so that the result can be stored with ``msgpack``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from robocop.project.collector import CollectedFile, RawImport
+from robocop.project.definitions import (
+    ArgumentsSpec,
+    ImportType,
+    KeywordDefinition,
+    KeywordUsage,
+    Location,
+    VariableDefinition,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+SERIALIZATION_VERSION = 1
+"""Version of the format used to store the collected data. Bump it whenever the format changes."""
+
+
+def _location_to_dict(location: Location) -> dict[str, Any]:
+    return {
+        "lineno": location.lineno,
+        "col": location.col,
+        "end_lineno": location.end_lineno,
+        "end_col": location.end_col,
+    }
+
+
+def _location_from_dict(data: dict[str, Any], source: Path) -> Location:
+    return Location(
+        source=source,
+        lineno=data["lineno"],
+        col=data["col"],
+        end_lineno=data["end_lineno"],
+        end_col=data["end_col"],
+    )
+
+
+def _arguments_to_dict(arguments: ArgumentsSpec) -> dict[str, Any]:
+    return {
+        "positional": list(arguments.positional),
+        "defaults": sorted(arguments.defaults),
+        "var_positional": arguments.var_positional,
+        "var_named": arguments.var_named,
+        "named_only": list(arguments.named_only),
+    }
+
+
+def _arguments_from_dict(data: dict[str, Any]) -> ArgumentsSpec:
+    return ArgumentsSpec(
+        positional=tuple(data["positional"]),
+        defaults=frozenset(data["defaults"]),
+        var_positional=data["var_positional"],
+        var_named=data["var_named"],
+        named_only=tuple(data["named_only"]),
+    )
+
+
+def _keyword_to_dict(keyword: KeywordDefinition) -> dict[str, Any]:
+    return {
+        "name": keyword.name,
+        "normalized_name": keyword.normalized_name,
+        "location": _location_to_dict(keyword.location),
+        "arguments": _arguments_to_dict(keyword.arguments),
+        "embedded": {"pattern": keyword.embedded.pattern, "flags": keyword.embedded.flags}
+        if keyword.embedded is not None
+        else None,
+        "is_private": keyword.is_private,
+        "library_name": keyword.library_name,
+    }
+
+
+def _keyword_from_dict(data: dict[str, Any], source: Path) -> KeywordDefinition:
+    embedded = data["embedded"]
+    return KeywordDefinition(
+        name=data["name"],
+        normalized_name=data["normalized_name"],
+        location=_location_from_dict(data["location"], source),
+        arguments=_arguments_from_dict(data["arguments"]),
+        embedded=re.compile(embedded["pattern"], embedded["flags"]) if embedded is not None else None,
+        is_private=data["is_private"],
+        library_name=data["library_name"],
+    )
+
+
+def _usage_to_dict(usage: KeywordUsage) -> dict[str, Any]:
+    return {
+        "name": usage.name,
+        "normalized_name": usage.normalized_name,
+        "location": _location_to_dict(usage.location),
+        "arguments": list(usage.arguments),
+        "name_contains_variable": usage.name_contains_variable,
+        "bdd_prefix": usage.bdd_prefix,
+        "is_template": usage.is_template,
+    }
+
+
+def _usage_from_dict(data: dict[str, Any], source: Path) -> KeywordUsage:
+    return KeywordUsage(
+        name=data["name"],
+        normalized_name=data["normalized_name"],
+        location=_location_from_dict(data["location"], source),
+        arguments=tuple(data["arguments"]),
+        name_contains_variable=data["name_contains_variable"],
+        bdd_prefix=data["bdd_prefix"],
+        is_template=data["is_template"],
+    )
+
+
+def _variable_to_dict(variable: VariableDefinition) -> dict[str, Any]:
+    return {
+        "name": variable.name,
+        "normalized_name": variable.normalized_name,
+        "value": variable.value,
+        "location": _location_to_dict(variable.location) if variable.location is not None else None,
+    }
+
+
+def _variable_from_dict(data: dict[str, Any], source: Path) -> VariableDefinition:
+    location = data["location"]
+    return VariableDefinition(
+        name=data["name"],
+        normalized_name=data["normalized_name"],
+        value=data["value"],
+        location=_location_from_dict(location, source) if location is not None else None,
+    )
+
+
+def _import_to_dict(raw_import: RawImport) -> dict[str, Any]:
+    return {
+        "import_type": raw_import.import_type.value,
+        "name": raw_import.name,
+        "location": _location_to_dict(raw_import.location),
+        "args": list(raw_import.args),
+        "alias": raw_import.alias,
+    }
+
+
+def _import_from_dict(data: dict[str, Any], source: Path) -> RawImport:
+    return RawImport(
+        import_type=ImportType(data["import_type"]),
+        name=data["name"],
+        location=_location_from_dict(data["location"], source),
+        args=tuple(data["args"]),
+        alias=data["alias"],
+    )
+
+
+def collected_file_to_dict(collected: CollectedFile) -> dict[str, Any]:
+    """
+    Convert data collected from a single file into plain types.
+
+    The path of the file is not stored, since it is already the key of the cache entry. Locations are stored
+    without the source path for the same reason.
+
+    Returns:
+        Dictionary that can be stored in the cache.
+
+    """
+    return {
+        "version": SERIALIZATION_VERSION,
+        "is_suite": collected.is_suite,
+        "is_init_file": collected.is_init_file,
+        "keywords": [_keyword_to_dict(keyword) for keyword in collected.keywords],
+        "usages": [_usage_to_dict(usage) for usage in collected.usages],
+        "variables": [_variable_to_dict(variable) for variable in collected.variables],
+        "used_variables": sorted(collected.used_variables),
+        "imports": [_import_to_dict(raw_import) for raw_import in collected.imports],
+    }
+
+
+def _restore_all(
+    data: dict[str, Any], key: str, restore: Callable[[dict[str, Any], Path], Any], source: Path
+) -> list[Any]:
+    return [restore(item, source) for item in data[key]]
+
+
+def collected_file_from_dict(data: dict[str, Any], path: Path) -> CollectedFile | None:
+    """
+    Restore data collected from a single file.
+
+    Returns:
+        CollectedFile, or None if the stored data was saved in a different format and cannot be restored.
+
+    """
+    if data.get("version") != SERIALIZATION_VERSION:
+        return None
+    try:
+        return CollectedFile(
+            path=path,
+            is_suite=data["is_suite"],
+            is_init_file=data["is_init_file"],
+            keywords=_restore_all(data, "keywords", _keyword_from_dict, path),
+            usages=_restore_all(data, "usages", _usage_from_dict, path),
+            variables=_restore_all(data, "variables", _variable_from_dict, path),
+            used_variables=set(data["used_variables"]),
+            imports=_restore_all(data, "imports", _import_from_dict, path),
+        )
+    except (KeyError, TypeError, ValueError, re.error):  # pragma: no cover - defensive, corrupted cache
+        return None

--- a/tests/project/test_project_cache.py
+++ b/tests/project/test_project_cache.py
@@ -1,0 +1,175 @@
+import os
+import time
+
+import pytest
+
+from robocop.config.manager import ConfigManager
+from robocop.config.schema import RawCacheConfig, RawConfig
+from robocop.project.collector import ProjectFileCollector
+from robocop.project.context import build_project_context, collection_hash
+from robocop.project.serialization import collected_file_from_dict, collected_file_to_dict
+
+
+@pytest.fixture
+def project(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "common.resource").write_text(
+        "*** Keywords ***\n"
+        "Common Keyword\n"
+        "    [Arguments]    ${a}    ${b}=2\n"
+        "    Log    ${a}\n"
+        "\n"
+        "Login As ${user}\n"
+        "    Log    ${user}\n"
+        "\n"
+        "Private Keyword\n"
+        "    [Tags]    robot:private\n"
+        "    Log    private\n"
+    )
+    (source / "test.robot").write_text(
+        "*** Settings ***\n"
+        "Resource    common.resource\n"
+        "Library     Collections    AS    Col\n"
+        "\n"
+        "*** Variables ***\n"
+        "${GREETING}     hello\n"
+        "\n"
+        "*** Test Cases ***\n"
+        "Test\n"
+        "    [Setup]    Common Keyword    1\n"
+        "    Login As bob\n"
+        "    Log    ${GREETING}\n"
+    )
+    return source
+
+
+def build_context(project, cache_dir, enabled=True, **config):
+    config_manager = ConfigManager(
+        sources=[str(project)],
+        root=project,
+        ignore_file_config=True,
+        overwrite_config=RawConfig(cache=RawCacheConfig(enabled=enabled, cache_dir=cache_dir), **config),
+    )
+    context = build_project_context(config_manager, silent=True)
+    config_manager.cache.save()
+    return context
+
+
+def count_collected(project, cache_dir, **config):
+    """
+    Build the context and count how many files had to be collected instead of being read from the cache.
+
+    Returns:
+        Number of files parsed and collected during the run.
+
+    """
+    collected = 0
+    original = ProjectFileCollector.collect
+
+    def counting_collect(self, model):
+        nonlocal collected
+        collected += 1
+        return original(self, model)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(ProjectFileCollector, "collect", counting_collect)
+        build_context(project, cache_dir, **config)
+    return collected
+
+
+def describe(context):
+    """Describe the collected data in a way that can be compared between the runs."""
+    described = {}
+    for path, project_file in sorted(context.files.items()):
+        described[path.name] = {
+            "is_suite": project_file.is_suite,
+            "keywords": [
+                (
+                    keyword.name,
+                    keyword.location.lineno,
+                    keyword.location.col,
+                    keyword.is_private,
+                    keyword.has_embedded_arguments,
+                    keyword.arguments.describe_accepted(),
+                )
+                for keyword in project_file.keywords
+            ],
+            "usages": [
+                (usage.name, usage.location.lineno, usage.arguments, usage.is_template) for usage in project_file.usages
+            ],
+            "variables": [(variable.name, variable.value) for variable in project_file.variables],
+            "used_variables": sorted(project_file.used_variables),
+            "imports": [
+                (imported.import_type.value, imported.resolved_name, imported.status.value, imported.alias)
+                for imported in project_file.imports
+            ],
+        }
+    return described
+
+
+class TestProjectCache:
+    def test_collected_data_is_stored_in_cache(self, project, tmp_path):
+        assert count_collected(project, tmp_path / "cache") == 2
+        assert count_collected(project, tmp_path / "cache") == 0
+
+    def test_files_are_not_parsed_again_in_next_run(self, project, tmp_path, monkeypatch):
+        expected = describe(build_context(project, tmp_path / "cache"))
+
+        monkeypatch.setattr(
+            ProjectFileCollector,
+            "collect",
+            lambda *args, **kwargs: pytest.fail("File should be read from the cache"),  # noqa: ARG005
+        )
+        assert describe(build_context(project, tmp_path / "cache")) == expected
+
+    def test_modified_file_is_collected_again(self, project, tmp_path):
+        build_context(project, tmp_path / "cache")
+
+        test_file = project / "test.robot"
+        test_file.write_text("*** Keywords ***\nOther Keyword\n    Log    a\n")
+        os.utime(test_file, (time.time() + 10, time.time() + 10))
+
+        context = build_context(project, tmp_path / "cache")
+        assert [keyword.name for keyword in context.get_file(test_file).keywords] == ["Other Keyword"]
+
+    def test_cache_is_not_used_when_language_changes(self, project, tmp_path):
+        build_context(project, tmp_path / "cache")
+        collected = count_collected(project, tmp_path / "cache", language=["pl"])
+        assert collected == 2
+
+    def test_nothing_is_stored_when_cache_is_disabled(self, project, tmp_path):
+        config_manager = ConfigManager(
+            sources=[str(project)],
+            root=project,
+            ignore_file_config=True,
+            overwrite_config=RawConfig(cache=RawCacheConfig(enabled=False, cache_dir=tmp_path / "cache")),
+        )
+        build_project_context(config_manager, silent=True)
+        assert not config_manager.cache.data.project
+
+    def test_embedded_keyword_still_matches_after_restoring(self, project, tmp_path):
+        build_context(project, tmp_path / "cache")
+        context = build_context(project, tmp_path / "cache")
+        assert context.visible_keywords(project / "test.robot").find("login as ANNE")
+
+
+class TestCollectionHash:
+    def test_same_configuration_gives_same_hash(self):
+        assert collection_hash(None) == collection_hash(None)
+
+    def test_language_changes_the_hash(self):
+        from robot.conf import Languages  # noqa: PLC0415
+
+        assert collection_hash(None) != collection_hash(Languages(["pl"]))
+
+
+class TestSerialization:
+    def test_round_trip_keeps_collected_data(self, project, tmp_path):
+        context = build_context(project, tmp_path / "cache", enabled=False)
+        for path, project_file in context.files.items():
+            restored = collected_file_from_dict(collected_file_to_dict(project_file.collected), path)
+            assert restored == project_file.collected
+
+    def test_unknown_format_is_ignored(self, tmp_path):
+        assert collected_file_from_dict({"version": -1}, tmp_path) is None

--- a/tests/project/test_project_cache.py
+++ b/tests/project/test_project_cache.py
@@ -4,10 +4,17 @@ import time
 import pytest
 
 from robocop.config.manager import ConfigManager
+from robocop.config.parser import load_languages
 from robocop.config.schema import RawCacheConfig, RawConfig
 from robocop.project.collector import ProjectFileCollector
 from robocop.project.context import build_project_context, collection_hash
 from robocop.project.serialization import collected_file_from_dict, collected_file_to_dict
+from robocop.version_handling import ROBOT_VERSION, Version
+
+pytestmark_languages = pytest.mark.skipif(
+    ROBOT_VERSION < Version("6.0"),  # noqa: SIM300
+    reason="Languages are supported since RF 6.0",
+)
 
 
 @pytest.fixture
@@ -133,6 +140,7 @@ class TestProjectCache:
         context = build_context(project, tmp_path / "cache")
         assert [keyword.name for keyword in context.get_file(test_file).keywords] == ["Other Keyword"]
 
+    @pytestmark_languages
     def test_cache_is_not_used_when_language_changes(self, project, tmp_path):
         build_context(project, tmp_path / "cache")
         collected = count_collected(project, tmp_path / "cache", language=["pl"])
@@ -158,10 +166,9 @@ class TestCollectionHash:
     def test_same_configuration_gives_same_hash(self):
         assert collection_hash(None) == collection_hash(None)
 
+    @pytestmark_languages
     def test_language_changes_the_hash(self):
-        from robot.conf import Languages  # noqa: PLC0415
-
-        assert collection_hash(None) != collection_hash(Languages(["pl"]))
+        assert collection_hash(None) != collection_hash(load_languages(["pl"]))
 
 
 class TestSerialization:


### PR DESCRIPTION
Project checks parse every file in the project, which is the slowest part of the run. This PR stores everything collected from a source file - keyword definitions, keyword calls, variables and imports - in the existing `.robocop_cache`, so that unmodified files are not parsed again.

Measured on ~800 files from `tests/linter/rules` (`--select unused-keyword --select circular-import --no-analyze-libraries`):

| run | time |
| --- | --- |
| cold cache | 4.92 s |
| warm cache | 2.27 s |

Output of both runs is identical.

### How it works

- `robocop.project.serialization` converts `CollectedFile` to and from plain types that `msgpack` can store. The format has its own `SERIALIZATION_VERSION`, so an old entry is ignored instead of failing.
- A new `project` section in `RobocopCache` is keyed by resolved path and validated with mtime + size, exactly like the linter and formatter sections.
- The config hash covers only what changes the collected data: the `--language` option and the Robot Framework version. Selected rules and command line variables are applied later, on the already collected data, so changing them does not invalidate the entries.

The compiled pattern of embedded arguments is stored with its flags. Recompiling from the pattern alone would drop `re.IGNORECASE` and silently make embedded keyword matching case sensitive after a cache hit - there is a test covering it.

### Breaking change

`KeywordDefinition.node` and `ResolvedImport.node` are removed. They held the Robot Framework AST node, which cannot be serialized. Neither was read anywhere in Robocop - `ResolvedImport.node` was never even assigned. Custom project rules should use the `location` attribute, which is what `report()` needs anyway.

### Validation

- `uv run ruff format .`, `uv run ruff check .` - clean
- `uv run mypy --config-file=pyproject.toml .\src\robocop\` - 7 pre-existing errors, no new ones
- `uv run pytest tests -q` - 2063 passed, 77 skipped (10 new tests in `tests/project/test_project_cache.py`)