### PR TITLE
feat: add fixes for the empty settings rules

### DIFF
--- a/src/robocop/linter/checkers/settings.py
+++ b/src/robocop/linter/checkers/settings.py
@@ -75,7 +75,6 @@ class SettingsChecker(VisitorChecker):
         self.task_section: bool | None = None
         self.libraries: list[LibraryImport] = []
         self.resources: list[ResourceImport] = []
-        self.suite_settings: set[str] = set()
         self.in_test_case = False
         super().__init__()
 
@@ -90,34 +89,22 @@ class SettingsChecker(VisitorChecker):
                 else:
                     self.task_section = False
                 break
-        self.suite_settings = self.find_suite_settings(node)
         self.libraries = []
         self.resources = []
         self.in_test_case = False
         self.generic_visit(node)
         self.check_import_order()
 
-    @staticmethod
-    def find_suite_settings(node: File) -> set[str]:
+    def overwrites_suite_setting(self) -> bool:
         """
-        Find suite settings that can be overwritten by the test case settings.
+        Check if the empty setting can overwrite the suite setting.
 
-        Test case settings such as ``[Timeout]`` can be used with an empty value to overwrite the suite setting.
-        Such settings should not be removed, but replaced with the explicit ``NONE`` value.
+        Test case settings such as ``[Timeout]`` are used with an empty value to overwrite the suite setting.
+        The suite setting can be defined in the same file, but also in the ``__init__.robot`` file of the parent
+        suite. Because of that such settings should not be removed, but replaced with the explicit ``NONE`` value.
+        Keyword settings can never overwrite the suite settings and can be safely removed.
         """
-        overwritable = {Token.TEST_SETUP, Token.TEST_TEARDOWN, Token.TEST_TIMEOUT, Token.TEST_TEMPLATE}
-        suite_settings = set()
-        for section in node.sections:
-            if not isinstance(section, SettingSection):
-                continue
-            for statement in section.body:
-                if statement.type in overwritable and len(statement.data_tokens) > 1:
-                    suite_settings.add(statement.type)
-        return suite_settings
-
-    def overwrites_suite_setting(self, setting_type: str) -> bool:
-        """Check if the empty test case setting overwrites the suite setting."""
-        return self.in_test_case and setting_type in self.suite_settings
+        return self.in_test_case
 
     def check_import_order(self) -> None:
         built_in_libs: list[LibraryImport] = []
@@ -226,7 +213,7 @@ class SettingsChecker(VisitorChecker):
             self.libraries.append(node)
 
     def visit_Setup(self, node: Statement) -> None:  # noqa: N802
-        self.empty_setup.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_SETUP))
+        self.empty_setup.check(node, self.parent_node_name, self.overwrites_suite_setting())
         self.check_setting_name(node)
 
     def visit_SuiteSetup(self, node: Statement) -> None:  # noqa: N802
@@ -238,7 +225,7 @@ class SettingsChecker(VisitorChecker):
         self.check_setting_name(node)
 
     def visit_Teardown(self, node: Statement) -> None:  # noqa: N802
-        self.empty_teardown.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_TEARDOWN))
+        self.empty_teardown.check(node, self.parent_node_name, self.overwrites_suite_setting())
         self.check_setting_name(node)
 
     def visit_SuiteTeardown(self, node: Statement) -> None:  # noqa: N802
@@ -250,7 +237,7 @@ class SettingsChecker(VisitorChecker):
         self.check_setting_name(node)
 
     def visit_Timeout(self, node: Statement) -> None:  # noqa: N802
-        self.empty_timeout.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_TIMEOUT))
+        self.empty_timeout.check(node, self.parent_node_name, self.overwrites_suite_setting())
         self.check_setting_name(node)
 
     def visit_TestTimeout(self, node: Statement) -> None:  # noqa: N802
@@ -258,7 +245,7 @@ class SettingsChecker(VisitorChecker):
         self.check_setting_name(node)
 
     def visit_Template(self, node: Template) -> None:  # noqa: N802
-        self.empty_template.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_TEMPLATE))
+        self.empty_template.check(node, self.parent_node_name, self.overwrites_suite_setting())
         self.check_setting_name(node)
 
     def visit_TestTemplate(self, node: Statement) -> None:  # noqa: N802

--- a/src/robocop/linter/checkers/settings.py
+++ b/src/robocop/linter/checkers/settings.py
@@ -6,14 +6,14 @@ from typing import TYPE_CHECKING
 
 from robot.api import Token
 from robot.libraries import STDLIBS
-from robot.parsing.model.blocks import TestCaseSection
+from robot.parsing.model.blocks import SettingSection, TestCaseSection
 
 from robocop.linter.rules import VisitorChecker, deprecated, errors, imports, lengths, naming
 from robocop.version_handling import ROBOT_VERSION
 
 if TYPE_CHECKING:
     from robot.parsing import File
