### PR TITLE
feat: add missing-keyword-prefix project rule with a fix

### DIFF
--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -135,6 +135,7 @@ Currently available project level rules are:
 - ``unused-resource-import`` - nothing from the imported resource file is used,
 - ``unused-library-import`` - no keyword from the imported library is used,
 - ``ambiguous-keyword-name`` - keyword name matches keywords from more than one source,
+- ``missing-keyword-prefix`` - keyword is called without the name of the resource file or library it comes from,
 - ``keyword-not-found`` - called keyword is not defined anywhere (requires ``--analyze-libraries``),
 - ``circular-import`` - resource file imports, directly or indirectly, the file it is imported in,
 - ``duplicated-variable-in-project`` - the same variable is defined in multiple files visible together.

--- a/src/robocop/linter/checkers/usage.py
+++ b/src/robocop/linter/checkers/usage.py
@@ -280,6 +280,76 @@ def _describe_sources(definitions: list[KeywordDefinition]) -> str:
     return ", ".join(sources)
 
 
+class MissingKeywordPrefix(ProjectChecker):
+    """Reports keyword calls that do not use the name of the resource file or library the keyword comes from."""
+
+    missing_keyword_prefix: usage.MissingKeywordPrefixRule
+
+    def scan_project(
+        self,
+        project_source_file: SourceFile | VirtualSourceFile,
+        config_manager: ConfigManager,  # noqa: ARG002
+        context: ProjectContext,
+    ) -> list[Diagnostic]:
+        self.issues = []
+        for project_file, keyword_usage in context.iter_usages():
+            prefix = self._find_prefix(context, keyword_usage)
+            if prefix is None:
+                continue
+            self.report(
+                self.missing_keyword_prefix,
+                source=SourceFile(path=project_file.path, config=project_source_file.config),
+                keyword_name=keyword_usage.name,
+                prefix=prefix,
+                prefix_offset=_bdd_prefix_offset(keyword_usage),
+                lineno=keyword_usage.location.lineno,
+                col=keyword_usage.location.col,
+                end_lineno=keyword_usage.location.end_lineno,
+                end_col=keyword_usage.location.end_col,
+            )
+        return self.issues
+
+    def _find_prefix(self, context: ProjectContext, keyword_usage: KeywordUsage) -> str | None:
+        """
+        Find the prefix the call should use.
+
+        Returns:
+            Name of the resource file or library, or None if the call should not be reported.
+
+        """
+        if keyword_usage.name_contains_variable or keyword_usage.is_template:
+            return None
+        name = keyword_usage.names_to_check()[-1]
+        if "." in name:
+            return None  # already prefixed, or the name contains a dot and cannot be prefixed safely
+        definitions = context.resolve_keyword(keyword_usage)
+        if len(definitions) != 1:
+            return None  # not defined in the project, or ambiguous
+        definition = definitions[0]
+        if definition.location.source == keyword_usage.location.source:
+            return None  # keyword defined in the file with the call, there is nothing to prefix it with
+        # keywords from the libraries imported with the ``AS`` syntax already use the alias as the library name
+        prefix = definition.library_name or definition.location.source.stem
+        if normalize_robot_name(prefix) in self.missing_keyword_prefix.ignored_sources:
+            return None
+        return prefix
+
+
+def _bdd_prefix_offset(keyword_usage: KeywordUsage) -> int:
+    """
+    Find where the keyword name starts, ignoring the BDD prefix.
+
+    The prefix is added after the BDD word, so that ``Given Login`` becomes ``Given login.Login``.
+
+    Returns:
+        Number of characters between the start of the call and the start of the keyword name.
+
+    """
+    if keyword_usage.bdd_prefix is None:
+        return 0
+    return len(keyword_usage.name) - len(keyword_usage.names_to_check()[-1])
+
+
 class UnusedKeywords(ProjectChecker):
     """Reports keywords that are never called in the project."""
 

--- a/src/robocop/linter/rules/usage.py
+++ b/src/robocop/linter/rules/usage.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, Rule, RuleParam, RuleSeverity
+from robocop.linter.rules.keywords import comma_separated_list
+
+if TYPE_CHECKING:
+    from robocop.linter.diagnostics import Diagnostic
 
 
 class UnusedKeywordRule(Rule):
