### PR TITLE
feat: allow to skip report file generation on empty results

### DIFF
--- a/docs/linter/reports/gitlab.md
+++ b/docs/linter/reports/gitlab.md
@@ -67,3 +67,28 @@ by the report:
     ```
 
 The default path is ``robocop-code-quality.json``.
+
+### ``Skip on empty``
+
+By default, the report file is generated even if Robocop did not find any issue. Set the ``skip_on_empty`` option
+to ``True`` to not create the file when there is nothing to report:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports gitlab --configure gitlab.skip_on_empty=True
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "gitlab"
+    ]
+    configure = [
+        "gitlab.skip_on_empty=True"
+    ]
+    ```
+
+If the file was created by a previous run, it is left untouched.

--- a/docs/linter/reports/json.md
+++ b/docs/linter/reports/json.md
@@ -76,3 +76,28 @@ by the report:
     ```
 
 The default path is ``robocop.json``.
+
+### ``Skip on empty``
+
+By default, the report file is generated even if Robocop did not find any issue. Set the ``skip_on_empty`` option
+to ``True`` to not create the file when there is nothing to report:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports json_report --configure json_report.skip_on_empty=True
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "json_report"
+    ]
+    configure = [
+        "json_report.skip_on_empty=True"
+    ]
+    ```
+
+If the file was created by a previous run, it is left untouched.

--- a/docs/linter/reports/sarif.md
+++ b/docs/linter/reports/sarif.md
@@ -54,3 +54,28 @@ by the report:
     ```
 
 The default path is ``.sarif.json``.
+
+### ``Skip on empty``
+
+By default, the report file is generated even if Robocop did not find any issue. Set the ``skip_on_empty`` option
+to ``True`` to not create the file when there is nothing to report:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports sarif --configure sarif.skip_on_empty=True
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "sarif"
+    ]
+    configure = [
+        "sarif.skip_on_empty=True"
+    ]
+    ```
+
+If the file was created by a previous run, it is left untouched.

--- a/docs/linter/reports/sonarqube.md
+++ b/docs/linter/reports/sonarqube.md
@@ -77,3 +77,28 @@ You can configure the version of the SonarQube generic formatter format with the
         "sonarqube.sonar_version=9.9"
     ]
     ```
+
+### ``Skip on empty``
+
+By default, the report file is generated even if Robocop did not find any issue. Set the ``skip_on_empty`` option
+to ``True`` to not create the file when there is nothing to report:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports sonarqube --configure sonarqube.skip_on_empty=True
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "sonarqube"
+    ]
+    configure = [
+        "sonarqube.skip_on_empty=True"
+    ]
+    ```
+
+If the file was created by a previous run, it is left untouched.

--- a/docs/linter/reports/textfile.md
+++ b/docs/linter/reports/textfile.md
@@ -49,3 +49,28 @@ by the report:
     ```
 
 The default path is ``robocop.txt``.
+
+### ``Skip on empty``
+
+By default, the report file is generated even if Robocop did not find any issue. Set the ``skip_on_empty`` option
+to ``True`` to not create the file when there is nothing to report:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports text_file --configure text_file.skip_on_empty=True
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "text_file"
+    ]
+    configure = [
+        "text_file.skip_on_empty=True"
+    ]
+    ```
+
+If the file was created by a previous run, it is left untouched.

--- a/src/robocop/linter/reports/__init__.py
+++ b/src/robocop/linter/reports/__init__.py
@@ -8,11 +8,12 @@ from typing import TYPE_CHECKING, Any
 from robocop import exceptions
 from robocop.config import defaults
 from robocop.config.builder import ConfigBuilder
-from robocop.linter.utils.misc import get_robocop_cache_directory
+from robocop.linter.utils.misc import get_robocop_cache_directory, str2bool
 from robocop.runtime.resolver import LinterImporter
 
 if TYPE_CHECKING:
     from robocop.config.schema import Config
+    from robocop.linter.diagnostics import Diagnostics
 
 
 class Report:
@@ -40,12 +41,36 @@ class Report:
         raise NotImplementedError
 
 
-class JsonFileReport(Report):
+class FileReport(Report):
+    """Base class for a report that saves its output to a file."""
+
+    def __init__(self, config: Config, skip_on_empty: bool = False) -> None:
+        self.skip_on_empty = skip_on_empty
+        super().__init__(config)
+
+    def configure(self, name: str, value: str) -> None:
+        if name == "skip_on_empty":
+            self.skip_on_empty = str2bool(value)
+        else:
+            super().configure(name, value)
+
+    def should_skip(self, diagnostics: Diagnostics) -> bool:
+        """
+        Check if the report file generation should be skipped.
+
+        Returns:
+            True if the report is configured with ``skip_on_empty`` and there are no issues to report.
+
+        """
+        return self.skip_on_empty and not diagnostics.diagnostics
+
+
+class JsonFileReport(FileReport):
     """Base class for a report that generates a json-based file."""
 
