### PR TITLE
feat: add missing-argument-name project rule with a fix

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -131,6 +131,7 @@ Currently available project level rules are:
 - ``unresolved-library-import`` - imported library cannot be imported,
 - ``unused-keyword`` - user keyword is never called in the project,
 - ``invalid-argument-count`` - keyword is called with a number of arguments its ``[Arguments]`` do not accept,
+- ``missing-argument-name`` - keyword is called with a positional argument instead of a named one,
 - ``unused-resource-import`` - nothing from the imported resource file is used,
 - ``unused-library-import`` - no keyword from the imported library is used,
 - ``ambiguous-keyword-name`` - keyword name matches keywords from more than one source,

--- a/src/robocop/linter/checkers/keyword_arguments.py
+++ b/src/robocop/linter/checkers/keyword_arguments.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from robocop.linter.rules import ProjectChecker, VisitorChecker, arguments, keywords, spacing
+from robocop.parsing.run_keywords import is_run_keyword
 from robocop.source_file import SourceFile
 
 if TYPE_CHECKING:
@@ -86,3 +87,59 @@ class ProjectArgumentsChecker(ProjectChecker):
         if definition.has_embedded_arguments:
             return None
         return definition.arguments.validate_call(usage.arguments)
+
+
+class ProjectArgumentNamesChecker(ProjectChecker):
+    """Checker for rules that require argument names from the keyword definitions in the whole project."""
+
+    missing_argument_name: arguments.MissingArgumentNameRule
+
+    def scan_project(
+        self,
+        project_source_file: SourceFile | VirtualSourceFile,
+        config_manager: ConfigManager,  # noqa: ARG002
+        context: ProjectContext,
+    ) -> list[Diagnostic]:
+        self.issues = []
+        for project_file, usage in context.iter_usages():
+            named_arguments = self._find_positional_arguments(context, usage)
+            if len(named_arguments) < self.missing_argument_name.min_arguments:
+                continue
+            source = SourceFile(path=project_file.path, config=project_source_file.config)
+            for index, argument_name in named_arguments:
+                lineno, col, end_col = usage.argument_positions[index]
+                self.report(
+                    self.missing_argument_name,
+                    source=source,
+                    keyword_name=usage.name,
+                    argument_name=argument_name,
+                    lineno=lineno,
+                    col=col,
+                    end_lineno=lineno,
+                    end_col=end_col,
+                )
+        return self.issues
+
+    def _find_positional_arguments(self, context: ProjectContext, usage: KeywordUsage) -> list[tuple[int, str]]:
+        """
+        Find arguments passed by the position together with their names from the keyword definition.
+
+        Returns:
+            List of ``(index in the call, argument name)`` pairs, empty if the call should not be reported.
+
+        """
+        if usage.is_template or usage.name_contains_variable or usage.has_argument_expansion:
+            return []
+        if len(usage.arguments) != len(usage.argument_positions):
+            return []  # positions are missing, for example when data comes from an older cache
+        if is_run_keyword(usage.name):
+            return []  # arguments of the run keywords are keyword names and their arguments
+        definitions = context.resolve_keyword(usage)
+        if len(definitions) != 1:
+            return []  # not defined in the project, or ambiguous
+        definition = definitions[0]
+        if definition.has_embedded_arguments or (
+            definition.is_from_library and self.missing_argument_name.ignore_library_keywords
+        ):
+            return []
+        return definition.arguments.name_positional_arguments(usage.arguments) or []

--- a/src/robocop/linter/fix.py
+++ b/src/robocop/linter/fix.py
@@ -266,15 +266,32 @@ class FixApplier:
 
         for edit in sorted_edits[1:]:
             # Check if this edit starts after the previous edit ends
-            end_line = (
-                non_overlapping[-1].end_line
-                if non_overlapping[-1].end_line is not None
-                else non_overlapping[-1].start_line
-            )
-            if edit.start_line > end_line:
+            previous = non_overlapping[-1]
+            end_line = previous.end_line if previous.end_line is not None else previous.start_line
+            if edit.start_line > end_line or FixApplier._is_after_on_the_same_line(previous, edit):
                 non_overlapping.append(edit)
 
         return non_overlapping
