### PR TITLE
feat: apply fixes reported by project level rules

### DIFF
--- a/docs/linter/custom_rules.md
+++ b/docs/linter/custom_rules.md
@@ -473,6 +473,15 @@ receives:
 
     ``source`` passed to ``self.report()`` must be a ``SourceFile`` instance, not a ``Path`` or a string.
 
+### Fixes in project checks
+
+Rules reported by project checkers can provide fixes in the same way as the file level rules - inherit from
+``FixableRule`` and implement the ``fix()`` method, or pass a ready ``Fix`` to ``self.report()``.
+
+Fixes are applied when Robocop is run with ``--fix``, after all project checks are finished. Only files selected
+for the run are modified: the project context is built from the whole project, but a file the user did not select
+is never fixed, even if an issue is reported in it.
+
 ### Project context
 
 ``ProjectContext`` holds everything Robocop collected from the project:

--- a/src/robocop/linter/fix.py
+++ b/src/robocop/linter/fix.py
@@ -244,7 +244,8 @@ class FixApplier:
             self.fix_stats.by_file[source_file.path][key] = self.fix_stats.by_file[source_file.path].get(key, 0) + 1
 
         source_file.modified = True
-        self.modified_files.append(source_file)
+        if source_file not in self.modified_files:
+            self.modified_files.append(source_file)
 
         source_file.reload_model()
         return True

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from robocop.config.manager import ConfigManager
     from robocop.config.schema import Config
     from robocop.linter.diagnostics import Diagnostic
+    from robocop.linter.rules import ProjectChecker
     from robocop.project.context import ProjectContext
 
 
@@ -104,10 +106,12 @@ class RobocopLinter:
         self.diagnostics = []
         files = 0
         cached_files = 0
+        checked_paths: set[Path] = set()
         fix_applier = FixApplier()
         for source_file in self.config_manager.paths:
             if source_file.config.verbose:
                 print(f"Scanning file: {source_file.path}")
+            checked_paths.add(source_file.path.resolve())
             diagnostics = self.get_cached_diagnostics(source_file.config, source_file.path)
             if diagnostics is not None:
                 no_fixables = all(not diag.rule.fixable for diag in diagnostics)
@@ -124,7 +128,7 @@ class RobocopLinter:
             if not source_file.config.linter.diff:  # diff simulate fixes, so it's best to ignore the results
                 self.config_manager.cache.set_linter_entry(source_file.path, source_file.config.hash, diagnostics)
         self.config_manager.cache.save()
-        self.diagnostics.extend(self.run_project_checks())
+        self.diagnostics.extend(self.run_project_checks(fix_applier, checked_paths))
         self.config_manager.cache.save()  # project analysis may cache imported libraries
 
         if not files and not self.config_manager.default_config.silent:
@@ -193,19 +197,27 @@ class RobocopLinter:
             fix_applier.fix_stats.total_fixes += max(prev_fixable - len(fixable_diagnostics), 0)
             prev_fixable = len(fixable_diagnostics)
             # Collect fixes from diagnostics
-            fixes = [diag.fix or diag.rule.fix(diag, source_file) for diag in fixable_diagnostics]
-            if not fix_applier.apply_fixes(source_file, fixes):
+            fixes = [diag.fix or diag.rule.fix(diag, source_file.source_lines) for diag in fixable_diagnostics]
+            if not fix_applier.apply_fixes(source_file, [fix for fix in fixes if fix]):
                 break
         if source_file.config.linter.fix and not source_file.config.linter.diff:
             source_file.write_changes()
         return found_diagnostics
 
