### PR TITLE
feat: add fix for the empty-return rule

### DIFF
--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -27,7 +27,9 @@ except ImportError:
     Var = None
 
 from robocop.linter import sonar_qube
+from robocop.linter.fix import FixAvailability, remove_statement_fix
 from robocop.linter.rules import (
+    FixableRule,
     Rule,
     RuleParam,
     RuleSeverity,
@@ -39,6 +41,9 @@ if TYPE_CHECKING:
     from robot.parsing.model import File
     from robot.parsing.model.blocks import Block, If, VariableSection
     from robot.parsing.model.statements import Error, Node
+
+    from robocop.linter.diagnostics import Diagnostic
+    from robocop.linter.fix import Fix
 
 
 FOR_LOOP_KEYWORDS = frozenset(
@@ -156,7 +161,7 @@ class KeywordAfterReturnRule(Rule):
             )
 
 
-class EmptyReturnRule(Rule):
+class EmptyReturnRule(FixableRule):
     """
     ``[Return]`` is empty.
 
@@ -178,6 +183,8 @@ class EmptyReturnRule(Rule):
             Gather Results
             Assert Results
 
+    The fix removes the empty ``[Return]`` setting. Comments are not removed.
+
     """
 
     name = "empty-return"
@@ -190,6 +197,7 @@ class EmptyReturnRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0903",)
+    fix_availability = FixAvailability.ALWAYS
 
     def check(self, node: Block) -> None:
         """Report ``[Return]`` settings that do not return any value."""
@@ -203,6 +211,12 @@ class EmptyReturnRule(Rule):
                     col=token.col_offset + 1,
                     end_col=token.col_offset + len(token.value),
                 )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Remove the empty ``[Return]`` setting."""
+        if diag.node is None:
+            return None
+        return remove_statement_fix(self, diag.node, source_lines, "Remove empty '[Return]' setting")
 
 
 class NestedForLoopRule(Rule):

--- a/tests/linter/rules/misc/empty_return/expected_extended.txt
+++ b/tests/linter/rules/misc/empty_return/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:21:5 MISC02 [Return] is empty
     |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/empty_return/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/misc/empty_return/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 4 issues:
+- actual_fixed${/}test.robot:
+    1 x MISC02 (empty-return)
+- actual_fixed${/}with_comments.robot:
+    3 x MISC02 (empty-return)
+
+Found 4 issues (4 fixed, 0 remaining).

--- a/tests/linter/rules/misc/empty_return/expected_fixed/test.robot
+++ b/tests/linter/rules/misc/empty_return/expected_fixed/test.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+RETURN
+    RETURN

--- a/tests/linter/rules/misc/empty_return/expected_fixed/with_comments.robot
+++ b/tests/linter/rules/misc/empty_return/expected_fixed/with_comments.robot
@@ -1,0 +1,11 @@
+*** Keywords ***
+Empty Return With Comment
+    No Operation
+    # comment
+
+Empty Return With Two Comments
+    No Operation
+    # comment    # second comment
+
+Empty Return Last In File
+    No Operation

--- a/tests/linter/rules/misc/empty_return/expected_output.txt
+++ b/tests/linter/rules/misc/empty_return/expected_output.txt
@@ -1,3 +1,5 @@
 test.robot:21:5 [W] MISC02 [Return] is empty
 
 Found 1 issue.
+
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/empty_return/test_rule.py
+++ b/tests/linter/rules/misc/empty_return/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "with_comments.robot"])

--- a/tests/linter/rules/misc/empty_return/with_comments.robot
+++ b/tests/linter/rules/misc/empty_return/with_comments.robot
@@ -1,0 +1,12 @@
+*** Keywords ***
+Empty Return With Comment
+    No Operation
+    [Return]    # comment
+
+Empty Return With Two Comments
+    No Operation
+    [Return]    # comment    # second comment
+
+Empty Return Last In File
+    No Operation
+    [Return]


### PR DESCRIPTION
Adds an automatic fix for the `empty-return` (MISC02) rule - the empty `[Return]` setting is removed.
Comments placed in the removed line are preserved.

This was the last setting handled by the `RemoveEmptySettings` formatter that had no rule fix counterpart,
so the formatter can now be removed in a follow-up.

Related to #1631.
