### PR TITLE
feat: add fix for the empty-tags rule

### DIFF
--- a/src/robocop/linter/checkers/tags.py
+++ b/src/robocop/linter/checkers/tags.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from robot.api import Token
+from robot.parsing.model.blocks import SettingSection
 
 from robocop.linter.rules import VisitorChecker, tags
 from robocop.linter.rules.tags import TagNode, new_tag_token, split_tag_on_variables
@@ -50,6 +51,7 @@ class TagsChecker(VisitorChecker):
         self.keyword_tags_node: KeywordTags | None = None
         self.test_cases_count = 0
         self.keywords_count = 0
+        self.suite_default_tags = False
         super().__init__()
 
     def visit_File(self, node: File) -> None:  # noqa: N802
@@ -62,9 +64,26 @@ class TagsChecker(VisitorChecker):
         self.keyword_tags_node = None
         self.test_cases_count = 0
         self.keywords_count = 0
+        self.suite_default_tags = self.has_default_tags(node)
         super().visit_File(node)
         self.check_common_test_tags(node)
         self.check_common_keyword_tags(node)
+
+    @staticmethod
+    def has_default_tags(node: File) -> bool:
+        """
+        Check if the suite defines ``Default Tags`` with a value.
+
+        Empty test case ``[Tags]`` is used to overwrite such setting and should not be removed.
+        ``Default Tags`` is not allowed in the suite initialization file, so it is enough to look it up in the
+        current file.
+        """
+        return any(
+            statement.type == Token.DEFAULT_TAGS and len(statement.data_tokens) > 1
+            for section in node.sections
+            if isinstance(section, SettingSection)
+            for statement in section.body
+        )
 
     def check_common_test_tags(self, node: File) -> None:
         """Report tags shared by all tests only if every test in the suite defines its own tags."""
@@ -118,7 +137,7 @@ class TagsChecker(VisitorChecker):
 
     def visit_Tags(self, node: Tags) -> None:  # noqa: N802
         self.check_tag_names(node)
-        self.empty_tags.check(node, self.in_keywords)
+        self.empty_tags.check(node, self.in_keywords, not self.in_keywords and self.suite_default_tags)
         tags = [tag.value for tag in node.data_tokens[1:] if not tag.value.startswith("robot:")]
         if self.in_keywords:
             self.tags_in_keywords.append(tags)

--- a/src/robocop/linter/rules/tags.py
+++ b/src/robocop/linter/rules/tags.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, ClassVar, TypeAlias
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity
+from robocop.linter.fix import FixAvailability, remove_empty_setting_fix
+from robocop.linter.rules import FixableRule, Rule, RuleSeverity
 from robocop.parsing.variables import VariableMatches  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
@@ -19,6 +20,9 @@ if TYPE_CHECKING:
         KeywordTags,
         Tags,
     )
+
+    from robocop.linter.diagnostics import Diagnostic
+    from robocop.linter.fix import Fix
 
 TagNode: TypeAlias = "ForceTags | DefaultTags | Tags | KeywordTags"
 
@@ -298,12 +302,38 @@ class UnnecessaryDefaultTagsRule(Rule):
         )
 
 
-class EmptyTagsRule(Rule):
+class EmptyTagsRule(FixableRule):
     """
     ``[Tags]`` setting without any value.
 
     If you want to use empty ``[Tags]`` (for example, to overwrite ``Default Tags``), then use the ``NONE`` value
     to be explicit.
+
+    Incorrect code example:
+
+        *** Settings ***
+        Default Tags    tag
+
+
+        *** Test Cases ***
+        Test without tags
+            [Tags]
+            Keyword Call
+
+    Correct code example:
+
+        *** Settings ***
+        Default Tags    tag
+
+
+        *** Test Cases ***
+        Test without tags
+            [Tags]    NONE
+            Keyword Call
+
+    The fix removes the empty ``[Tags]`` setting. If the suite defines ``Default Tags``, the test case ``[Tags]``
+    is not removed but filled with the explicit ``NONE`` value instead, since the empty ``[Tags]`` overwrites the
+    ``Default Tags``. Comments are never removed by the fix.
 
     """
 
@@ -316,17 +346,22 @@ class EmptyTagsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0608",)
+    fix_availability = FixAvailability.ALWAYS
 
-    def check(self, node: Tags, in_keywords: bool) -> None:
+    def check(self, node: Tags, in_keywords: bool, overwrites_default_tags: bool = False) -> None:
         if not self.enabled or node.values:
             return
         suffix = "" if in_keywords else ". Consider using NONE if you want to overwrite the Default Tags"
         self.report(
             optional_warning=suffix,
+            overwrites_suite_setting=overwrites_default_tags,
             node=node,
             col=node.data_tokens[0].col_offset + 1,
             end_col=node.end_col_offset,
         )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        return remove_empty_setting_fix(self, diag, source_lines)
 
 
 class DuplicatedTagsRule(Rule):