-    def run_project_checks(self) -> list[Diagnostic]:
+    def run_project_checks(
+        self, fix_applier: FixApplier | None = None, checked_paths: set[Path] | None = None
+    ) -> list[Diagnostic]:
         """
         Run project level checkers on the whole project.
 
         Project checkers are only run if the project analysis is enabled. By default it happens whenever
         at least one project rule is enabled. It can be forced or disabled with the ``project`` option.
+
+        Args:
+            fix_applier: The applier responsible for applying fixes to the source files. Project checks are
+                repeated after applying the fixes, so that the reported issues match the fixed files.
+            checked_paths: Paths of the files selected for the run. Only those files can be fixed, even though
+                the project context is built from the whole project.
 
         Returns:
             List of diagnostics found by the project checkers.
@@ -217,17 +229,96 @@ class RobocopLinter:
         resolved_config = self.config_resolver.resolve_config(config)
         if not resolved_config.project_checkers:
             return []
+        if fix_applier is None:
+            fix_applier = FixApplier()
         project_name = self.config_manager.root.name
         project_source_file = VirtualSourceFile(Path(project_name), config)
+        diagnostics = self.scan_project(project_source_file, resolved_config.project_checkers, config)
+        if not (config.linter.fix or config.linter.diff):
+            return diagnostics
+        # Fixes may reveal or resolve other issues, so the project is scanned again until it converges.
+        # In the diff mode files are not saved, so repeating the analysis would produce the same diagnostics.
+        attempts = 5 if config.linter.fix and not config.linter.diff else 1
+        for _ in range(attempts):
+            if not self.apply_project_fixes(diagnostics, fix_applier, checked_paths, save=not config.linter.diff):
+                break
+            diagnostics = self.scan_project(project_source_file, resolved_config.project_checkers, config)
+        return diagnostics
+
+    def scan_project(
+        self,
+        project_source_file: VirtualSourceFile,
+        project_checkers: list[ProjectChecker],
+        config: Config,
+    ) -> list[Diagnostic]:
+        """
+        Build the project context and run every project checker on it.
+
+        Returns:
+            List of diagnostics found by the project checkers.
+
+        """
         context = self.build_context(config)
         diagnostics: list[Diagnostic] = []
-        for checker in resolved_config.project_checkers:
+        for checker in project_checkers:
             checker.issues = []
             checker.scan_project(project_source_file, self.config_manager, context)
             diagnostics.extend(
                 [diagnostic for diagnostic in checker.issues if not (diagnostic.severity < config.linter.threshold)]
             )
         return diagnostics
+
+    def apply_project_fixes(
+        self,
+        diagnostics: list[Diagnostic],
+        fix_applier: FixApplier,
+        checked_paths: set[Path] | None,
+        save: bool,
+    ) -> bool:
+        """
+        Apply fixes for the issues reported by the project checkers.
+
+        Diagnostics reported by project checkers point to different source files, so they are grouped by the file
+        first. Every file is fixed and saved separately. Only files selected for the run are fixed - the project
+        context contains every file from the project, but files the user did not select are never modified.
+
+        Args:
+            diagnostics: Diagnostics reported by the project checkers.
+            fix_applier: The applier responsible for applying fixes to the source files.
+            checked_paths: Paths of the files selected for the run. If None, all files can be fixed.
+            save: Whether the fixed files should be saved. Disabled in the diff mode.
+
+        Returns:
+            True if any fix was applied.
+
+        """
+        diag_by_source: dict[Path, list[Diagnostic]] = defaultdict(list)
+        for diagnostic in diagnostics:
+            if not diagnostic.rule.fixable:
+                continue
+            if checked_paths is not None and diagnostic.source.path.resolve() not in checked_paths:
+                continue
+            diag_by_source[diagnostic.source.path].append(diagnostic)
+        if not diag_by_source:
+            return False
+        modified_files = {source_file.path: source_file for source_file in fix_applier.modified_files}
+        fixed = False
+        for path, source_diagnostics in diag_by_source.items():
+            # reuse source file already modified by the file level fixes to not lose their changes
+            source_file = modified_files.get(path, source_diagnostics[0].source)
+            fixes = [diag.fix or diag.rule.fix(diag, source_file.source_lines) for diag in source_diagnostics]
+            fixes_before = self.count_applied_fixes(fix_applier)
+            if not fix_applier.apply_fixes(source_file, [fix for fix in fixes if fix]):
+                continue
+            fix_applier.fix_stats.total_fixes += self.count_applied_fixes(fix_applier) - fixes_before
+            fixed = True
+            if save:
+                source_file.write_changes()
+        return fixed
+
+    @staticmethod
+    def count_applied_fixes(fix_applier: FixApplier) -> int:
+        return sum(sum(rules.values()) for rules in fix_applier.fix_stats.by_file.values())
 
     def build_context(self, config: Config) -> ProjectContext:
         """