+
+    @staticmethod
+    def _is_after_on_the_same_line(previous: TextEdit, edit: TextEdit) -> bool:
+        """
+        Check if both edits replace a part of the same line and do not overlap.
+
+        Only single line replacements can be applied together, other kinds of edits replace, insert or delete
+        whole lines.
+
+        Returns:
+            True if the edit can be applied together with the previous one.
+
+        """
+        single_line_kinds = (
+            previous.kind == TextEditKind.REPLACEMENT
+            and edit.kind == TextEditKind.REPLACEMENT
+            and previous.start_line == previous.end_line
+            and edit.start_line == edit.end_line
+        )
+        return single_line_kinds and previous.start_line == edit.start_line and edit.start_col >= previous.end_col
 
     @staticmethod
     def _apply_edit(lines: list[str], edit: TextEdit) -> None:

--- a/src/robocop/linter/rules/arguments.py
+++ b/src/robocop/linter/rules/arguments.py
@@ -5,12 +5,15 @@ from typing import TYPE_CHECKING, ClassVar
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity
-from robocop.linter.utils.misc import normalize_robot_var_name, split_argument_default_value
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, Rule, RuleParam, RuleSeverity
+from robocop.linter.utils.misc import normalize_robot_var_name, split_argument_default_value, str2bool
 from robocop.version_handling import TYPE_SUPPORTED
 
 if TYPE_CHECKING:
     from robot.parsing.model.statements import Arguments, KeywordCall
+
+    from robocop.linter.diagnostics import Diagnostic
 
 
 class UnusedArgumentRule(Rule):
@@ -358,3 +361,93 @@ class InvalidArgumentCountRule(Rule):
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
+
+
+class MissingArgumentNameRule(FixableRule):
+    """
+    Keyword is called with a positional argument instead of a named one.
+
+    Optional rule for projects that require every keyword to be called with named arguments. Positional arguments
+    are easy to mix up, especially with keywords that accept a lot of them:
+
+        *** Keywords ***
+        Create User
+            [Arguments]    ${name}    ${surname}    ${age}    ${city}
+            Log Many    ${name}    ${surname}    ${age}    ${city}
+
+        *** Test Cases ***
+        Test
+            Create User    Bob    Smith    30    Berlin  # will report 4 issues
+
+    With this rule enabled, the call should be written as:
+
+        *** Test Cases ***
+        Test
+            Create User    name=Bob    surname=Smith    age=30    city=Berlin
+
+    The rule is not enabled by default. Select it to use it:
+
+        robocop check --select missing-argument-name
+
+    Argument names are taken from the keyword definition, so the whole project needs to be analyzed. Keywords
+    coming from the libraries are ignored by default, since it is not always possible to call them with named
+    arguments. Configure ``ignore_library_keywords`` to check them as well:
+
+        robocop check --select missing-argument-name --configure missing-argument-name.ignore_library_keywords=False
+
+    Calls with only a few arguments are often clear enough. Use ``min_arguments`` to only report calls that use
+    at least given number of positional arguments:
+
+        robocop check --select missing-argument-name --configure missing-argument-name.min_arguments=3
+
+    To avoid false positives, the argument is not reported when:
+
+    - the keyword name is built from a variable,
+    - the keyword is not found in the project, or more than one definition matches the name,
+    - the keyword uses embedded arguments,
+    - the call expands a list (``@{args}``) or dictionary (``&{kwargs}``) variable,
+    - the keyword is used as a test template,
+    - the argument is passed to ``*varargs``, or the keyword does not accept it as a named argument.
+
+    """
+
+    name = "missing-argument-name"
+    project_rule = True
+    rule_id = "ARG09"
+    message = "Argument '{argument_name}' of the keyword '{keyword_name}' should be passed as a named argument"
+    severity = RuleSeverity.WARNING
+    enabled = False
+    added_in_version = "9.0.0"
+    fix_availability = FixAvailability.ALWAYS
+    fix_suggestion = "Add the argument name, for example 'name=Bob' instead of 'Bob'"
+    parameters = [
+        RuleParam(
+            name="ignore_library_keywords",
+            default=True,
+            converter=str2bool,
+            show_type="bool",
+            desc="Do not report calls of the keywords imported from the libraries",
+        ),
+        RuleParam(
+            name="min_arguments",
+            default=1,
+            converter=int,
+            desc="Minimal number of the positional arguments in the call required to report it",
+        ),
+    ]
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        argument_name = diag.reported_arguments["argument_name"]
+        edit = TextEdit(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            start_line=diag.range.start.line,
+            start_col=diag.range.start.character,
+            end_line=diag.range.start.line,
+            end_col=diag.range.start.character,
+            replacement=f"{argument_name}=",
+        )
+        return Fix(edits=[edit], message=f"Add '{argument_name}' argument name", applicability=FixApplicability.SAFE)

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -301,11 +301,15 @@ class RobocopLinter:
             diag_by_source[diagnostic.source.path].append(diagnostic)
         if not diag_by_source:
             return False