-    from robot.parsing.model.blocks import InvalidSection, Keyword, SettingSection
+    from robot.parsing.model.blocks import InvalidSection, Keyword, TestCase
     from robot.parsing.model.statements import (
         Arguments,
         LibraryImport,
@@ -75,6 +75,8 @@ class SettingsChecker(VisitorChecker):
         self.task_section: bool | None = None
         self.libraries: list[LibraryImport] = []
         self.resources: list[ResourceImport] = []
+        self.suite_settings: set[str] = set()
+        self.in_test_case = False
         super().__init__()
 
     def visit_File(self, node: File) -> None:  # noqa: N802
@@ -88,10 +90,34 @@ class SettingsChecker(VisitorChecker):
                 else:
                     self.task_section = False
                 break
+        self.suite_settings = self.find_suite_settings(node)
         self.libraries = []
         self.resources = []
+        self.in_test_case = False
         self.generic_visit(node)
         self.check_import_order()
+
+    @staticmethod
+    def find_suite_settings(node: File) -> set[str]:
+        """
+        Find suite settings that can be overwritten by the test case settings.
+
+        Test case settings such as ``[Timeout]`` can be used with an empty value to overwrite the suite setting.
+        Such settings should not be removed, but replaced with the explicit ``NONE`` value.
+        """
+        overwritable = {Token.TEST_SETUP, Token.TEST_TEARDOWN, Token.TEST_TIMEOUT, Token.TEST_TEMPLATE}
+        suite_settings = set()
+        for section in node.sections:
+            if not isinstance(section, SettingSection):
+                continue
+            for statement in section.body:
+                if statement.type in overwritable and len(statement.data_tokens) > 1:
+                    suite_settings.add(statement.type)
+        return suite_settings
+
+    def overwrites_suite_setting(self, setting_type: str) -> bool:
+        """Check if the empty test case setting overwrites the suite setting."""
+        return self.in_test_case and setting_type in self.suite_settings
 
     def check_import_order(self) -> None:
         built_in_libs: list[LibraryImport] = []
@@ -142,6 +168,11 @@ class SettingsChecker(VisitorChecker):
     def visit_TestCaseName(self, node: Statement) -> None:  # noqa: N802
         self.parent_node_name = f"'{node.name}' Test Case" if node.name else ""
         self.generic_visit(node)
+
+    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
+        self.in_test_case = True
+        self.generic_visit(node)
+        self.in_test_case = False
 
     def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
         self.parent_node_name = f"'{node.name}' Keyword" if node.name else ""
@@ -195,7 +226,7 @@ class SettingsChecker(VisitorChecker):
             self.libraries.append(node)
 
     def visit_Setup(self, node: Statement) -> None:  # noqa: N802
-        self.empty_setup.check(node, self.parent_node_name)
+        self.empty_setup.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_SETUP))
         self.check_setting_name(node)
 
     def visit_SuiteSetup(self, node: Statement) -> None:  # noqa: N802
@@ -207,7 +238,7 @@ class SettingsChecker(VisitorChecker):
         self.check_setting_name(node)
 
     def visit_Teardown(self, node: Statement) -> None:  # noqa: N802
-        self.empty_teardown.check(node, self.parent_node_name)
+        self.empty_teardown.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_TEARDOWN))
         self.check_setting_name(node)
 
     def visit_SuiteTeardown(self, node: Statement) -> None:  # noqa: N802
@@ -219,7 +250,7 @@ class SettingsChecker(VisitorChecker):
         self.check_setting_name(node)
 
     def visit_Timeout(self, node: Statement) -> None:  # noqa: N802
-        self.empty_timeout.check(node, self.parent_node_name)
+        self.empty_timeout.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_TIMEOUT))
         self.check_setting_name(node)
 
     def visit_TestTimeout(self, node: Statement) -> None:  # noqa: N802
@@ -227,7 +258,7 @@ class SettingsChecker(VisitorChecker):
         self.check_setting_name(node)
 
     def visit_Template(self, node: Template) -> None:  # noqa: N802
-        self.empty_template.check(node, self.parent_node_name)
+        self.empty_template.check(node, self.parent_node_name, self.overwrites_suite_setting(Token.TEST_TEMPLATE))
         self.check_setting_name(node)
 
     def visit_TestTemplate(self, node: Statement) -> None:  # noqa: N802

--- a/src/robocop/linter/fix.py
+++ b/src/robocop/linter/fix.py
@@ -4,12 +4,17 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from robot.api import Token
+
 from robocop.files import path_relative_to_cwd
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from robocop.linter.diagnostics import Range
+    from robot.parsing.model.statements import Statement
+
+    from robocop.linter.diagnostics import Diagnostic, Range
+    from robocop.linter.rules import Rule
     from robocop.source_file import SourceFile
 
 
@@ -157,6 +162,81 @@ class Fix:
     edits: list[TextEdit]
     message: str
     applicability: FixApplicability
