### PR TITLE
feat: add fixes for missing-space-after-comment and ignored-data rules

### DIFF
--- a/src/robocop/linter/rules/comments.py
+++ b/src/robocop/linter/rules/comments.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from robot.api import Token, get_tokens
 
 from robocop.linter import sonar_qube
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit, TextEditKind
 from robocop.linter.rules import (
+    FixableRule,
     Rule,
     RuleParam,
     RuleSeverity,
 )
+
+if TYPE_CHECKING:
+    from robocop.linter.diagnostics import Diagnostic
 
 
 def regex(value: str) -> re.Pattern[str]:
@@ -82,7 +88,7 @@ class ToDoInCommentRule(Rule):
     deprecated_names = ("0701",)
 
 
-class MissingSpaceAfterCommentRule(Rule):
+class MissingSpaceAfterCommentRule(FixableRule):
     """
     No space after the ``#`` character and comment body.
 
@@ -118,6 +124,9 @@ class MissingSpaceAfterCommentRule(Rule):
         or
         #* Headers *#
 
+    The fix adds the missing space. Comments that would still violate the rule after adding the space
+    (such as ``##comment``, which is not recognized as a block comment) are not fixed.
+
     """
 
     name = "missing-space-after-comment"
@@ -139,6 +148,40 @@ class MissingSpaceAfterCommentRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0702",)
+    fix_availability = FixAvailability.SOMETIMES
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """
+        Add a missing space between the leading ``#`` characters and the comment body.
+
+        Comments that would still violate the rule after adding the space (such as ``##comment``, which is not
+        recognized as a block comment) are not fixed.
+        """
+        lineno, col = diag.range.start.line, diag.range.start.character
+        comment = source_lines[lineno - 1][col - 1 :].rstrip("\n")
+        hashes = len(comment) - len(comment.lstrip("#"))
+        if not hashes:
+            return None
+        fixed_comment = f"{'#' * hashes} {comment[hashes:]}"
+        if hashes > 1 and not self.block.match(fixed_comment):
+            return None
+        column = col + hashes
+        return Fix(
+            edits=[
+                TextEdit(
+                    rule_id=self.rule_id,
+                    rule_name=self.name,
+                    start_line=lineno,
+                    start_col=column,
+                    end_line=lineno,
+                    end_col=column,
+                    replacement=" ",
+                    kind=TextEditKind.REPLACEMENT,
+                )
+            ],
+            message="Add missing space after the comment character",
+            applicability=FixApplicability.SAFE,
+        )
 
 
 class InvalidCommentRule(Rule):
@@ -173,7 +216,7 @@ class InvalidCommentRule(Rule):
     # TODO: deprecate (<4)
 
 
-class IgnoredDataRule(Rule):
+class IgnoredDataRule(FixableRule):
     """
     Ignored data found in the file.
 
@@ -196,6 +239,9 @@ class IgnoredDataRule(Rule):
 
         *** Test Cases ***
 
+    The fix adds the ``*** Comments ***`` section header before the ignored data. Data containing the language
+    header is not fixed, since the header would stop working inside the ``*** Comments ***`` section.
+
     """
 
     name = "ignored-data"
@@ -208,6 +254,7 @@ class IgnoredDataRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0704",)
+    fix_availability = FixAvailability.SOMETIMES
 
     SECTION_HEADER = "***"
     IGNORE_DIRECTIVES = ("# robocop:", "# fmt:")
@@ -238,6 +285,25 @@ class IgnoredDataRule(Rule):
                 continue
             self.report(lineno=lineno, col=1, end_col=len(line.rstrip()) + 1)
             return
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """
+        Add the ``*** Comments ***`` section header before the ignored data.
+
+        The header is not added if the ignored data contains the language header - it would be placed inside the
+        ``*** Comments ***`` section and stop working.
+        """
+        for line in source_lines[diag.range.start.line - 1 :]:
+            stripped = line.strip()
+            if stripped.startswith(self.SECTION_HEADER):
+                break
+            if stripped.lower().startswith(self.LANGUAGE_HEADER):
+                return None
+        return Fix(
+            edits=[TextEdit.insert_at_range(self.rule_id, self.name, diag.range, "*** Comments ***\n")],
+            message="Add the '*** Comments ***' section header before the ignored data",
+            applicability=FixApplicability.SAFE,
+        )
 
 
 class BomEncodingRule(Rule):