-        modified_files = {source_file.path: source_file for source_file in fix_applier.modified_files}
+        modified_files = {source_file.path.resolve(): source_file for source_file in fix_applier.modified_files}
+        project_files = {source_file.path.resolve(): source_file for source_file in self.config_manager.project_paths}
         fixed = False
         for path, source_diagnostics in diag_by_source.items():
-            # reuse source file already modified by the file level fixes to not lose their changes
-            source_file = modified_files.get(path, source_diagnostics[0].source)
+            # reuse source file already parsed for the project context, so that the next scan sees fixed model
+            resolved_path = path.resolve()
+            source_file = modified_files.get(resolved_path) or project_files.get(resolved_path)
+            if source_file is None:
+                source_file = source_diagnostics[0].source
             fixes = [diag.fix or diag.rule.fix(diag, source_file.source_lines) for diag in source_diagnostics]
             fixes_before = self.count_applied_fixes(fix_applier)
             if not fix_applier.apply_fixes(source_file, [fix for fix in fixes if fix]):

--- a/src/robocop/project/collector.py
+++ b/src/robocop/project/collector.py
@@ -213,9 +213,9 @@ class ProjectFileCollector(ModelVisitor):  # type: ignore[misc]
 
     def _add_usages(self, node: Statement, name_token_type: str) -> None:
         for call in iterate_keyword_calls(node, name_token_type):
-            self._add_usage(call.name, [token.value for token in call.arguments])
+            self._add_usage(call.name, list(call.arguments))
 
-    def _add_usage(self, token: Token, arguments: list[str], is_template: bool = False) -> None:
+    def _add_usage(self, token: Token, arguments: list[Token], is_template: bool = False) -> None:
         if not token.value:
             return
         match = search_variable(token.value, ignore_errors=True)
@@ -230,7 +230,10 @@ class ProjectFileCollector(ModelVisitor):  # type: ignore[misc]
                     end_lineno=token.lineno,
                     end_col=token.end_col_offset + 1,
                 ),
-                arguments=tuple(arguments),
+                arguments=tuple(argument.value for argument in arguments),
+                argument_positions=tuple(
+                    (argument.lineno, argument.col_offset + 1, argument.end_col_offset + 1) for argument in arguments
+                ),
                 name_contains_variable=bool(match.base),
                 bdd_prefix=self._bdd_prefix(token.value),
                 is_template=is_template,

--- a/src/robocop/project/definitions.py
+++ b/src/robocop/project/definitions.py
@@ -224,6 +224,34 @@ class ArgumentsSpec:
                 positional_values.append(argument)
         return self._compare(positional_values, named_names)
 
+    def name_positional_arguments(self, arguments: Sequence[str]) -> list[tuple[int, str]] | None:
+        """
+        Match arguments passed by the position in the call with the names from this specification.
+
+        Returns:
+            List of ``(index in the call, argument name)`` pairs, or None if the call cannot be analyzed
+            with certainty.
+
+        """
+        known_names = self._known_names()
+        positional_arguments: list[tuple[int, str]] = []
+        used_named = False
+        for index, argument in enumerate(arguments):
+            split = _split_named_argument(argument)
+            if split is not None:
+                name, _value = split
+                if search_variable(name, ignore_errors=True).base is not None:
+                    return None  # named argument built from a variable, anything is possible
+                if normalize_robot_name(name) in known_names or self.accepts_named:
+                    used_named = True
+                    continue
+            if used_named:
+                return None  # positional argument after a named one, such call is invalid anyway
+            if len(positional_arguments) >= len(self.positional):
+                return None  # argument is passed to the ``*varargs`` and cannot be named
+            positional_arguments.append((index, self.positional[len(positional_arguments)]))
+        return positional_arguments
+
     def _compare(self, positional_values: list[str], named_names: set[str]) -> ArgumentsMismatch | None:
         provided = len(positional_values)
         maximum = self.max_args