@@ -136,3 +143,82 @@ class AmbiguousKeywordNameRule(Rule):
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
+
+
+class MissingKeywordPrefixRule(FixableRule):
+    """
+    Keyword is called without the name of the resource file or library it comes from.
+
+    Optional rule for projects that require every keyword call to be prefixed with the source of the keyword.
+    Such calls are unambiguous and it is immediately clear where the keyword comes from:
+
+        *** Settings ***
+        Resource       login.resource
+        Library        SeleniumLibrary
+
+        *** Test Cases ***
+        Test
+            Login    user    password        # will be reported
+            Click Element    id:submit       # will be reported
+
+            login.Login    user    password  # explicit, not reported
+            SeleniumLibrary.Click Element    id:submit
+
+    The rule is not enabled by default. Select it to use it:
+
+        robocop check --select missing-keyword-prefix
+
+    Libraries imported with the ``AS`` (``WITH NAME``) syntax are expected to be called using the alias.
+    Keywords defined in the file with the call are never reported, since there is nothing to prefix them with.
+
+    ``BuiltIn`` keywords are not reported by default. Configure ``ignored_sources`` with a comma separated list of
+    resource file, library and alias names to change it:
+
+        robocop check --select missing-keyword-prefix -c missing-keyword-prefix.ignored_sources=BuiltIn,Collections
+
+    To avoid false positives, the call is not reported when:
+
+    - the keyword name is built from a variable,
+    - the keyword name already contains a dot, since it may be prefixed already,
+    - the keyword is not found in the project, or more than one definition matches the name.
+
+    Keywords coming from libraries are only reported if the library analysis is enabled (it is by default).
+
+    """
+
+    name = "missing-keyword-prefix"
+    project_rule = True
+    rule_id = "KW07"
+    message = "Keyword '{keyword_name}' should be called with the '{prefix}' prefix"
+    severity = RuleSeverity.WARNING
+    enabled = False
+    added_in_version = "9.0.0"
+    fix_availability = FixAvailability.ALWAYS
+    fix_suggestion = "Add the name of the resource file or library to the keyword call"
+    parameters = [
+        RuleParam(
+            name="ignored_sources",
+            default="BuiltIn",
+            converter=comma_separated_list,
+            show_type="str",
+            desc="Comma separated list of the resource files and libraries that do not require the prefix",
+        )
+    ]
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        prefix = str(diag.reported_arguments["prefix"])
+        offset = int(diag.reported_arguments["prefix_offset"])  # type: ignore[call-overload]
+        column = diag.range.start.character + offset
+        edit = TextEdit(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            start_line=diag.range.start.line,
+            start_col=column,
+            end_line=diag.range.start.line,
+            end_col=column,
+            replacement=f"{prefix}.",
+        )
+        return Fix(edits=[edit], message=f"Add '{prefix}' prefix", applicability=FixApplicability.SAFE)

--- a/tests/linter/rules/keywords/missing_keyword_prefix/alias/expected_output.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/alias/expected_output.txt
@@ -1,0 +1,4 @@
+test.robot:6:5 [W] KW07 Keyword 'Append To List' should be called with the 'Coll' prefix
+
+Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/alias/test.robot
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/alias/test.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Library     Collections    AS    Coll
+
+*** Test Cases ***
+Test
+    Append To List    ${list}    item
+    Coll.Append To List    ${list}    item