--- a/tests/project/project_fix_rules.py
+++ b/tests/project/project_fix_rules.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, ProjectChecker, RuleSeverity
+
+if TYPE_CHECKING:
+    from robocop.config.manager import ConfigManager
+    from robocop.linter.diagnostics import Diagnostic
+    from robocop.project.context import ProjectContext
+    from robocop.source_file import VirtualSourceFile
+
+
+class RenamedKeywordRule(FixableRule):
+    """Custom project rule with a fix. Reports calls of the ``Old Keyword`` keyword."""
+
+    name = "renamed-keyword"
+    rule_id = "PFX01"
+    message = "Keyword '{keyword_name}' was renamed to 'New Keyword'"
+    severity = RuleSeverity.WARNING
+    added_in_version = "9.0.0"
+    project_rule = True
+    fix_availability = FixAvailability.ALWAYS
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        return Fix(
+            edits=[TextEdit.replace_at_range(self.rule_id, self.name, diag.range, "New Keyword")],
+            message="Replace 'Old Keyword' with 'New Keyword'",
+            applicability=FixApplicability.SAFE,
+        )
+
+
+class RenamedKeywordChecker(ProjectChecker):
+    """Project checker reporting calls of the renamed keyword."""
+
+    renamed_keyword: RenamedKeywordRule
+
+    def scan_project(
+        self,
+        project_source_file: VirtualSourceFile,  # noqa: ARG002
+        config_manager: ConfigManager,  # noqa: ARG002
+        context: ProjectContext,
+    ) -> None:
+        for project_file, usage in context.iter_usages():
+            if usage.normalized_name != "oldkeyword":
+                continue
+            self.report(
+                self.renamed_keyword,
+                source=project_file.source_file,
+                keyword_name=usage.name,
+                lineno=usage.location.lineno,
+                col=usage.location.col,
+                end_lineno=usage.location.end_lineno,
+                end_col=usage.location.end_col,
+            )

--- a/tests/project/test_project_fixes.py
+++ b/tests/project/test_project_fixes.py
@@ -1,0 +1,80 @@
+"""Tests for applying fixes reported by the project level rules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robocop.run import check_files
+
+CUSTOM_RULES = str(Path(__file__).parent / "project_fix_rules.py")
+SOURCE = "*** Test Cases ***\nTest\n    Old Keyword\n    Old Keyword    argument\n"
+FIXED = "*** Test Cases ***\nTest\n    New Keyword\n    New Keyword    argument\n"
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "test.robot").write_text(SOURCE)
+    return tmp_path
+
+
+def run(source, root=None, **kwargs):
+    return check_files(
+        sources=[source],
+        select=["renamed-keyword"],
+        custom_rules=[CUSTOM_RULES],
+        root=root or source,
+        ignore_file_config=True,
+        return_result=True,
+        cache=False,
+        silent=True,
+        **kwargs,
+    )
+
+
+class TestProjectFixes:
+    def test_issues_are_reported_without_fix(self, project):
+        diagnostics = run(project)
+
+        assert len(diagnostics) == 2
+        assert (project / "test.robot").read_text() == SOURCE
+
+    def test_fix_is_applied_and_saved(self, project):
+        diagnostics = run(project, fix=True)
+
+        assert (project / "test.robot").read_text() == FIXED
+        assert diagnostics == []  # issues are fixed, so they are not reported anymore
+
+    def test_diff_does_not_modify_the_file(self, project):
+        run(project, diff=True)
+
+        assert (project / "test.robot").read_text() == SOURCE
+
+    def test_file_outside_of_the_selected_paths_is_not_fixed(self, project):
+        """Project context is built from the whole project, but only selected files are fixed."""
+        other = project / "other.robot"
+        other.write_text(SOURCE)
+
+        run(project / "test.robot", root=project, fix=True)
+
+        assert (project / "test.robot").read_text() == FIXED
+        assert other.read_text() == SOURCE
+
+    def test_file_level_fixes_are_not_lost(self, project):
+        """Both file level and project level rules fix the same file in one run."""
+        (project / "test.robot").write_text(SOURCE.replace("Test Cases ***", "Test Cases ***  "))
+
+        check_files(
+            sources=[project],
+            select=["renamed-keyword", "trailing-whitespace"],
+            custom_rules=[CUSTOM_RULES],
+            root=project,
+            ignore_file_config=True,
+            return_result=True,
+            cache=False,
+            silent=True,
+            fix=True,
+        )
+
+        assert (project / "test.robot").read_text() == FIXED


### PR DESCRIPTION
Preparation for the upcoming project level rules with fixes (`missing-argument-name`, keyword prefix rule).

Diagnostics reported by project checkers were never passed to the fix applier - `run_check()` collects fixes per file, but `run_project_checks()` results went straight to the reports. Project rules therefore could not provide fixes at all.

Now they can:

- diagnostics are grouped by source file, since a single project checker reports issues in many files,
- **only files selected for the run are modified** - the project context is always built from the whole project, but a file the user did not select is never fixed, even if an issue is reported in it,
- project checks are repeated (up to 5 times) after applying fixes, so the reported issues match the fixed files, same as `run_check()` does for file level rules,
- `--diff` applies fixes in memory only and does not repeat the analysis,
- file level and project level fixes for the same file reuse the same `SourceFile` instance, so they do not overwrite each other.

Also:
- `Rule.fix()` is now called with the source lines, as its signature always declared (`source_lines: list[str]`), instead of the `SourceFile` instance. No rule used that argument.
- `FixApplier` no longer adds the same source file to `modified_files` twice.