-    def __init__(self, output_path: str, config: Config) -> None:
+    def __init__(self, output_path: str, config: Config, skip_on_empty: bool = False) -> None:
         self.output_path = output_path
-        super().__init__(config)
+        super().__init__(config, skip_on_empty=skip_on_empty)
 
     def configure(self, name: str, value: str) -> None:
         if name == "output_path":

--- a/src/robocop/linter/reports/gitlab.py
+++ b/src/robocop/linter/reports/gitlab.py
@@ -31,6 +31,10 @@ class GitlabReport(robocop.linter.reports.JsonFileReport):
 
     The default path is ``robocop-code-quality.json``.
 
+    Set ``skip_on_empty`` to ``True`` to not generate the file when there are no issues to report:
+
+        robocop check --configure gitlab.skip_on_empty=True
+
     """
 
     NO_ALL = False
@@ -41,6 +45,8 @@ class GitlabReport(robocop.linter.reports.JsonFileReport):
         super().__init__(output_path="robocop-code-quality.json", config=config)
 
     def generate_report(self, diagnostics: Diagnostics, **kwargs: object) -> None:  # type: ignore[override]  # noqa: ARG002
+        if self.should_skip(diagnostics):
+            return
         report = self.generate_gitlab_report(diagnostics)
         super().generate_report_with_type(report, "Gitlab Code Quality")
 

--- a/src/robocop/linter/reports/json_report.py
+++ b/src/robocop/linter/reports/json_report.py
@@ -27,6 +27,10 @@ class JsonReport(robocop.linter.reports.JsonFileReport):
 
     The default path is ``robocop.json``.
 
+    Set ``skip_on_empty`` to ``True`` to not generate the file when there are no issues to report:
+
+        robocop check --configure json_report.skip_on_empty=True
+
     Example content of the file:
 
         [
@@ -64,6 +68,8 @@ class JsonReport(robocop.linter.reports.JsonFileReport):
         super().__init__(output_path="robocop.json", config=config)
 
     def generate_report(self, diagnostics: Diagnostics, **kwargs: object) -> None:  # type: ignore[override]  # noqa: ARG002
+        if self.should_skip(diagnostics):
+            return
         issues = [self.message_to_json(diagnostic) for diagnostic in diagnostics]
         super().generate_report_with_type(issues, "JSON")
 

--- a/src/robocop/linter/reports/sarif.py
+++ b/src/robocop/linter/reports/sarif.py
@@ -34,6 +34,10 @@ class SarifReport(robocop.linter.reports.JsonFileReport):
 
     The default path is ``.sarif.json``.
 
+    Set ``skip_on_empty`` to ``True`` to not generate the file when there are no issues to report:
+
+        robocop check --configure sarif.skip_on_empty=True
+
     """
 
     NO_ALL = False
@@ -119,5 +123,7 @@ class SarifReport(robocop.linter.reports.JsonFileReport):
     ) -> None:
         # TODO: In case of several configs we may not have all rules in default config
         # instead, we could use diagnostic.rule and aggregate them
+        if self.should_skip(diagnostics):
+            return
         report = self.generate_sarif_report(diagnostics, config_manager.root, resolved_config.rules)
         super().generate_report_with_type(report, "SARIF")

--- a/src/robocop/linter/reports/sonarqube.py
+++ b/src/robocop/linter/reports/sonarqube.py
@@ -43,6 +43,10 @@ class SonarQubeReport(robocop.linter.reports.JsonFileReport):
 
     The default path is ``robocop_sonar_qube.json``.
 
+    Set ``skip_on_empty`` to ``True`` to not generate the file when there are no issues to report:
+
+        robocop check --configure sonarqube.skip_on_empty=True
+
     """
 
     NO_ALL = False
@@ -76,6 +80,8 @@ class SonarQubeReport(robocop.linter.reports.JsonFileReport):
         config_manager: ConfigManager,
         **kwargs: object,  # noqa: ARG002
     ) -> None:
+        if self.should_skip(diagnostics):
+            return
         report = self.report_generator().generate_sonarqube_report(diagnostics, config_manager.root)
         super().generate_report_with_type(report, "SonarQube")
 

--- a/src/robocop/linter/reports/text_file.py
+++ b/src/robocop/linter/reports/text_file.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from robocop.linter.diagnostics import Diagnostics
 
 
-class TextFile(robocop.linter.reports.Report):
+class TextFile(robocop.linter.reports.FileReport):
     """
     **Report name**: ``text_file``
 
@@ -23,6 +23,10 @@ class TextFile(robocop.linter.reports.Report):
         robocop check --configure text_file.output_path=output/robocop.txt
 
     ``text_file`` report supports only the `` simple `` issue output format.