--- a/tests/linter/rules/keywords/missing_keyword_prefix/expected_extended.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/expected_extended.txt
@@ -1,0 +1,54 @@
+test.robot:8:5 KW07 Keyword 'Login' should be called with the 'login' prefix
+   |
+ 6 | *** Test Cases ***
+ 7 | Missing Prefix
+ 8 |     Login    user
+   |     ^^^^^ KW07
+ 9 |     Given Logout
+10 |     Append To List    ${list}    item
+   | Suggestion: Add the name of the resource file or library to the keyword call
+   |
+
+test.robot:9:5 KW07 Keyword 'Given Logout' should be called with the 'login' prefix
+   |
+ 7 | Missing Prefix
+ 8 |     Login    user
+ 9 |     Given Logout
+   |     ^^^^^^^^^^^^ KW07
+10 |     Append To List    ${list}    item
+11 |     Convert To Lower Case    ABC
+   | Suggestion: Add the name of the resource file or library to the keyword call
+   |
+
+test.robot:10:5 KW07 Keyword 'Append To List' should be called with the 'Collections' prefix
+    |
+  8 |     Login    user
+  9 |     Given Logout
+ 10 |     Append To List    ${list}    item
+    |     ^^^^^^^^^^^^^^ KW07
+ 11 |     Convert To Lower Case    ABC
+ 12 |     Keyword With value Argument
+    | Suggestion: Add the name of the resource file or library to the keyword call
+    |
+
+test.robot:11:5 KW07 Keyword 'Convert To Lower Case' should be called with the 'Str' prefix
+    |
+  9 |     Given Logout
+ 10 |     Append To List    ${list}    item
+ 11 |     Convert To Lower Case    ABC
+    |     ^^^^^^^^^^^^^^^^^^^^^ KW07
+ 12 |     Keyword With value Argument
+    | Suggestion: Add the name of the resource file or library to the keyword call
+    |
+
+test.robot:12:5 KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
+    |
+ 10 |     Append To List    ${list}    item
+ 11 |     Convert To Lower Case    ABC
+ 12 |     Keyword With value Argument
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ KW07
+    | Suggestion: Add the name of the resource file or library to the keyword call
+    |
+
+Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/expected_extended.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/expected_extended.txt
@@ -1,54 +1,43 @@
-test.robot:8:5 KW07 Keyword 'Login' should be called with the 'login' prefix
+test.robot:7:5 KW07 Keyword 'Login' should be called with the 'login' prefix
    |
- 6 | *** Test Cases ***
- 7 | Missing Prefix
- 8 |     Login    user
+ 5 | *** Test Cases ***
+ 6 | Missing Prefix
+ 7 |     Login    user
    |     ^^^^^ KW07
- 9 |     Given Logout
-10 |     Append To List    ${list}    item
+ 8 |     Given Logout
+ 9 |     Append To List    ${list}    item
    | Suggestion: Add the name of the resource file or library to the keyword call
    |
 
-test.robot:9:5 KW07 Keyword 'Given Logout' should be called with the 'login' prefix
+test.robot:8:5 KW07 Keyword 'Given Logout' should be called with the 'login' prefix
    |
- 7 | Missing Prefix
- 8 |     Login    user
- 9 |     Given Logout
+ 6 | Missing Prefix
+ 7 |     Login    user
+ 8 |     Given Logout
    |     ^^^^^^^^^^^^ KW07
-10 |     Append To List    ${list}    item
-11 |     Convert To Lower Case    ABC
+ 9 |     Append To List    ${list}    item
+10 |     Keyword With value Argument
    | Suggestion: Add the name of the resource file or library to the keyword call
    |
 
-test.robot:10:5 KW07 Keyword 'Append To List' should be called with the 'Collections' prefix
-    |
-  8 |     Login    user
-  9 |     Given Logout
- 10 |     Append To List    ${list}    item
-    |     ^^^^^^^^^^^^^^ KW07
- 11 |     Convert To Lower Case    ABC
- 12 |     Keyword With value Argument
-    | Suggestion: Add the name of the resource file or library to the keyword call
-    |
+test.robot:9:5 KW07 Keyword 'Append To List' should be called with the 'Collections' prefix
+   |
+ 7 |     Login    user
+ 8 |     Given Logout
+ 9 |     Append To List    ${list}    item
+   |     ^^^^^^^^^^^^^^ KW07
+10 |     Keyword With value Argument
+   | Suggestion: Add the name of the resource file or library to the keyword call
+   |
 
-test.robot:11:5 KW07 Keyword 'Convert To Lower Case' should be called with the 'Str' prefix
+test.robot:10:5 KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
     |
-  9 |     Given Logout
- 10 |     Append To List    ${list}    item
- 11 |     Convert To Lower Case    ABC
-    |     ^^^^^^^^^^^^^^^^^^^^^ KW07
- 12 |     Keyword With value Argument
-    | Suggestion: Add the name of the resource file or library to the keyword call
-    |
-
-test.robot:12:5 KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
-    |
- 10 |     Append To List    ${list}    item
- 11 |     Convert To Lower Case    ABC
- 12 |     Keyword With value Argument
+  8 |     Given Logout
+  9 |     Append To List    ${list}    item
+ 10 |     Keyword With value Argument
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ KW07
     | Suggestion: Add the name of the resource file or library to the keyword call
     |
 
