### PR TITLE
feat: add fixes for the deprecated-with-name and deprecated-singular-header rules

### DIFF
--- a/src/robocop/linter/rules/deprecated.py
+++ b/src/robocop/linter/rules/deprecated.py
@@ -72,7 +72,7 @@ class DeprecatedStatementRule(Rule):
     deprecated = True
 
 
-class DeprecatedWithNameRule(Rule):
+class DeprecatedWithNameRule(FixableRule):
     """
     Deprecated 'WITH NAME' alias marker used instead of 'AS'.
 
@@ -89,6 +89,8 @@ class DeprecatedWithNameRule(Rule):
         *** Settings ***
         Library    Collections    AS    AliasedName
 
+    The fix replaces the ``WITH NAME`` marker with ``AS``.
+
     """
 
     name = "deprecated-with-name"
@@ -101,6 +103,7 @@ class DeprecatedWithNameRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0321",)
+    fix_availability = FixAvailability.ALWAYS
 
     def check(self, node: LibraryImport) -> None:
         if not self.enabled:
@@ -114,8 +117,15 @@ class DeprecatedWithNameRule(Rule):
             end_col=with_name_token.end_col_offset + 1,
         )
 
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        return Fix(
+            edits=[TextEdit.replace_at_range(self.rule_id, self.name, diag.range, "AS")],
+            message="Replace WITH NAME alias marker with AS",
+            applicability=FixApplicability.SAFE,
+        )
 
-class DeprecatedSingularHeaderRule(Rule):
+
+class DeprecatedSingularHeaderRule(FixableRule):
     """
     Deprecated singular header used instead of plural form.
 
@@ -132,6 +142,8 @@ class DeprecatedSingularHeaderRule(Rule):
         *** Settings ***
         *** Keywords ***
 
+    The fix replaces the singular header with the plural one, keeping the original header formatting.
+
     """
 
     name = "deprecated-singular-header"
@@ -144,6 +156,7 @@ class DeprecatedSingularHeaderRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0322",)
+    fix_availability = FixAvailability.ALWAYS
 
     english_headers_singular = {
         "Comment",
@@ -178,9 +191,24 @@ class DeprecatedSingularHeaderRule(Rule):
         self.report(
             singular_header=f"*** {node.name} ***",
             plural_header=f"*** {node.name}s ***",
+            header_name=node.name,
             node=header_node,
             col=header_node.col_offset + 1,
             end_col=header_node.end_col_offset + 1,
+        )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        """Replace the singular header with the plural one, keeping the original header formatting."""
+        header_name = str(diag.reported_arguments["header_name"])
+        header = getattr(diag.node, "value", "")
+        if header_name and header_name in header:
+            replacement = header.replace(header_name, f"{header_name}s", 1)
+        else:
+            replacement = str(diag.reported_arguments["plural_header"])
+        return Fix(
+            edits=[TextEdit.replace_at_range(self.rule_id, self.name, diag.range, replacement)],
+            message=f"Replace '{header}' header with '{replacement}'",
+            applicability=FixApplicability.SAFE,
         )
 
 

--- a/tests/linter/rules/deprecated/deprecated_singular_header/expected_extended.txt
+++ b/tests/linter/rules/deprecated/deprecated_singular_header/expected_extended.txt
@@ -56,3 +56,4 @@ test.robot:12:1 DEPR04 '*** Comment ***' deprecated singular header used instead
     |
 
 Found 6 issues.
+6 fixable with the '--fix' option.

--- a/tests/linter/rules/deprecated/deprecated_singular_header/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/deprecated/deprecated_singular_header/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 6 issues:
+- actual_fixed${/}test.robot:
+    6 x DEPR04 (deprecated-singular-header)
+
+Found 6 issues (6 fixed, 0 remaining).

--- a/tests/linter/rules/deprecated/deprecated_singular_header/expected_fixed/test.robot
+++ b/tests/linter/rules/deprecated/deprecated_singular_header/expected_fixed/test.robot
@@ -1,0 +1,13 @@
+*** Settings ***  this is comment
+Documentation    doc
+*** Settings ***
+*** Variables ***  # this is also comment
+*** Variables ***
+*** Test Cases ***
+*** Test Cases ***
+*** Keywords ***
+** Keywords ***
+*** Keywords ***
+*** Keywords **
+*** Comments ***
+*** Comments ***

--- a/tests/linter/rules/deprecated/deprecated_singular_header/expected_output.txt
+++ b/tests/linter/rules/deprecated/deprecated_singular_header/expected_output.txt
@@ -6,3 +6,4 @@ test.robot:9:1 [W] DEPR04 '*** Keyword ***' deprecated singular header used inst
 test.robot:12:1 [W] DEPR04 '*** Comment ***' deprecated singular header used instead of '*** Comments ***'
 
 Found 6 issues.
+6 fixable with the '--fix' option.

--- a/tests/linter/rules/deprecated/deprecated_singular_header/test_rule.py
+++ b/tests/linter/rules/deprecated/deprecated_singular_header/test_rule.py
@@ -18,3 +18,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_pre_rf5(self):
         self.check_rule(src_files=["test.robot"], expected_file="not_enabled", test_on_version="<=5")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"], test_on_version=">=6.0")

--- a/tests/linter/rules/deprecated/deprecated_with_name/expected_extended.txt
+++ b/tests/linter/rules/deprecated/deprecated_with_name/expected_extended.txt
@@ -8,3 +8,4 @@ test.robot:3:22 DEPR03 Deprecated 'WITH NAME' alias marker used instead of 'AS'
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/deprecated/deprecated_with_name/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/deprecated/deprecated_with_name/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 1 issue:
+- actual_fixed${/}test.robot:
+    1 x DEPR03 (deprecated-with-name)
+
+Found 1 issue (1 fixed, 0 remaining).

--- a/tests/linter/rules/deprecated/deprecated_with_name/expected_fixed/test.robot
+++ b/tests/linter/rules/deprecated/deprecated_with_name/expected_fixed/test.robot
@@ -1,0 +1,4 @@
+*** Settings ***
+Library    Library
+Library   Library    AS    Library2
+Library   Library    AS    Library2

--- a/tests/linter/rules/deprecated/deprecated_with_name/expected_output.txt
+++ b/tests/linter/rules/deprecated/deprecated_with_name/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:22 [W] DEPR03 Deprecated 'WITH NAME' alias marker used instead of 'AS'
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/deprecated/deprecated_with_name/test_rule.py
+++ b/tests/linter/rules/deprecated/deprecated_with_name/test_rule.py
@@ -6,4 +6,12 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=6.0")
 
     def test_extended(self):
-        self.check_rule(expected_file="expected_extended.txt", output_format="extended", test_on_version=">=6.0")
+        self.check_rule(
+            src_files=["test.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=6.0",
+        )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"], test_on_version=">=6.0")


### PR DESCRIPTION
Adds automatic fixes (`--fix`) for two easy and safe deprecation rules. Grouped in one PR since both are simple token replacements.

**DEPR03 `deprecated-with-name`** - replaces the `WITH NAME` alias marker with `AS`.

**DEPR04 `deprecated-singular-header`** - replaces the singular section header with the plural one. The original header formatting is kept, so `** Keyword ***` becomes `** Keywords ***` and `***Comment***` becomes `***Comments***`.

Part of #1631.