@@ -282,6 +310,8 @@ class KeywordUsage:
     location: Location
     arguments: tuple[str, ...] = ()
     """Raw values of the arguments used in this call."""
+    argument_positions: tuple[tuple[int, int, int], ...] = ()
+    """Position of every argument in the source file, as a ``(line, column, end column)`` tuple."""
     name_contains_variable: bool = False
     """Keyword is called using a name built from a variable. Its definition cannot be found statically."""
     bdd_prefix: str | None = None

--- a/src/robocop/project/serialization.py
+++ b/src/robocop/project/serialization.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
-SERIALIZATION_VERSION = 1
+SERIALIZATION_VERSION = 2
 """Version of the format used to store the collected data. Bump it whenever the format changes."""
 
 
@@ -100,6 +100,7 @@ def _usage_to_dict(usage: KeywordUsage) -> dict[str, Any]:
         "normalized_name": usage.normalized_name,
         "location": _location_to_dict(usage.location),
         "arguments": list(usage.arguments),
+        "argument_positions": [list(position) for position in usage.argument_positions],
         "name_contains_variable": usage.name_contains_variable,
         "bdd_prefix": usage.bdd_prefix,
         "is_template": usage.is_template,
@@ -112,6 +113,7 @@ def _usage_from_dict(data: dict[str, Any], source: Path) -> KeywordUsage:
         normalized_name=data["normalized_name"],
         location=_location_from_dict(data["location"], source),
         arguments=tuple(data["arguments"]),
+        argument_positions=tuple(tuple(position) for position in data["argument_positions"]),
         name_contains_variable=data["name_contains_variable"],
         bdd_prefix=data["bdd_prefix"],
         is_template=data["is_template"],

--- a/tests/linter/rules/arguments/missing_argument_name/expected_extended.txt
+++ b/tests/linter/rules/arguments/missing_argument_name/expected_extended.txt
@@ -1,0 +1,82 @@
+test.robot:13:14 ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+    |
+ 11 |
+ 12 | Positional Calls
+ 13 |     Login    user    pass
+    |              ^^^^ ARG09
+ 14 |     With Default    1
+ 15 |     With Default    1    2
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:13:22 ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+    |
+ 11 |
+ 12 | Positional Calls
+ 13 |     Login    user    pass
+    |                      ^^^^ ARG09
+ 14 |     With Default    1
+ 15 |     With Default    1    2
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:14:21 ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+    |
+ 12 | Positional Calls
+ 13 |     Login    user    pass
+ 14 |     With Default    1
+    |                     ^ ARG09
+ 15 |     With Default    1    2
+ 16 |     With Kwargs    1    other=2
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:15:21 ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+    |
+ 13 |     Login    user    pass
+ 14 |     With Default    1
+ 15 |     With Default    1    2
+    |                     ^ ARG09
+ 16 |     With Kwargs    1    other=2
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:15:26 ARG09 Argument 'b' of the keyword 'With Default' should be passed as a named argument
+    |
+ 13 |     Login    user    pass
+ 14 |     With Default    1
+ 15 |     With Default    1    2
+    |                          ^ ARG09
+ 16 |     With Kwargs    1    other=2
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:16:20 ARG09 Argument 'a' of the keyword 'With Kwargs' should be passed as a named argument
+    |
+ 14 |     With Default    1
+ 15 |     With Default    1    2
+ 16 |     With Kwargs    1    other=2
+    |                    ^ ARG09
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:29:14 ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+    |
+ 27 |
+ 28 | Value With Equal Sign
+ 29 |     Login    user=name    pass
+    |              ^^^^^^^^^ ARG09
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+test.robot:29:27 ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+    |
+ 27 |
+ 28 | Value With Equal Sign
+ 29 |     Login    user=name    pass
+    |                           ^^^^ ARG09
+    | Suggestion: Add the argument name, for example 'name=Bob' instead of 'Bob'
+    |
+
+Found 8 issues.
+8 fixable with the '--fix' option.