+
+    Set ``skip_on_empty`` to ``True`` to not generate the file when there are no issues to report:
+
+        robocop check --configure text_file.skip_on_empty=True
     """
 
     NO_ALL = False
@@ -34,6 +38,8 @@ class TextFile(robocop.linter.reports.Report):
         super().__init__(config)
 
     def generate_report(self, diagnostics: Diagnostics, **kwargs: object) -> None:  # type: ignore[override]  # noqa: ARG002
+        if self.should_skip(diagnostics):
+            return
         cwd = Path.cwd()
         messages: list[str] = []
         for source, diag_by_source in diagnostics.diag_by_source.items():

--- a/tests/linter/reports/test_skip_on_empty.py
+++ b/tests/linter/reports/test_skip_on_empty.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from robocop.exceptions import ConfigurationError
+from robocop.linter.diagnostics import Diagnostics
+from robocop.linter.reports.gitlab import GitlabReport
+from robocop.linter.reports.json_report import JsonReport
+from robocop.linter.reports.sarif import SarifReport
+from robocop.linter.reports.sonarqube import SonarQubeReport
+from robocop.linter.reports.text_file import TextFile
+from robocop.runtime.resolved_config import ResolvedConfig
+from tests.linter.reports import generate_issues
+
+
+def generate_file_report(report, diagnostics: Diagnostics) -> None:
+    """Call ``generate_report`` with the arguments required by the given report."""
+    if isinstance(report, SarifReport):
+        config_manager = Mock()
+        config_manager.root = Path.cwd()
+        resolved_config = Mock(spec=ResolvedConfig)
+        resolved_config.rules = {}
+        report.generate_report(diagnostics, config_manager, resolved_config)
+    elif isinstance(report, SonarQubeReport):
+        config_manager = Mock()
+        config_manager.root = Path.cwd()
+        report.generate_report(diagnostics, config_manager)
+    else:
+        report.generate_report(diagnostics)
+
+
+FILE_REPORTS = [GitlabReport, JsonReport, SarifReport, SonarQubeReport, TextFile]
+
+
+class TestSkipOnEmpty:
+    @pytest.mark.parametrize("report_class", FILE_REPORTS)
+    def test_file_not_created_on_empty_results(self, report_class, empty_config, tmp_path):
+        output_file = tmp_path / "reports" / "report.out"
+        report = report_class(empty_config)
+        report.configure("output_path", str(output_file))
+        report.configure("skip_on_empty", "True")
+
+        generate_file_report(report, Diagnostics([]))
+
+        assert not output_file.exists()
+
+    @pytest.mark.parametrize("report_class", FILE_REPORTS)
+    def test_previous_file_is_not_overwritten(self, report_class, empty_config, tmp_path):
+        output_file = tmp_path / "report.out"
+        output_file.write_text("previous run")
+        report = report_class(empty_config)
+        report.configure("output_path", str(output_file))
+        report.configure("skip_on_empty", "True")
+
+        generate_file_report(report, Diagnostics([]))
+
+        assert output_file.read_text() == "previous run"
+
+    @pytest.mark.parametrize("report_class", FILE_REPORTS)
+    def test_file_created_when_there_are_issues(self, report_class, empty_config, tmp_path, rule, rule2):
+        output_file = tmp_path / "report.out"
+        report = report_class(empty_config)
+        report.configure("output_path", str(output_file))
+        report.configure("skip_on_empty", "True")
+
+        generate_file_report(report, Diagnostics(generate_issues(empty_config, rule, rule2)))
+
+        assert output_file.exists()
+
+    @pytest.mark.parametrize("report_class", FILE_REPORTS)
+    def test_file_created_on_empty_results_by_default(self, report_class, empty_config, tmp_path):
+        output_file = tmp_path / "report.out"
+        report = report_class(empty_config)
+        report.configure("output_path", str(output_file))
+
+        generate_file_report(report, Diagnostics([]))
+
+        assert output_file.exists()
+
+    @pytest.mark.parametrize("report_class", FILE_REPORTS)
+    def test_invalid_configuration(self, report_class, empty_config):
+        report = report_class(empty_config)
+        with pytest.raises(ConfigurationError):
+            report.configure("skip_on_empy", "True")


### PR DESCRIPTION
Closes #1332

File based reports always created their output file, even when there were no issues at all. This adds a `skip_on_empty` option, shared by all reports that write a file:

```bash
robocop check --reports sarif --configure sarif.skip_on_empty=True
```

- New `FileReport` base class holds the flag, its configuration and the `should_skip()` check. `JsonFileReport` and `text_file` inherit from it, so `gitlab`, `json_report`, `sarif`, `sonarqube` and `text_file` all support it.
- Default is `False` - the previous behaviour (always write the file) is unchanged.
- When skipped, a file left by a previous run is not overwritten either.