--- a/tests/linter/rules/comments/ignored_data/expected_fixed/bom_and_two_ignored_lines.robot
+++ b/tests/linter/rules/comments/ignored_data/expected_fixed/bom_and_two_ignored_lines.robot
@@ -1,0 +1,6 @@
+﻿ignored but prefixed with bom
+*** Comments ***
+second line
+*** Settings ***
+Documentation     This file is created with VSCode by choosing `UTF-8 with BOM` encoding.
+...               It can create problems when running these kind of files with Robot Framework.

--- a/tests/linter/rules/comments/ignored_data/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/comments/ignored_data/expected_fixed/expected_output.txt
@@ -1,0 +1,18 @@
+actual_fixed${/}language_header_in_second_line.robot:1:1 COM04 Ignored data found in file
+   |
+ 1 |
+   | ^ COM04
+ 2 | language: pl
+   |
+
+Fixed 4 issues:
+- actual_fixed${/}bom_and_two_ignored_lines.robot:
+    1 x COM04 (ignored-data)
+- actual_fixed${/}language_header_and_other.robot:
+    1 x COM04 (ignored-data)
+- actual_fixed${/}with_ignored_data.robot:
+    1 x COM04 (ignored-data)
+- actual_fixed${/}with_ignored_rule_and_data.robot:
+    1 x COM04 (ignored-data)
+
+Found 5 issues (4 fixed, 1 remaining).

--- a/tests/linter/rules/comments/ignored_data/expected_fixed/language_header_and_other.robot
+++ b/tests/linter/rules/comments/ignored_data/expected_fixed/language_header_and_other.robot
@@ -1,0 +1,7 @@
+Language: fi
+
+*** Comments ***
+I am comment that should be in the *** Comments *** section
+
+*** Asetukset ***
+Dokumentaatio        Example using Finnish.

--- a/tests/linter/rules/comments/ignored_data/expected_fixed/language_header_in_second_line.robot
+++ b/tests/linter/rules/comments/ignored_data/expected_fixed/language_header_in_second_line.robot
@@ -1,0 +1,5 @@
+
+language: pl
+
+*** Zmienne ***
+${ZMIENNA}    1

--- a/tests/linter/rules/comments/ignored_data/expected_fixed/with_ignored_data.robot
+++ b/tests/linter/rules/comments/ignored_data/expected_fixed/with_ignored_data.robot
@@ -1,0 +1,10 @@
+*** Comments ***
+${var}    10    # This should throw a warning.
+*** Settings ***
+Documentation    Doc
+
+
+*** Test Cases ***
+First Test Case
+    [Documentation]    Doc
+    No Operation

--- a/tests/linter/rules/comments/ignored_data/expected_fixed/with_ignored_rule_and_data.robot
+++ b/tests/linter/rules/comments/ignored_data/expected_fixed/with_ignored_rule_and_data.robot
@@ -1,0 +1,12 @@
+# robocop: off=1001
+*** Comments ***
+${var}    10    # This should throw a warning.
+${var}    20    # This is not good but one warning is enough.
+*** Settings ***
+Documentation    Doc
+
+
+*** Test Cases ***
+First Test Case
+    [Documentation]    Doc
+    No Operation

--- a/tests/linter/rules/comments/ignored_data/test_rule.py
+++ b/tests/linter/rules/comments/ignored_data/test_rule.py
@@ -1,9 +1,34 @@
 from tests.linter.utils import RuleAcceptance
 
+SRC_FILES = [
+    "bom_and_ignored_data.robot",
+    "bom_and_two_ignored_lines.robot",
+    "bom_example.robot",
+    "just_ignored_rule.robot",
+    "just_language_header.robot",
+    "language_header_and_other.robot",
+    "language_header_in_second_line.robot",
+    "robotidy_disabler.robot",
+    "test.robot",
+    "with_ignored_data.robot",
+    "with_ignored_rule_and_data.robot",
+]
+
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt")
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_output.txt")
 
     def test_extended(self):