-Found 5 issues.
-5 fixable with the '--fix' option.
+Found 4 issues.
+4 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/expected_ignored_sources.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/expected_ignored_sources.txt
@@ -1,6 +1,6 @@
-test.robot:8:5 [W] KW07 Keyword 'Login' should be called with the 'login' prefix
-test.robot:9:5 [W] KW07 Keyword 'Given Logout' should be called with the 'login' prefix
-test.robot:12:5 [W] KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
+test.robot:7:5 [W] KW07 Keyword 'Login' should be called with the 'login' prefix
+test.robot:8:5 [W] KW07 Keyword 'Given Logout' should be called with the 'login' prefix
+test.robot:10:5 [W] KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
 
 Found 3 issues.
 3 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/expected_ignored_sources.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/expected_ignored_sources.txt
@@ -1,0 +1,6 @@
+test.robot:8:5 [W] KW07 Keyword 'Login' should be called with the 'login' prefix
+test.robot:9:5 [W] KW07 Keyword 'Given Logout' should be called with the 'login' prefix
+test.robot:12:5 [W] KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
+
+Found 3 issues.
+3 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/expected_output.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/expected_output.txt
@@ -1,8 +1,7 @@
-test.robot:8:5 [W] KW07 Keyword 'Login' should be called with the 'login' prefix
-test.robot:9:5 [W] KW07 Keyword 'Given Logout' should be called with the 'login' prefix
-test.robot:10:5 [W] KW07 Keyword 'Append To List' should be called with the 'Collections' prefix
-test.robot:11:5 [W] KW07 Keyword 'Convert To Lower Case' should be called with the 'Str' prefix
-test.robot:12:5 [W] KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
+test.robot:7:5 [W] KW07 Keyword 'Login' should be called with the 'login' prefix
+test.robot:8:5 [W] KW07 Keyword 'Given Logout' should be called with the 'login' prefix
+test.robot:9:5 [W] KW07 Keyword 'Append To List' should be called with the 'Collections' prefix
+test.robot:10:5 [W] KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
 
-Found 5 issues.
-5 fixable with the '--fix' option.
+Found 4 issues.
+4 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/expected_output.txt
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/expected_output.txt
@@ -1,0 +1,8 @@
+test.robot:8:5 [W] KW07 Keyword 'Login' should be called with the 'login' prefix
+test.robot:9:5 [W] KW07 Keyword 'Given Logout' should be called with the 'login' prefix
+test.robot:10:5 [W] KW07 Keyword 'Append To List' should be called with the 'Collections' prefix
+test.robot:11:5 [W] KW07 Keyword 'Convert To Lower Case' should be called with the 'Str' prefix
+test.robot:12:5 [W] KW07 Keyword 'Keyword With value Argument' should be called with the 'login' prefix
+
+Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/keywords/missing_keyword_prefix/resources/login.resource
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/resources/login.resource
@@ -1,0 +1,10 @@
+*** Keywords ***
+Login
+    [Arguments]    ${username}
+    Log    ${username}
+
+Logout
+    Log    bye
+
+Keyword With ${embedded} Argument
+    Log    ${embedded}

--- a/tests/linter/rules/keywords/missing_keyword_prefix/test.robot
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/test.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Resource    resources/login.resource
+Library     Collections
+Library     String    AS    Str
+
+*** Test Cases ***
+Missing Prefix
+    Login    user
+    Given Logout
+    Append To List    ${list}    item
+    Convert To Lower Case    ABC
+    Keyword With value Argument
+
+Prefixed Calls
+    login.Login    user
+    Collections.Append To List    ${list}    item
+    Str.Convert To Lower Case    ABC
+
+Ignored Calls
+    Log    message
+    Local Keyword
+    ${name} =    Set Variable    Login
+    Run Keyword    ${name}
+    Not Defined Anywhere    argument
+
+*** Keywords ***
+Local Keyword
+    Log    local

--- a/tests/linter/rules/keywords/missing_keyword_prefix/test.robot
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/test.robot
@@ -1,20 +1,17 @@
 *** Settings ***
 Resource    resources/login.resource
 Library     Collections
-Library     String    AS    Str
 
 *** Test Cases ***
 Missing Prefix
     Login    user
     Given Logout
     Append To List    ${list}    item
-    Convert To Lower Case    ABC
     Keyword With value Argument
 
 Prefixed Calls
     login.Login    user
     Collections.Append To List    ${list}    item
-    Str.Convert To Lower Case    ABC
 
 Ignored Calls
     Log    message

--- a/tests/linter/rules/keywords/missing_keyword_prefix/test_rule.py
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/test_rule.py
@@ -5,13 +5,19 @@ class TestRuleAcceptance(RuleAcceptance):
     rule_name = "missing-keyword-prefix"
 
     def test_rule(self):