--- a/tests/linter/rules/arguments/missing_argument_name/expected_library_keywords.txt
+++ b/tests/linter/rules/arguments/missing_argument_name/expected_library_keywords.txt
@@ -1,0 +1,18 @@
+keywords.resource:4:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+keywords.resource:8:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+keywords.resource:12:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+keywords.resource:16:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+keywords.resource:19:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+keywords.resource:22:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+keywords.resource:26:12 [W] ARG09 Argument 'message' of the keyword 'Log' should be passed as a named argument
+test.robot:13:14 [W] ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+test.robot:13:22 [W] ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+test.robot:14:21 [W] ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+test.robot:15:21 [W] ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+test.robot:15:26 [W] ARG09 Argument 'b' of the keyword 'With Default' should be passed as a named argument
+test.robot:16:20 [W] ARG09 Argument 'a' of the keyword 'With Kwargs' should be passed as a named argument
+test.robot:29:14 [W] ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+test.robot:29:27 [W] ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+
+Found 15 issues.
+15 fixable with the '--fix' option.

--- a/tests/linter/rules/arguments/missing_argument_name/expected_min_arguments.txt
+++ b/tests/linter/rules/arguments/missing_argument_name/expected_min_arguments.txt
@@ -1,0 +1,9 @@
+test.robot:13:14 [W] ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+test.robot:13:22 [W] ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+test.robot:15:21 [W] ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+test.robot:15:26 [W] ARG09 Argument 'b' of the keyword 'With Default' should be passed as a named argument
+test.robot:29:14 [W] ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+test.robot:29:27 [W] ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+
+Found 6 issues.
+6 fixable with the '--fix' option.

--- a/tests/linter/rules/arguments/missing_argument_name/expected_output.txt
+++ b/tests/linter/rules/arguments/missing_argument_name/expected_output.txt
@@ -1,0 +1,11 @@
+test.robot:13:14 [W] ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+test.robot:13:22 [W] ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+test.robot:14:21 [W] ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+test.robot:15:21 [W] ARG09 Argument 'a' of the keyword 'With Default' should be passed as a named argument
+test.robot:15:26 [W] ARG09 Argument 'b' of the keyword 'With Default' should be passed as a named argument
+test.robot:16:20 [W] ARG09 Argument 'a' of the keyword 'With Kwargs' should be passed as a named argument
+test.robot:29:14 [W] ARG09 Argument 'username' of the keyword 'Login' should be passed as a named argument
+test.robot:29:27 [W] ARG09 Argument 'password' of the keyword 'Login' should be passed as a named argument
+
+Found 8 issues.
+8 fixable with the '--fix' option.

--- a/tests/linter/rules/arguments/missing_argument_name/keywords.resource
+++ b/tests/linter/rules/arguments/missing_argument_name/keywords.resource
@@ -1,0 +1,26 @@
+*** Keywords ***
+Login
+    [Arguments]    ${username}    ${password}
+    Log    ${username}
+
+With Default
+    [Arguments]    ${a}    ${b}=2
+    Log    ${a}
+
+With Varargs
+    [Arguments]    ${a}    @{rest}
+    Log    ${a}
+
+With Kwargs
+    [Arguments]    ${a}    &{opts}
+    Log    ${a}
+
+No Args
+    Log    hello
+
+Embedded ${name} Keyword
+    Log    ${name}
+
+Named Only
+    [Arguments]    ${a}    @{}    ${strict}
+    Log    ${a}

--- a/tests/linter/rules/arguments/missing_argument_name/test.robot
+++ b/tests/linter/rules/arguments/missing_argument_name/test.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Resource    keywords.resource
+
+*** Test Cases ***
+Named Calls
+    Login    username=user    password=pass
+    With Default    a=1
+    With Kwargs    a=1    other=2
+    No Args
+    Named Only    a=1    strict=yes
+
+Positional Calls
+    Login    user    pass
+    With Default    1
+    With Default    1    2
+    With Kwargs    1    other=2
+
+Guarded Calls
+    ${name} =    Set Variable    Login
+    Run Keyword    ${name}
+    Login    @{args}
+    Login    &{kwargs}
+    Unknown Library Keyword    a    b    c
+    Embedded value Keyword
+    With Varargs    1    2    3
+    Log    anything
+
+Value With Equal Sign
+    Login    user=name    pass
+
+Templated Test
+    [Template]    Login
+    user    pass