-        self.check_rule(expected_file="expected_extended.txt", output_format="extended")
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(
+            src_files=[
+                "bom_and_two_ignored_lines.robot",
+                "language_header_and_other.robot",
+                "language_header_in_second_line.robot",
+                "with_ignored_data.robot",
+                "with_ignored_rule_and_data.robot",
+            ]
+        )

--- a/tests/linter/rules/comments/missing_space_after_comment/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/comments/missing_space_after_comment/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 35 issues:
+- actual_fixed${/}test.robot:
+    35 x COM02 (missing-space-after-comment)
+
+Found 35 issues (35 fixed, 0 remaining).

--- a/tests/linter/rules/comments/missing_space_after_comment/expected_fixed/test.robot
+++ b/tests/linter/rules/comments/missing_space_after_comment/expected_fixed/test.robot
@@ -1,0 +1,70 @@
+*** Settings ***
+Documentation  doc  # invalid comment
+Metadata   myvalue  # invalid comment
+Force Tags  sometag  # invalid comment
+Default Tags  mytag  # invalid comment
+Test Setup      Keyword  # invalid comment
+Test Teardown   Keyword  # invalid comment
+Suite Setup     Keyword  # invalid comment
+Suite Teardown  Keyword  # invalid comment
+Test Template   Keyword  # invalid comment
+
+
+*** Variables ***
+${MY_VAR}    1  # invalid comment  with 2 spaces
+
+
+*** Test Cases ***  # valid comment
+Test  # invalid comment
+    [Documentation]  doc  # valid comment
+    [Tags]  sometag  # invalid comment
+    [Setup]  Keyword  # invalid comment
+    [Template]  Keyword  # invalid comment
+    [Timeout]  10  # invalid comment
+    Pass
+    Keyword  # valid comment
+    One More
+# invalid comment
+
+*** Keywords ***  # invalid comment
+Keyword  # invalid comment
+    [Documentation]  this is doc  # invalid comment
+    [Arguments]  ${arg}  # invalid comment
+    [Timeout]  10  # invalid comment
+    No Operation  # invalid comment
+    Pass
+    No Operation
+    Fail
+    IF  ${var}  # invalid comment
+        My Keyword
+    ELSE IF  ${another_var}  # invalid comment
+        Not My Keyword
+    ELSE  # invalid comment
+        Banned Keyword
+    END
+    FOR  ${var}  IN  @{list}  # invalid comment
+        My Keyword
+    END
+    [Return]  ${val}  # invalid comment
+
+RF 5 syntax
+    WHILE    $condition  # invalid comment
+        TRY  # invalid comment
+            Keyword
+        EXCEPT  # invalid comment
+            Keyword
+        FINALLY  # invalid comment
+            Keyword
+        ELSE  # invalid comment
+            Keyword
+        END  # invalid comment
+        CONTINUE  # invalid comment
+        BREAK  # invalid comment
+    END
+
+Double comments
+    # valid  still valid  with 2 spaces
+    # valid  ## valid
+    ########### block comments #########
+    Keyword  # valid  still valid  with 2 spaces
+    Keyword  # valid  ## valid

--- a/tests/linter/rules/comments/missing_space_after_comment/test_rule.py
+++ b/tests/linter/rules/comments/missing_space_after_comment/test_rule.py
@@ -14,3 +14,6 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["block.robot"],
             expected_file="expected_output_block.txt",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])


### PR DESCRIPTION
Adds automatic fixes for two comment rules (part of #1631).

### COM02 `missing-space-after-comment` (`SOMETIMES`)
Inserts a single space after the leading `#` run:
```
#comment  ->  # comment
```
Comments that would still violate the rule after the fix (e.g. `##comment`, which is not matched by the default
`block` pattern `^###`) are left untouched - this mirrors the behaviour of the `NormalizeComments` formatter.

### COM04 `ignored-data` (`SOMETIMES`)
Inserts a `*** Comments ***` section header before the ignored data.

The fix is skipped when the ignored data contains a `language:` header - moving it inside a `*** Comments ***`
section would stop the translation from being applied (verified with RF 7.4.2: a second-line language header
is still honoured, but not when it lands inside a comment section).