-        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_output.txt",
+            exclude=["alias"],
+            project_check=True,
+        )
 
     def test_extended(self):
         self.check_rule(
             src_files=["."],
             expected_file="expected_extended.txt",
             output_format="extended",
+            exclude=["alias"],
             project_check=True,
         )
 
@@ -19,6 +25,17 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(
             src_files=["."],
             expected_file="expected_ignored_sources.txt",
-            configure=["missing-keyword-prefix.ignored_sources=BuiltIn,Collections,Str"],
+            configure=["missing-keyword-prefix.ignored_sources=BuiltIn,Collections"],
+            exclude=["alias"],
+            project_check=True,
+        )
+
+    def test_library_alias(self):
+        """Library imported with the ``AS`` syntax should be called using the alias."""
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_output.txt",
+            test_dir=self.test_class_dir / "alias",
+            test_on_version=">=6",
             project_check=True,
         )

--- a/tests/linter/rules/keywords/missing_keyword_prefix/test_rule.py
+++ b/tests/linter/rules/keywords/missing_keyword_prefix/test_rule.py
@@ -1,0 +1,24 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    rule_name = "missing-keyword-prefix"
+
+    def test_rule(self):
+        self.check_rule(src_files=["."], expected_file="expected_output.txt", project_check=True)
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            project_check=True,
+        )
+
+    def test_ignored_sources(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file="expected_ignored_sources.txt",
+            configure=["missing-keyword-prefix.ignored_sources=BuiltIn,Collections,Str"],
+            project_check=True,
+        )

--- a/tests/project/test_missing_keyword_prefix_fix.py
+++ b/tests/project/test_missing_keyword_prefix_fix.py
@@ -1,0 +1,77 @@
+"""Tests for the fix of the ``missing-keyword-prefix`` rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from robocop.run import check_files
+
+RESOURCE = """*** Keywords ***
+Login
+    [Arguments]    ${username}
+    Log    ${username}
+
+Logout
+    Log    bye
+"""
+SOURCE = """*** Settings ***
+Resource    login.resource
+
+*** Test Cases ***
+Test
+    Login    user
+    Given Logout
+    login.Login    user
+    Local Keyword
+
+*** Keywords ***
+Local Keyword
+    Log    local
+"""
+FIXED = """*** Settings ***
+Resource    login.resource
+
+*** Test Cases ***
+Test
+    login.Login    user
+    Given login.Logout
+    login.Login    user
+    Local Keyword
+
+*** Keywords ***
+Local Keyword
+    Log    local
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "login.resource").write_text(RESOURCE)
+    (tmp_path / "test.robot").write_text(SOURCE)
+    return tmp_path
+
+
+def run(source, **kwargs):
+    return check_files(
+        sources=[source],
+        select=["missing-keyword-prefix"],
+        root=source,
+        ignore_file_config=True,
+        return_result=True,
+        cache=False,
+        silent=True,
+        **kwargs,
+    )
+
+
+class TestMissingKeywordPrefixFix:
+    def test_prefix_is_added(self, project):
+        diagnostics = run(project, fix=True)
+
+        assert (project / "test.robot").read_text() == FIXED
+        assert diagnostics == []
+
+    def test_diff_does_not_modify_the_file(self, project):
+        run(project, diff=True)
+
+        assert (project / "test.robot").read_text() == SOURCE


### PR DESCRIPTION
Closes MarketSquare/robotframework-tidy#54


## `missing-keyword-prefix` (KW07)

New optional project level rule that reports keyword calls without the name of the resource file or library
the keyword comes from.

```robotframework
*** Settings ***
Resource       login.resource
Library        SeleniumLibrary

*** Test Cases ***
Test
    Login    user    password        # reported
    Click Element    id:submit       # reported

    login.Login    user    password  # ok
    SeleniumLibrary.Click Element    id:submit
```

- libraries imported with `AS` are expected to be called with the alias,
- keywords defined in the file with the call are never reported,
- BDD prefixes are kept in place (`Given Logout` -> `Given login.Logout`),
- `ignored_sources` (default `BuiltIn`) is a comma separated list of sources that do not need the prefix,
- calls are skipped when the name is built from a variable, already contains a dot, or the keyword is not found
  or ambiguous.

The rule comes with a SAFE fix that adds the prefix.