--- a/tests/linter/rules/arguments/missing_argument_name/test_rule.py
+++ b/tests/linter/rules/arguments/missing_argument_name/test_rule.py
@@ -1,0 +1,36 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    rule_name = "missing-argument-name"
+
+    def test_rule(self):
+        self.check_rule(
+            src_files=["test.robot", "keywords.resource"],
+            expected_file="expected_output.txt",
+            project_check=True,
+        )
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["test.robot", "keywords.resource"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )
+
+    def test_min_arguments(self):
+        self.check_rule(
+            src_files=["test.robot", "keywords.resource"],
+            expected_file="expected_min_arguments.txt",
+            configure=["missing-argument-name.min_arguments=2"],
+            project_check=True,
+        )
+
+    def test_library_keywords(self):
+        self.check_rule(
+            src_files=["test.robot", "keywords.resource"],
+            expected_file="expected_library_keywords.txt",
+            configure=["missing-argument-name.ignore_library_keywords=False"],
+            project_check=True,
+        )

--- a/tests/project/test_missing_argument_name_fix.py
+++ b/tests/project/test_missing_argument_name_fix.py
@@ -1,0 +1,62 @@
+"""Tests for the fix of the ``missing-argument-name`` rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from robocop.run import check_files
+
+KEYWORDS = """*** Keywords ***
+Login
+    [Arguments]    ${username}    ${password}    ${remember}=False
+    Log    ${username}
+"""
+SOURCE = """*** Settings ***
+Resource    keywords.resource
+
+*** Test Cases ***
+Test
+    Login    user    pwd
+    Login    user    pwd=x    remember=True
+"""
+FIXED = """*** Settings ***
+Resource    keywords.resource
+
+*** Test Cases ***
+Test
+    Login    username=user    password=pwd
+    Login    username=user    password=pwd=x    remember=True
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "keywords.resource").write_text(KEYWORDS)
+    (tmp_path / "test.robot").write_text(SOURCE)
+    return tmp_path
+
+
+def run(source, **kwargs):
+    return check_files(
+        sources=[source],
+        select=["missing-argument-name"],
+        root=source,
+        ignore_file_config=True,
+        return_result=True,
+        cache=False,
+        silent=True,
+        **kwargs,
+    )
+
+
+class TestMissingArgumentNameFix:
+    def test_all_arguments_in_the_line_are_fixed_at_once(self, project):
+        diagnostics = run(project, fix=True)
+
+        assert (project / "test.robot").read_text() == FIXED
+        assert diagnostics == []
+
+    def test_diff_does_not_modify_the_file(self, project):
+        run(project, diff=True)
+
+        assert (project / "test.robot").read_text() == SOURCE


### PR DESCRIPTION
Closes #1677

## `missing-argument-name` (ARG09)

New optional project level rule that reports keyword calls using positional arguments instead of named ones.
Argument names come from the keyword definition, so the whole project is analyzed.

```robotframework
*** Test Cases ***
Test
    Create User    Bob    Smith    30  # 3 issues
    Create User    name=Bob    surname=Smith    age=30  # ok
```

Configurable with:

- `ignore_library_keywords` (default `True`) - do not report keywords imported from the libraries,
- `min_arguments` (default `1`) - report only calls with at least given number of positional arguments.

Calls are not reported when the keyword name is built from a variable, the keyword is not found or ambiguous,
it uses embedded arguments, the call expands `@{list}` / `&{dict}`, the keyword is used as a template,
it is a run keyword, or the argument would land in `*varargs`.

The rule comes with a SAFE fix that adds the argument name.

## Side changes

- `FixApplier` now keeps multiple non overlapping single line replacements, so all arguments in one line
  are fixed in a single pass (previously only the first edit per line was applied),
- project level fixes reuse source files already parsed for the project context. Without it the next scan
  used a stale model and re-applied the same fixes on already fixed lines,
- `KeywordUsage` stores positions of the arguments (cache format bumped to version 2).