+
+
+def _comment_lines(node: Statement, source_lines: list[str]) -> list[str]:
+    """
+    Return lines with the comments from the statement, without the statement data itself.
+
+    Only the first comment in the line is used, since the rest of the line is taken as it is.
+    The original indentation of the line is preserved.
+    """
+    comment_lines = []
+    seen_lines = set()
+    for token in node.get_tokens(Token.COMMENT):
+        if token.lineno in seen_lines:
+            continue
+        seen_lines.add(token.lineno)
+        line = source_lines[token.lineno - 1]
+        indent = line[: len(line) - len(line.lstrip())]
+        comment_lines.append(f"{indent}{line[token.col_offset :]}")
+    return comment_lines
+
+
+def remove_statement_fix(rule: Rule, node: Statement, source_lines: list[str], message: str) -> Fix:
+    """
+    Create a fix that removes the whole statement.
+
+    Comments are not removed together with the statement - they are left in place instead.
+    """
+    if comment_lines := _comment_lines(node, source_lines):
+        edit = TextEdit.replace_lines(rule.rule_id, rule.name, node.lineno, node.end_lineno, "".join(comment_lines))
+    else:
+        edit = TextEdit(
+            rule_id=rule.rule_id,
+            rule_name=rule.name,
+            start_line=node.lineno,
+            start_col=1,
+            end_line=node.end_lineno,
+            end_col=1,
+            replacement="",
+            kind=TextEditKind.DELETION,
+        )
+    return Fix(edits=[edit], message=message, applicability=FixApplicability.SAFE)
+
+
+def add_setting_value_fix(rule: Rule, node: Statement, value: str, message: str, separator: str = "    ") -> Fix:
+    """Create a fix that adds the value to the setting without any value."""
+    setting_token = node.data_tokens[0]
+    column = setting_token.end_col_offset + 1
+    edit = TextEdit(
+        rule_id=rule.rule_id,
+        rule_name=rule.name,
+        start_line=setting_token.lineno,
+        start_col=column,
+        end_line=setting_token.lineno,
+        end_col=column,
+        replacement=f"{separator}{value}",
+    )
+    return Fix(edits=[edit], message=message, applicability=FixApplicability.SAFE)
+
+
+def remove_empty_setting_fix(rule: Rule, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+    """
+    Create a fix for the setting without any value.
+
+    Empty settings are removed, unless they overwrite the suite setting. In such case the ``NONE`` value is used
+    to make the intention explicit.
+    """
+    node = diag.node
+    if node is None or not node.data_tokens:
+        return None
+    setting_name = node.data_tokens[0].value
+    if diag.reported_arguments.get("overwrites_suite_setting"):
+        return add_setting_value_fix(
+            rule, node, "NONE", f"Replace empty '{setting_name}' setting with an explicit NONE value"
+        )
+    return remove_statement_fix(rule, node, source_lines, f"Remove empty '{setting_name}' setting")
 
 
 @dataclass

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -522,8 +522,10 @@ class EmptySettingRule(FixableRule):
     Base class for the rules reporting settings without any value.
 
     The fix removes such setting, since a setting without a value does not have any effect.
-    The only exception are the settings overwriting the suite settings (for example ``[Timeout]`` when
-    ``Test Timeout`` is set). Those are not removed but filled with the explicit ``NONE`` value instead.
+    The only exception are the test case settings that can overwrite the suite settings
+    (``[Setup]``, ``[Teardown]``, ``[Timeout]`` and ``[Template]``). Those are not removed but filled with the
+    explicit ``NONE`` value instead, since the suite setting can be also defined in the ``__init__.robot`` file
+    of the parent suite.
     Comments are never removed by the fix.
     """
 

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -27,7 +27,9 @@ except ImportError:
     Var = None
 
 from robocop.linter import sonar_qube
+from robocop.linter.fix import FixAvailability, remove_empty_setting_fix
 from robocop.linter.rules import (
+    FixableRule,
     Rule,
     RuleParam,
     RuleSeverity,
@@ -44,6 +46,9 @@ if TYPE_CHECKING:
     from robot.parsing import File
     from robot.parsing.model.blocks import Section
     from robot.parsing.model.statements import Node, Statement
+
+    from robocop.linter.diagnostics import Diagnostic
+    from robocop.linter.fix import Fix
 
 
 class TooLongKeywordRule(Rule):
@@ -512,22 +517,41 @@ class NumberOfReturnedValuesRule(Rule):
             self.check(len(node.args) - 1, node)
 
 
+class EmptySettingRule(FixableRule):
+    """
+    Base class for the rules reporting settings without any value.
+
+    The fix removes such setting, since a setting without a value does not have any effect.
+    The only exception are the settings overwriting the suite settings (for example ``[Timeout]`` when
+    ``Test Timeout`` is set). Those are not removed but filled with the explicit ``NONE`` value instead.
+    Comments are never removed by the fix.
+    """
+
+    fix_availability = FixAvailability.ALWAYS
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        return remove_empty_setting_fix(self, diag, source_lines)
+
+
 def report_empty_setting(rule: Rule, node: Statement) -> None:
     """Report an empty setting that spans the whole statement."""
     rule.report(node=node, col=node.col_offset + 1, end_col=node.end_col_offset)
 
 
-def report_empty_block_setting(rule: Rule, node: Statement, block_name: str) -> None:
+def report_empty_block_setting(
+    rule: Rule, node: Statement, block_name: str, overwrites_suite_setting: bool = False
+) -> None:
     """Report an empty setting whose message names the block (test case or keyword) it belongs to."""
     rule.report(
         block_name=block_name,
+        overwrites_suite_setting=overwrites_suite_setting,
         node=node,
         col=node.data_tokens[0].col_offset + 1,
         end_col=node.end_col_offset,
     )
 
 
-class EmptyMetadataRule(Rule):
+class EmptyMetadataRule(EmptySettingRule):
     """
     Metadata settings do not have any value set.
 
@@ -558,7 +582,7 @@ class EmptyMetadataRule(Rule):
             self.report(node=node, col=node.col_offset + 1)
 
 
-class EmptyDocumentationRule(Rule):
+class EmptyDocumentationRule(EmptySettingRule):
     """Documentation is empty."""
 
     name = "empty-documentation"
@@ -576,7 +600,7 @@ class EmptyDocumentationRule(Rule):
             report_empty_block_setting(self, node, block_name)
 
 
-class EmptyForceTagsRule(Rule):  # TODO: Rename/deprecate and replace with Test Tags
+class EmptyForceTagsRule(EmptySettingRule):  # TODO: Rename/deprecate and replace with Test Tags
     """Force Tags are empty."""
 
     name = "empty-force-tags"
@@ -594,7 +618,7 @@ class EmptyForceTagsRule(Rule):  # TODO: Rename/deprecate and replace with Test 
             report_empty_setting(self, node)
 
 
-class EmptyDefaultTagsRule(Rule):
+class EmptyDefaultTagsRule(EmptySettingRule):
     """Default Tags are empty."""
 
     name = "empty-default-tags"
@@ -612,7 +636,7 @@ class EmptyDefaultTagsRule(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyVariablesImport(Rule):
+class EmptyVariablesImport(EmptySettingRule):
     """Import variables path is empty."""
 
     name = "empty-variables-import"
@@ -630,7 +654,7 @@ class EmptyVariablesImport(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyResourceImport(Rule):
+class EmptyResourceImport(EmptySettingRule):
     """Import resources path is empty."""
 
     name = "empty-resource-import"
@@ -648,7 +672,7 @@ class EmptyResourceImport(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyLibraryImport(Rule):
+class EmptyLibraryImport(EmptySettingRule):
     """Import library path is empty."""
 
     name = "empty-library-import"
@@ -666,8 +690,22 @@ class EmptyLibraryImport(Rule):
             report_empty_setting(self, node)
 
 
-class EmptySetupRule(Rule):
-    """Empty setup."""
+class EmptySetupRule(EmptySettingRule):
+    """
+    Empty setup.
+
+    ``[Setup]`` without a value does not have any effect and can be removed.
+    If the intention is to overwrite the ``Test Setup`` from the settings section, use the explicit ``NONE`` value:
+
+        *** Settings ***
+        Test Setup    Open Application
+
+        *** Test Cases ***
+        Test without setup
+            [Setup]    NONE
+            Keyword Call
+
+    """
 
     name = "empty-setup"
     rule_id = "LEN18"
@@ -679,12 +717,12 @@ class EmptySetupRule(Rule):
     )
     deprecated_names = ("0518",)
 
-    def check(self, node: Statement, block_name: str) -> None:
+    def check(self, node: Statement, block_name: str, overwrites_suite_setting: bool = False) -> None:
         if not node.name:
-            report_empty_block_setting(self, node, block_name)
+            report_empty_block_setting(self, node, block_name, overwrites_suite_setting)
 
 
-class EmptySuiteSetupRule(Rule):
+class EmptySuiteSetupRule(EmptySettingRule):
     """Empty Suite Setup."""
 
     name = "empty-suite-setup"
@@ -702,7 +740,7 @@ class EmptySuiteSetupRule(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyTestSetupRule(Rule):
+class EmptyTestSetupRule(EmptySettingRule):
     """Empty Test Setup."""
 
     name = "empty-test-setup"
@@ -720,8 +758,22 @@ class EmptyTestSetupRule(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyTeardownRule(Rule):
-    """Empty Teardown."""
+class EmptyTeardownRule(EmptySettingRule):
+    """
+    Empty Teardown.
+
+    ``[Teardown]`` without a value does not have any effect and can be removed.
+    If the intention is to overwrite the ``Test Teardown`` from the settings section, use the explicit ``NONE`` value:
+
+        *** Settings ***
+        Test Teardown    Close Application
+
+        *** Test Cases ***
+        Test without teardown
+            [Teardown]    NONE
+            Keyword Call
+
+    """
 
     name = "empty-teardown"
     rule_id = "LEN21"
@@ -733,12 +785,12 @@ class EmptyTeardownRule(Rule):
     )
     deprecated_names = ("0521",)
 
-    def check(self, node: Statement, block_name: str) -> None:
+    def check(self, node: Statement, block_name: str, overwrites_suite_setting: bool = False) -> None:
         if not node.name:
-            report_empty_block_setting(self, node, block_name)
+            report_empty_block_setting(self, node, block_name, overwrites_suite_setting)
 
 
-class EmptySuiteTeardownRule(Rule):
+class EmptySuiteTeardownRule(EmptySettingRule):
     """Empty Suite Teardown."""
 
     name = "empty-suite-teardown"
@@ -756,7 +808,7 @@ class EmptySuiteTeardownRule(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyTestTeardownRule(Rule):
+class EmptyTestTeardownRule(EmptySettingRule):
     """Empty Test Teardown."""
 
     name = "empty-test-teardown"
@@ -774,8 +826,22 @@ class EmptyTestTeardownRule(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyTimeoutRule(Rule):
-    """Empty Timeout."""
+class EmptyTimeoutRule(EmptySettingRule):
+    """
+    Empty Timeout.
+
+    ``[Timeout]`` without a value does not have any effect and can be removed.
+    If the intention is to overwrite the ``Test Timeout`` from the settings section, use the explicit ``NONE`` value:
+
+        *** Settings ***
+        Test Timeout    1 min
+
+        *** Test Cases ***
+        Test without timeout
+            [Timeout]    NONE
+            Keyword Call
+
+    """
 
     name = "empty-timeout"
     rule_id = "LEN24"
@@ -787,12 +853,13 @@ class EmptyTimeoutRule(Rule):
     )
     deprecated_names = ("0524",)
 
-    def check(self, node: Statement, block_name: str) -> None:
-        if not node.value:
-            report_empty_block_setting(self, node, block_name)
+    def check(self, node: Statement, block_name: str, overwrites_suite_setting: bool = False) -> None:
+        # ``value`` is not used, since Robot Framework returns None for the explicit ``NONE`` timeout
+        if len(node.data_tokens) < 2:
+            report_empty_block_setting(self, node, block_name, overwrites_suite_setting)
 
 
-class EmptyTestTimeoutRule(Rule):
+class EmptyTestTimeoutRule(EmptySettingRule):
     """Empty Test Timeout."""
 
     name = "empty-test-timeout"
@@ -806,11 +873,12 @@ class EmptyTestTimeoutRule(Rule):
     deprecated_names = ("0525",)
 
     def check(self, node: Statement) -> None:
-        if not node.value:
+        # ``value`` is not used, since Robot Framework returns None for the explicit ``NONE`` timeout
+        if len(node.data_tokens) < 2:
             report_empty_setting(self, node)
 
 
-class EmptyArgumentsRule(Rule):
+class EmptyArgumentsRule(EmptySettingRule):
     """Empty ``[Arguments]`` setting."""
 
     name = "empty-arguments"
@@ -868,7 +936,7 @@ class TooManyTestCasesRule(Rule):
             )
 
 
-class EmptyTestTemplateRule(Rule):
+class EmptyTestTemplateRule(EmptySettingRule):
     """
     Test Template is empty.
 
@@ -891,7 +959,7 @@ class EmptyTestTemplateRule(Rule):
             report_empty_setting(self, node)
 
 
-class EmptyTemplateRule(Rule):
+class EmptyTemplateRule(EmptySettingRule):
     """
     ``[Template]`` is empty.
 
@@ -923,12 +991,12 @@ class EmptyTemplateRule(Rule):
     )
     deprecated_names = ("0530",)
 
-    def check(self, node: Statement, block_name: str) -> None:
+    def check(self, node: Statement, block_name: str, overwrites_suite_setting: bool = False) -> None:
         if len(node.data_tokens) < 2:
-            report_empty_block_setting(self, node, block_name)
+            report_empty_block_setting(self, node, block_name, overwrites_suite_setting)
 
 
-class EmptyKeywordTagsRule(Rule):
+class EmptyKeywordTagsRule(EmptySettingRule):
     """Keyword Tags are empty."""
 
     name = "empty-keyword-tags"

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -197,7 +197,9 @@ def inherits_from(child: type, parent_name: str) -> bool:
 def is_rule(rule_class_def: tuple[str, type]) -> bool:
     if rule_class_def[0] in {"Rule", "RuleParam", "RuleSeverity", "FixableRule"}:
         return False
-    return inherits_from(rule_class_def[1], "Rule")
+    if not inherits_from(rule_class_def[1], "Rule"):
+        return False
+    return hasattr(rule_class_def[1], "name")  # skip base classes that do not define the rule itself
     # return issubclass(rule_class_def[1], Rule) TODO does not work as is_checker for some reason
 
 

--- a/tests/linter/rules/lengths/empty_arguments/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_arguments/expected_extended.txt
@@ -9,3 +9,4 @@ test.robot:17:5 LEN26 Arguments of 'Keyword Without Arguments' Keyword are empty
     |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_arguments/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_arguments/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 1 issue:
+- actual_fixed${/}test.robot:
+    1 x LEN26 (empty-arguments)
+
+Found 1 issue (1 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_arguments/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_arguments/expected_fixed/test.robot
@@ -1,0 +1,24 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword Without Arguments
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Arguments
+    [Arguments]  ${var}
+    No Operation

--- a/tests/linter/rules/lengths/empty_arguments/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_arguments/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:17:5 [E] LEN26 Arguments of 'Keyword Without Arguments' Keyword are empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_arguments/test_rule.py
+++ b/tests/linter/rules/lengths/empty_arguments/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/lengths/empty_default_tags/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_default_tags/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN14 Default Tags are empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_default_tags/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_default_tags/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [W] LEN14 Default Tags are empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_documentation/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_documentation/expected_extended.txt
@@ -26,3 +26,4 @@ test.robot:16:5 LEN12 Documentation of 'Keyword' Keyword is empty
     |
 
 Found 3 issues.
+3 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_documentation/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_documentation/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 3 issues:
+- actual_fixed${/}test.robot:
+    3 x LEN12 (empty-documentation)
+
+Found 3 issues (3 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_documentation/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_documentation/expected_fixed/test.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+
+
+*** Test Cases ***
+Test
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/empty_documentation/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_documentation/expected_output.txt
@@ -3,3 +3,4 @@ test.robot:7:5 [W] LEN12 Documentation of 'Test' Test Case is empty
 test.robot:16:5 [W] LEN12 Documentation of 'Keyword' Keyword is empty
 
 Found 3 issues.
+3 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_documentation/test_rule.py
+++ b/tests/linter/rules/lengths/empty_documentation/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/lengths/empty_force_tags/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_force_tags/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN13 Force Tags are empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_force_tags/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_force_tags/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [W] LEN13 Force Tags are empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_keyword_tags/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_keyword_tags/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN31 Keyword Tags are empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_keyword_tags/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_keyword_tags/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [W] LEN31 Keyword Tags are empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_library_import/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_library_import/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN17 Import library path is empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_library_import/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_library_import/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN17 Import library path is empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_metadata/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_metadata/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN11 Metadata settings does not have any value set
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_metadata/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_metadata/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 3 issues:
+- actual_fixed${/}test.robot:
+    1 x LEN11 (empty-metadata)
+- actual_fixed${/}with_comments.robot:
+    2 x LEN11 (empty-metadata)
+
+Found 3 issues (3 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_metadata/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_metadata/expected_fixed/test.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/empty_metadata/expected_fixed/with_comments.robot
+++ b/tests/linter/rules/lengths/empty_metadata/expected_fixed/with_comments.robot
@@ -1,0 +1,3 @@
+*** Settings ***
+# TODO: add the metadata
+Documentation    doc

--- a/tests/linter/rules/lengths/empty_metadata/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_metadata/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [W] LEN11 Metadata settings does not have any value set
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_metadata/test_rule.py
+++ b/tests/linter/rules/lengths/empty_metadata/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "with_comments.robot"])

--- a/tests/linter/rules/lengths/empty_metadata/with_comments.robot
+++ b/tests/linter/rules/lengths/empty_metadata/with_comments.robot
@@ -1,0 +1,4 @@
+*** Settings ***
+Metadata    # TODO: add the metadata
+Documentation    doc
+Metadata

--- a/tests/linter/rules/lengths/empty_resource_import/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_resource_import/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN16 Import resource path is empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_resource_import/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_resource_import/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN16 Import resource path is empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_setup/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_setup/expected_extended.txt
@@ -9,3 +9,4 @@ test.robot:9:5 LEN18 Setup of 'Test' Test Case does not have any keywords
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_setup/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_setup/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 2 issues:
+- actual_fixed${/}overwrite.robot:
+    1 x LEN18 (empty-setup)
+- actual_fixed${/}test.robot:
+    1 x LEN18 (empty-setup)
+
+Found 2 issues (2 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_setup/expected_fixed/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_setup/expected_fixed/overwrite.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Test Setup    Setup Keyword
+
+
+*** Test Cases ***
+Test with empty setup
+    [Setup]    NONE
+    Keyword Call
+
+Test with explicit NONE
+    [Setup]    NONE
+    Keyword Call

--- a/tests/linter/rules/lengths/empty_setup/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_setup/expected_fixed/test.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/empty_setup/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_setup/expected_fixed/test.robot
@@ -6,6 +6,7 @@ Documentation  doc
 Test
     [Documentation]  doc
     [Tags]  sometag
+    [Setup]    NONE
     Pass
     Keyword
     One More

--- a/tests/linter/rules/lengths/empty_setup/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_setup/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:9:5 [E] LEN18 Setup of 'Test' Test Case does not have any keywords
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_setup/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_setup/overwrite.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Test Setup    Setup Keyword
+
+
+*** Test Cases ***
+Test with empty setup
+    [Setup]
+    Keyword Call
+
+Test with explicit NONE
+    [Setup]    NONE
+    Keyword Call

--- a/tests/linter/rules/lengths/empty_setup/test_rule.py
+++ b/tests/linter/rules/lengths/empty_setup/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "overwrite.robot"])

--- a/tests/linter/rules/lengths/empty_suite_setup/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_suite_setup/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN19 Suite Setup does not have any keywords
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_suite_setup/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_suite_setup/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN19 Suite Setup does not have any keywords
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_suite_teardown/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_suite_teardown/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN22 Suite Teardown does not have any keywords
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_suite_teardown/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_suite_teardown/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN22 Suite Teardown does not have any keywords
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_teardown/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_teardown/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:21:5 LEN21 Teardown of 'Keyword' Keyword does not have any keywords
     |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_teardown/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_teardown/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 3 issues:
+- actual_fixed${/}overwrite.robot:
+    2 x LEN21 (empty-teardown)
+- actual_fixed${/}test.robot:
+    1 x LEN21 (empty-teardown)
+
+Found 3 issues (3 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_teardown/expected_fixed/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_teardown/expected_fixed/overwrite.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Test Teardown    Teardown Keyword
+
+
+*** Test Cases ***
+Test with empty teardown
+    [Teardown]    NONE
+    Keyword Call
+
+Test with explicit NONE
+    [Teardown]    NONE
+    Keyword Call
+
+
+*** Keywords ***
+Keyword with empty teardown
+    No Operation

--- a/tests/linter/rules/lengths/empty_teardown/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_teardown/expected_fixed/test.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/empty_teardown/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_teardown/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:21:5 [E] LEN21 Teardown of 'Keyword' Keyword does not have any keywords
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_teardown/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_teardown/overwrite.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Test Teardown    Teardown Keyword
+
+
+*** Test Cases ***
+Test with empty teardown
+    [Teardown]
+    Keyword Call
+
+Test with explicit NONE
+    [Teardown]    NONE
+    Keyword Call
+
+
+*** Keywords ***
+Keyword with empty teardown
+    [Teardown]
+    No Operation

--- a/tests/linter/rules/lengths/empty_teardown/test_rule.py
+++ b/tests/linter/rules/lengths/empty_teardown/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "overwrite.robot"])

--- a/tests/linter/rules/lengths/empty_template/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_template/expected_extended.txt
@@ -8,3 +8,4 @@ test.robot:14:5 LEN30 Template of 'Test with empty template' Test Case is empty.
     |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_template/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_template/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 2 issues:
+- actual_fixed${/}overwrite.robot:
+    1 x LEN30 (empty-template)
+- actual_fixed${/}test.robot:
+    1 x LEN30 (empty-template)
+
+Found 2 issues (2 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_template/expected_fixed/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_template/expected_fixed/overwrite.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Test Template    Template Keyword
+
+
+*** Test Cases ***
+Test with empty template
+    [Template]    NONE
+    Keyword Call
+
+Test with explicit NONE
+    [Template]    NONE
+    Keyword Call

--- a/tests/linter/rules/lengths/empty_template/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_template/expected_fixed/test.robot
@@ -11,6 +11,7 @@ Test with non-empty template
     argument
 
 Test with empty template
+    [Template]    NONE
     No Operation
 
 Test with empty template and NONE

--- a/tests/linter/rules/lengths/empty_template/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_template/expected_fixed/test.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Test Template
+
+
+*** Test Cases ***
+Test without template
+    No Operation
+
+Test with non-empty template
+    [Template]    Template
+    argument
+
+Test with empty template
+    No Operation
+
+Test with empty template and NONE
+    [Template]    NONE
+    No Operation

--- a/tests/linter/rules/lengths/empty_template/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_template/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:14:5 [W] LEN30 Template of 'Test with empty template' Test Case is empty. To overwrite suite Test Template use more explicit [Template]  NONE
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_template/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_template/overwrite.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Test Template    Template Keyword
+
+
+*** Test Cases ***
+Test with empty template
+    [Template]
+    Keyword Call
+
+Test with explicit NONE
+    [Template]    NONE
+    Keyword Call

--- a/tests/linter/rules/lengths/empty_template/test_rule.py
+++ b/tests/linter/rules/lengths/empty_template/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "overwrite.robot"])

--- a/tests/linter/rules/lengths/empty_test_setup/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_test_setup/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN20 Test Setup does not have any keywords
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_setup/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_test_setup/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN20 Test Setup does not have any keywords
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_teardown/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_test_teardown/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN23 Test Teardown does not have any keywords
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_teardown/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_test_teardown/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN23 Test Teardown does not have any keywords
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_template/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_test_template/expected_extended.txt
@@ -6,3 +6,4 @@ test.robot:2:1 LEN29 Test Template is empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_template/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_test_template/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:2:1 [E] LEN29 Test Template is empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_timeout/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_test_timeout/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN25 Test Timeout is empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_timeout/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_test_timeout/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 1 issue:
+- actual_fixed${/}test.robot:
+    1 x LEN25 (empty-test-timeout)
+
+Found 1 issue (1 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_test_timeout/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_test_timeout/expected_fixed/test.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/empty_test_timeout/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_test_timeout/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [W] LEN25 Test Timeout is empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_test_timeout/none_value.robot
+++ b/tests/linter/rules/lengths/empty_test_timeout/none_value.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Documentation    doc
+Test Timeout    NONE
+
+
+*** Test Cases ***
+Test
+    Keyword Call

--- a/tests/linter/rules/lengths/empty_test_timeout/test_rule.py
+++ b/tests/linter/rules/lengths/empty_test_timeout/test_rule.py
@@ -7,3 +7,9 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_explicit_none_is_not_reported(self):
+        self.check_rule(src_files=["none_value.robot"], expected_file=None)
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/lengths/empty_timeout/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_timeout/expected_extended.txt
@@ -9,3 +9,4 @@ test.robot:8:5 LEN24 Timeout of 'Test' Test Case is empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_timeout/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_timeout/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 3 issues:
+- actual_fixed${/}overwrite.robot:
+    2 x LEN24 (empty-timeout)
+- actual_fixed${/}test.robot:
+    1 x LEN24 (empty-timeout)
+
+Found 3 issues (3 fixed, 0 remaining).

--- a/tests/linter/rules/lengths/empty_timeout/expected_fixed/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_timeout/expected_fixed/overwrite.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Test Timeout    1 min
+
+
+*** Test Cases ***
+Test with empty timeout
+    [Timeout]    NONE
+    Keyword Call
+
+Test with explicit NONE
+    [Timeout]    NONE
+    Keyword Call
+
+
+*** Keywords ***
+Keyword with empty timeout
+    No Operation

--- a/tests/linter/rules/lengths/empty_timeout/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_timeout/expected_fixed/test.robot
@@ -5,6 +5,7 @@ Documentation  doc
 Test
     [Documentation]  doc
     [Tags]  sometag
+    [Timeout]    NONE
     Pass
     Keyword
     One More

--- a/tests/linter/rules/lengths/empty_timeout/expected_fixed/test.robot
+++ b/tests/linter/rules/lengths/empty_timeout/expected_fixed/test.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Documentation  doc
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/empty_timeout/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_timeout/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:8:5 [W] LEN24 Timeout of 'Test' Test Case is empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_timeout/overwrite.robot
+++ b/tests/linter/rules/lengths/empty_timeout/overwrite.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Test Timeout    1 min
+
+
+*** Test Cases ***
+Test with empty timeout
+    [Timeout]
+    Keyword Call
+
+Test with explicit NONE
+    [Timeout]    NONE
+    Keyword Call
+
+
+*** Keywords ***
+Keyword with empty timeout
+    [Timeout]
+    No Operation

--- a/tests/linter/rules/lengths/empty_timeout/test_rule.py
+++ b/tests/linter/rules/lengths/empty_timeout/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "overwrite.robot"])

