### PR TITLE
feat: add fix for the empty-section rule

### DIFF
--- a/src/robocop/linter/fix.py
+++ b/src/robocop/linter/fix.py
@@ -183,26 +183,32 @@ def _comment_lines(node: Statement, source_lines: list[str]) -> list[str]:
     return comment_lines
 
 
+def remove_lines_fix(rule: Rule, start_line: int, end_line: int, message: str, replacement: str = "") -> Fix:
+    """Create a fix that removes lines between ``start_line`` and ``end_line`` or replaces them with new content."""
+    if replacement:
+        edit = TextEdit.replace_lines(rule.rule_id, rule.name, start_line, end_line, replacement)
+    else:
+        edit = TextEdit(
+            rule_id=rule.rule_id,
+            rule_name=rule.name,
+            start_line=start_line,
+            start_col=1,
+            end_line=end_line,
+            end_col=1,
+            replacement="",
+            kind=TextEditKind.DELETION,
+        )
+    return Fix(edits=[edit], message=message, applicability=FixApplicability.SAFE)
+
+
 def remove_statement_fix(rule: Rule, node: Statement, source_lines: list[str], message: str) -> Fix:
     """
     Create a fix that removes the whole statement.
 
     Comments are not removed together with the statement - they are left in place instead.
     """
-    if comment_lines := _comment_lines(node, source_lines):
-        edit = TextEdit.replace_lines(rule.rule_id, rule.name, node.lineno, node.end_lineno, "".join(comment_lines))
-    else:
-        edit = TextEdit(
-            rule_id=rule.rule_id,
-            rule_name=rule.name,
-            start_line=node.lineno,
-            start_col=1,
-            end_line=node.end_lineno,
-            end_col=1,
-            replacement="",
-            kind=TextEditKind.DELETION,
-        )
-    return Fix(edits=[edit], message=message, applicability=FixApplicability.SAFE)
+    comment_lines = _comment_lines(node, source_lines)
+    return remove_lines_fix(rule, node.lineno, node.end_lineno, message, "".join(comment_lines))
 
 
 def add_setting_value_fix(rule: Rule, node: Statement, value: str, message: str, separator: str = "    ") -> Fix:

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -27,7 +27,7 @@ except ImportError:
     Var = None
 
 from robocop.linter import sonar_qube
-from robocop.linter.fix import FixAvailability, remove_empty_setting_fix
+from robocop.linter.fix import FixAvailability, remove_empty_setting_fix, remove_lines_fix
 from robocop.linter.rules import (
     FixableRule,
     Rule,
@@ -451,8 +451,31 @@ class LineTooLongRule(Rule):
         return bool(self.ignore_pattern and self.ignore_pattern.search(line))
 
 
-class EmptySectionRule(Rule):
-    """Section is empty."""
+class EmptySectionRule(FixableRule):
+    """
+    Section is empty.
+
+    Empty section does not have any effect and can be removed.
+
+    Incorrect code example:
+
+        *** Variables ***
+
+
+        *** Test Cases ***
+        Test
+            Keyword Call
+
+    Correct code:
+
+        *** Test Cases ***
+        Test
+            Keyword Call
+
+    Sections that contain only comments are also reported, but they are not removed by the fix -
+    it is not possible to tell whether such comments are still relevant.
+
+    """
 
     name = "empty-section"
     rule_id = "LEN09"
@@ -463,6 +486,7 @@ class EmptySectionRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0509",)
+    fix_availability = FixAvailability.SOMETIMES
 
     def check(self, node: Section) -> None:
         if not self.enabled or not node.header:
@@ -475,6 +499,21 @@ class EmptySectionRule(Rule):
                 col=node.col_offset + 1,
                 end_col=node.header.end_col_offset,
             )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        """
+        Remove the empty section.
+
+        Sections that contain comments are not fixed - removing them would remove the comments as well,
+        and it is not possible to tell whether the comments are still relevant.
+        """
+        node = diag.node
+        if node is None or node.header is None:
+            return None
+        if any(isinstance(statement, Comment) for statement in node.body):
+            return None
+        section_name = str(diag.reported_arguments["section_name"])
+        return remove_lines_fix(self, node.lineno, node.end_lineno, f"Remove empty '{section_name}' section")
 
 
 class NumberOfReturnedValuesRule(Rule):

--- a/tests/linter/rules/lengths/empty_section/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/lengths/empty_section/expected_fixed/expected_output.txt
@@ -1,0 +1,12 @@
+actual_fixed${/}with_empty_sections.robot:10:1 LEN09 Section '*** Keywords ***' is empty
+    |
+ 10 | *** Keywords ***
+    | ^^^^^^^^^^^^^^^^ LEN09
+ 11 | # This section considered as empty.
+    |
+
+Fixed 2 issues:
+- actual_fixed${/}with_empty_sections.robot:
+    2 x LEN09 (empty-section)
+
+Found 3 issues (2 fixed, 1 remaining).

--- a/tests/linter/rules/lengths/empty_section/expected_fixed/with_empty_sections.robot
+++ b/tests/linter/rules/lengths/empty_section/expected_fixed/with_empty_sections.robot
@@ -1,0 +1,15 @@
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+# This section considered as empty.
+
+
+*** Comments ***
+robocop: disable=all

--- a/tests/linter/rules/lengths/empty_section/test_rule.py
+++ b/tests/linter/rules/lengths/empty_section/test_rule.py
@@ -1,9 +1,14 @@
 from tests.linter.utils import RuleAcceptance
 
+SRC_FILES = ["test.robot", "with_empty_sections.robot", "missing_header_in_rf5.robot"]
+
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt")
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_output.txt")
 
     def test_extended(self):
-        self.check_rule(expected_file="expected_extended.txt", output_format="extended")
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["with_empty_sections.robot"])


### PR DESCRIPTION
Adds automatic fix (`--fix`) for the `empty-section` (LEN09) rule.

Behaviour:
- section with no content at all -> the whole section (header + trailing empty lines) is removed
- section containing only comments -> only the section header line is removed, so the comments are preserved

> [!NOTE]
> Stacked on top of #1840 (`feat/empty-settings-fix`) because it reuses the shared fix helpers in `linter/fix.py`. Please merge #1840 first.

Part of #1631.
