### PR TITLE
feat: select all project rules with PROJECT keyword

### DIFF
--- a/docs/configuration/configuration_reference.md
+++ b/docs/configuration/configuration_reference.md
@@ -614,6 +614,24 @@ option to select all rules except those you want to ignore:
     ]
     ```
 
+Use ``PROJECT`` keyword to select all [project level rules](../linter/linter.md#project-checks). It works with
+``--select``, ``--extend-select`` and ``--ignore``:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --extend-select PROJECT
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    extend-select = [
+        "PROJECT"
+    ]
+    ```
+
 ---
 
 #### ``extend select``

--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -144,6 +144,17 @@ Project rules are marked with the ``[project]`` tag in the [rules list](../rules
 robocop list rules --filter PROJECT
 ```
 
+All of them can be enabled at once with the special ``PROJECT`` value, which can be used with ``--select``,
+``--extend-select`` and ``--ignore``:
+
+```bash
+robocop check --select PROJECT  # run only the project level rules
+robocop check --extend-select PROJECT  # run the default rules and all project level rules
+robocop check --select ALL --ignore PROJECT  # run every rule except the project level ones
+```
+
+``--select ALL`` enables the project rules as well, since it selects every rule.
+
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the
 imports can be resolved:
 

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -40,6 +40,13 @@ class RulePattern(NamedTuple):
     name: str
 
 
+ALL_RULES = "ALL"
+"""Special value of ``--select`` that matches every rule."""
+
+PROJECT_RULES = "PROJECT"
+"""Special value of the rule filters that matches every project level rule."""
+
+
 @dataclass
 class RuleFilter:
     """Encapsulates a set of rules with both exact matches and patterns."""
@@ -56,13 +63,22 @@ class RuleFilter:
         )
 
     def matches(self, rule: Rule) -> bool:
-        """Check if the rule matches any filter and track the match."""
+        """
+        Check if the rule matches any filter and track the match.
+
+        Returns:
+            True if the rule matches the filter.
+
+        """
         # Check exact matches
         if rule.rule_id in self.exact_matches:
             self.matched.add(rule.rule_id)
             return True
         if rule.name in self.exact_matches:
             self.matched.add(rule.name)
+            return True
+        if rule.project_rule and PROJECT_RULES in self.exact_matches:
+            self.matched.add(PROJECT_RULES)
             return True
 
         # Check patterns
@@ -77,7 +93,7 @@ class RuleFilter:
         return not self.exact_matches and not self.patterns
 
     def has_all(self) -> bool:
-        return "ALL" in self.exact_matches
+        return ALL_RULES in self.exact_matches
 
 
 class RuleMatcher:
@@ -113,7 +129,7 @@ class RuleMatcher:
             return False
 
         if self.select_filter.has_all():
-            self.select_filter.matched.add("ALL")
+            self.select_filter.matched.add(ALL_RULES)
             return True
 
         # extend-select takes priority

--- a/tests/linter/test_rule_matcher.py
+++ b/tests/linter/test_rule_matcher.py
@@ -41,6 +41,15 @@ def get_disabled_rule(rule_id: str) -> CustomRule:
     return custom_rule
 
 
+def get_project_rule(rule_id: str) -> CustomRule:
+    custom_rule = CustomRule()
+    custom_rule.rule_id = rule_id
+    custom_rule.name = f"some-message-{rule_id}"
+    custom_rule.enabled = False
+    custom_rule.project_rule = True
+    return custom_rule
+
+
 def get_fixable_message_with_id(rule_id: str) -> CustomFixableRule:
     custom_rule = CustomFixableRule()
     custom_rule.rule_id = rule_id
@@ -227,6 +236,64 @@ class TestRuleMatcher:
         assert rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
         assert rule_matcher.is_rule_enabled(get_enabled_rule("0102"))
         assert not rule_matcher.is_rule_enabled(get_enabled_rule("0103"))
+
+    def test_project_token_selects_project_rules(self):
+        rule_matcher = RuleMatcher(
+            select=["PROJECT"],
+            extend_select=[],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert rule_matcher.is_rule_enabled(get_project_rule("0201"))
+        assert not rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
+
+    def test_project_token_extends_selection(self):
+        rule_matcher = RuleMatcher(
+            select=["0101"],
+            extend_select=["PROJECT"],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
+        assert rule_matcher.is_rule_enabled(get_project_rule("0201"))
+        assert not rule_matcher.is_rule_enabled(get_enabled_rule("0102"))
+
+    def test_project_token_ignores_project_rules(self):
+        rule_matcher = RuleMatcher(
+            select=["ALL"],
+            extend_select=[],
+            ignore=["PROJECT"],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
+        assert not rule_matcher.is_rule_enabled(get_project_rule("0201"))
+
+    def test_project_token_is_matched(self, capsys):
+        rule_matcher = RuleMatcher(
+            select=["PROJECT"],
+            extend_select=[],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert rule_matcher.is_rule_enabled(get_project_rule("0201"))
+        rule_matcher.check_unmatched_filters()
+        assert not capsys.readouterr().err
 
     def test_fixable_unfixable_nothing_selected(self):
         rule_matcher = RuleMatcher(


### PR DESCRIPTION
Closes part of the follow-up work on project level rules.

Project rules span several categories (`ARG08`, `DUP11`, `IMP05`-`IMP09`, `KW04`-`KW06`), so there was no way to enable them all without listing them one by one - no glob pattern covers them.

`--select ALL` already enabled them (it short-circuits before the `rule.enabled` fallback), but there was no way to enable *only* project rules, or to run everything *except* them.

This adds a `PROJECT` keyword to the rule filters, mirroring the existing `robocop list rules --filter PROJECT`:

```bash
robocop check --select PROJECT  # only project level rules
robocop check --extend-select PROJECT  # default rules + all project level rules
robocop check --select ALL --ignore PROJECT  # everything except project level rules
```

Implemented in `RuleFilter.matches()`, so it works for `--select`, `--extend-select` and `--ignore` at once, and is correctly tracked by the unmatched filter check.