--- a/tests/linter/rules/lengths/empty_variables_import/expected_extended.txt
+++ b/tests/linter/rules/lengths/empty_variables_import/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 LEN15 Import variables path is empty
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/lengths/empty_variables_import/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_variables_import/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [E] LEN15 Import variables path is empty
 
 Found 1 issue.
+1 fixable with the '--fix' option.


### PR DESCRIPTION
Implements fixes for the `empty-*` rules from #1631.

## What changed

Rules reporting a setting without any value now provide a **safe fix**: LEN11-LEN26, LEN29-LEN31
(`empty-metadata`, `empty-documentation`, `empty-force-tags`, `empty-default-tags`, `empty-variables-import`,
`empty-resource-import`, `empty-library-import`, `empty-setup`, `empty-suite-setup`, `empty-test-setup`,
`empty-teardown`, `empty-suite-teardown`, `empty-test-teardown`, `empty-timeout`, `empty-test-timeout`,
`empty-arguments`, `empty-test-template`, `empty-template`, `empty-keyword-tags`).

The fix removes the empty setting, **unless** it overwrites a suite setting. Test case `[Setup]`, `[Teardown]`,
`[Timeout]` and `[Template]` used together with `Test Setup`, `Test Teardown`, `Test Timeout` or `Test Template`
are filled with the explicit `NONE` value instead, so the behaviour is preserved:

```robotframework
*** Settings ***
Test Timeout    1 min


*** Test Cases ***
Test
    [Timeout]        # -> [Timeout]    NONE
    Keyword Call


*** Keywords ***
Keyword
    [Timeout]        # -> removed, Test Timeout does not affect keywords
    No Operation
```

Comments are never removed together with the setting - the line is replaced with the comment only.

## Bug fix

`empty-timeout` and `empty-test-timeout` no longer report the explicit `NONE` value. Robot Framework returns `None`
as `Timeout.value` for `NONE`, so `[Timeout]    NONE` (the recommended form) was reported as empty.

## Notes

This covers the functionality of the `RemoveEmptySettings` formatter (including its `more_explicit` behaviour) and
extends it to more settings. Deprecating the formatter can be handled separately.
`[Tags]` / `Default Tags` (TAG08 `empty-tags`) and `empty-section` (LEN09) are left for follow-up PRs.