--- a/tests/linter/rules/tags/empty_tags/expected_extended.txt
+++ b/tests/linter/rules/tags/empty_tags/expected_extended.txt
@@ -17,4 +17,32 @@ default_and_empty_tags.robot:31:5 TAG08 [Tags] setting without values
  32 |     No Operation
     |
 
-Found 2 issues.
+without_default_tags.robot:7:5 TAG08 [Tags] setting without values. Consider using NONE if you want to overwrite the Default Tags
+   |
+ 5 | *** Test Cases ***
+ 6 | Test With Empty Tags
+ 7 |     [Tags]
+   |     ^^^^^^ TAG08
+ 8 |     Keyword Call
+   |
+
+without_default_tags.robot:11:5 TAG08 [Tags] setting without values. Consider using NONE if you want to overwrite the Default Tags
+    |
+  9 |
+ 10 | Test With Empty Tags And Comment
+ 11 |     [Tags]    # comment
+    |     ^^^^^^^^^^^^^^^^^^^ TAG08
+ 12 |     Keyword Call
+    |
+
+without_default_tags.robot:17:5 TAG08 [Tags] setting without values
+    |
+ 15 | *** Keywords ***
+ 16 | Keyword With Empty Tags
+ 17 |     [Tags]
+    |     ^^^^^^ TAG08
+ 18 |     No Operation
+    |
+
+Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/empty_tags/expected_fixed/default_and_empty_tags.robot
+++ b/tests/linter/rules/tags/empty_tags/expected_fixed/default_and_empty_tags.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Documentation  doc
+Default Tags  tag  othertag
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]    NONE
+    Pass
+    Keyword
+    One More
+
+Test With Tags
+    [Tags]    dummy
+    Log    2
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Tags
+    [Tags]    tag
+    No Operation
+
+Keyword With Empty Tags
+    No Operation

--- a/tests/linter/rules/tags/empty_tags/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/tags/empty_tags/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 5 issues:
+- actual_fixed${/}default_and_empty_tags.robot:
+    2 x TAG08 (empty-tags)
+- actual_fixed${/}without_default_tags.robot:
+    3 x TAG08 (empty-tags)
+
+Found 5 issues (5 fixed, 0 remaining).

--- a/tests/linter/rules/tags/empty_tags/expected_fixed/without_default_tags.robot
+++ b/tests/linter/rules/tags/empty_tags/expected_fixed/without_default_tags.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test With Empty Tags
+    Keyword Call
+
+Test With Empty Tags And Comment
+    # comment
+    Keyword Call
+
+
+*** Keywords ***
+Keyword With Empty Tags
+    No Operation

--- a/tests/linter/rules/tags/empty_tags/expected_output.txt
+++ b/tests/linter/rules/tags/empty_tags/expected_output.txt
@@ -1,4 +1,8 @@
 default_and_empty_tags.robot:8:5 [W] TAG08 [Tags] setting without values. Consider using NONE if you want to overwrite the Default Tags
 default_and_empty_tags.robot:31:5 [W] TAG08 [Tags] setting without values
+without_default_tags.robot:7:5 [W] TAG08 [Tags] setting without values. Consider using NONE if you want to overwrite the Default Tags
+without_default_tags.robot:11:5 [W] TAG08 [Tags] setting without values. Consider using NONE if you want to overwrite the Default Tags
+without_default_tags.robot:17:5 [W] TAG08 [Tags] setting without values
 
-Found 2 issues.
+Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/empty_tags/test_rule.py
+++ b/tests/linter/rules/tags/empty_tags/test_rule.py
@@ -1,11 +1,14 @@
 from tests.linter.utils import RuleAcceptance
 
+SRC_FILES = ["default_and_empty_tags.robot", "without_default_tags.robot"]
+
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["default_and_empty_tags.robot"], expected_file="expected_output.txt")
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_output.txt")
 
     def test_extended(self):
-        self.check_rule(
-            src_files=["default_and_empty_tags.robot"], expected_file="expected_extended.txt", output_format="extended"
-        )
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=SRC_FILES)

--- a/tests/linter/rules/tags/empty_tags/without_default_tags.robot
+++ b/tests/linter/rules/tags/empty_tags/without_default_tags.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test With Empty Tags
+    [Tags]
+    Keyword Call
+
+Test With Empty Tags And Comment
+    [Tags]    # comment
+    Keyword Call
+
+
+*** Keywords ***
+Keyword With Empty Tags
+    [Tags]
+    No Operation


### PR DESCRIPTION
Adds automatic fix (`--fix`) for the `empty-tags` (TAG08) rule.

Behaviour:
- test case `[Tags]` in a suite that defines `Default Tags` -> replaced with the explicit `[Tags]    NONE`, since the empty `[Tags]` overwrites the `Default Tags`
- any other empty `[Tags]` -> removed
- keyword `[Tags]` is always removed - it does not overwrite `Keyword Tags` (verified with Robot Framework)
- comments are never removed

`Default Tags` is not allowed in the suite initialization file, so looking it up in the current file is enough.

Part of #1631.