### PR TITLE
feat: add fixes for the empty-library-alias and duplicated-library-alias rules

### DIFF
--- a/src/robocop/linter/rules/naming.py
+++ b/src/robocop/linter/rules/naming.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, Rule, RuleParam, RuleSeverity
 from robocop.linter.utils import misc as utils
 from robocop.parsing.string_operations import get_unmasked_string
 from robocop.version_handling import ROBOT_VERSION
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
         SectionHeader,
         TestCaseName,
     )
+
+    from robocop.linter.diagnostics import Diagnostic
 
 SECTION_NAME_PATTERN = re.compile(r"\*\*\*\s.+\s\*\*\*")
 LETTER_PATTERN = re.compile(r"[^\w()-]|_", re.UNICODE)
@@ -81,6 +84,40 @@ def report_wrong_case_in_keyword(rule: Rule, node: Node, keyword_name: str, norm
 # Separating alias values since RF 3 uses WITH_NAME instead of WITH NAME
 ALIAS_TOKENS = [Token.WITH_NAME] if ROBOT_VERSION.major < 5 else ["WITH NAME", "AS"]
 ALIAS_TOKENS_VALUES = ["WITH NAME"] if ROBOT_VERSION.major < 5 else ["WITH NAME", "AS"]
+ALIAS_MARKER_PATTERN = re.compile(r"\s+(WITH NAME|AS)\s*$")
+
+
+def remove_alias_fix(
+    rule: Rule, diag: Diagnostic, source_lines: list[str], message: str, *, with_marker: bool
+) -> Fix | None:
+    """
+    Create a fix removing the alias part of the library import.
+
+    Everything from the end of the preceding value up to the end of the reported range is removed. With
+    ``with_marker`` the alias marker (``AS`` or ``WITH NAME``) placed before the reported range is removed too.
+    Imports with the alias split into multiple lines are not fixed.
+    """
+    reported_range = diag.range
+    if reported_range.start.line != reported_range.end.line:
+        return None
+    line = source_lines[reported_range.start.line - 1]
+    prefix = line[: reported_range.start.character - 1].rstrip()
+    if with_marker:
+        prefix, removed_marker = ALIAS_MARKER_PATTERN.subn("", prefix)
+        if not removed_marker:  # the alias marker is placed in the previous line
+            return None
+    if prefix.strip() in ("", "..."):  # only the continuation mark would be left in the line
+        return None
+    replacement = prefix + line[reported_range.end.character - 1 :]
+    return Fix(
+        edits=[
+            TextEdit.replace_lines(
+                rule.rule_id, rule.name, reported_range.start.line, reported_range.start.line, replacement
+            )
+        ],
+        message=message,
+        applicability=FixApplicability.SAFE,
+    )
 
 
 def library_has_alias(node: LibraryImport) -> bool | None:
@@ -607,7 +644,7 @@ class TestCaseNameIsEmptyRule(Rule):
         self.report(node=node)
 
 
-class EmptyLibraryAliasRule(Rule):
+class EmptyLibraryAliasRule(FixableRule):
     """
     Library alias is empty.
 
@@ -623,6 +660,9 @@ class EmptyLibraryAliasRule(Rule):
         *** Settings ***
         Library  CustomLibrary  AS  AnotherName
 
+    The fix removes the alias marker without the name. Imports with the alias split into multiple lines
+    are not fixed.
+
     """
 
     name = "empty-library-alias"
@@ -634,6 +674,7 @@ class EmptyLibraryAliasRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0314",)
+    fix_availability = FixAvailability.SOMETIMES
 
     def check(self, node: LibraryImport) -> None:
         if library_has_alias(node) is not False:
@@ -643,8 +684,12 @@ class EmptyLibraryAliasRule(Rule):
                 col = arg.col_offset + 1
                 self.report(node=arg, col=col, end_col=col + len(arg.value))
 
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Remove the alias marker that is not followed by the alias name."""
+        return remove_alias_fix(self, diag, source_lines, "Remove the empty library alias", with_marker=False)
 
-class DuplicatedLibraryAliasRule(Rule):
+
+class DuplicatedLibraryAliasRule(FixableRule):
     """
     Library alias is the same as the original name.
 
@@ -653,6 +698,8 @@ class DuplicatedLibraryAliasRule(Rule):
          *** Settings ***
          Library  CustomLibrary  AS  CustomLibrary   # same as library name
          Library  CustomLibrary  AS  Custom Library  # same as library name (spaces are ignored)
+
+    The fix removes the redundant alias. Imports with the alias split into multiple lines are not fixed.
 
     """
 
@@ -665,6 +712,7 @@ class DuplicatedLibraryAliasRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0315",)
+    fix_availability = FixAvailability.SOMETIMES
 
     def check(self, node: LibraryImport) -> None:
         if library_has_alias(node) is not True:
@@ -673,6 +721,10 @@ class DuplicatedLibraryAliasRule(Rule):
             return
         name_token = node.get_tokens(Token.NAME)[-1]
         self.report(node=name_token, col=name_token.col_offset + 1, end_col=name_token.end_col_offset + 1)
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Remove the alias that is the same as the library name."""
+        return remove_alias_fix(self, diag, source_lines, "Remove the duplicated library alias", with_marker=True)
 
 
 class BddWithoutKeywordCallRule(Rule):

--- a/tests/linter/rules/naming/duplicated_library_alias/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/naming/duplicated_library_alias/expected_fixed/expected_output.txt
@@ -1,0 +1,23 @@
+actual_fixed${/}multiline.robot:4:8 NAME13 Library alias is the same as original name
+   |
+ 2 | Library      Collections
+ 3 | ...    WITH NAME
+ 4 | ...    Collections
+   |        ^^^^^^^^^^^ NAME13
+ 5 | Library      Collections
+ 6 | ...    AS    Collections
+   |
+
+actual_fixed${/}multiline.robot:6:14 NAME13 Library alias is the same as original name
+   |
+ 4 | ...    Collections
+ 5 | Library      Collections
+ 6 | ...    AS    Collections
+   |              ^^^^^^^^^^^ NAME13
+   |
+
+Fixed 4 issues:
+- actual_fixed${/}test.robot:
+    4 x NAME13 (duplicated-library-alias)
+
+Found 6 issues (4 fixed, 2 remaining).

--- a/tests/linter/rules/naming/duplicated_library_alias/expected_fixed/multiline.robot
+++ b/tests/linter/rules/naming/duplicated_library_alias/expected_fixed/multiline.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library      Collections
+...    WITH NAME
+...    Collections
+Library      Collections
+...    AS    Collections

--- a/tests/linter/rules/naming/duplicated_library_alias/expected_fixed/test.robot
+++ b/tests/linter/rules/naming/duplicated_library_alias/expected_fixed/test.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Resource     library.py
+Library      Collections
+Library      Collections
+Library      other_library.py    WITH NAME  PrettyName
+Library      WITH NAME
+Library      Collections
+Library      Collections

--- a/tests/linter/rules/naming/duplicated_library_alias/multiline.robot
+++ b/tests/linter/rules/naming/duplicated_library_alias/multiline.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library      Collections
+...    WITH NAME
+...    Collections
+Library      Collections
+...    AS    Collections

--- a/tests/linter/rules/naming/duplicated_library_alias/test_rule.py
+++ b/tests/linter/rules/naming/duplicated_library_alias/test_rule.py
@@ -15,3 +15,6 @@ class TestRuleAcceptance(RuleAcceptance):
             output_format="extended",
             test_on_version=">=6.0",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "multiline.robot"], test_on_version=">=6.0")

--- a/tests/linter/rules/naming/empty_library_alias/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/naming/empty_library_alias/expected_fixed/expected_output.txt
@@ -1,0 +1,23 @@
+actual_fixed${/}multiline.robot:3:8 NAME12 Library alias is empty
+   |
+ 1 | *** Settings ***
+ 2 | Library      Collections
+ 3 | ...    WITH NAME
+   |        ^^^^^^^^^ NAME12
+ 4 | Library      other_library.py
+ 5 | ...    arg=1
+   |
+
+actual_fixed${/}multiline.robot:6:8 NAME12 Library alias is empty
+   |
+ 4 | Library      other_library.py
+ 5 | ...    arg=1
+ 6 | ...    AS
+   |        ^^ NAME12
+   |
+
+Fixed 4 issues:
+- actual_fixed${/}test.robot:
+    4 x NAME12 (empty-library-alias)
+
+Found 6 issues (4 fixed, 2 remaining).

--- a/tests/linter/rules/naming/empty_library_alias/expected_fixed/multiline.robot
+++ b/tests/linter/rules/naming/empty_library_alias/expected_fixed/multiline.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library      Collections
+...    WITH NAME
+Library      other_library.py
+...    arg=1
+...    AS

--- a/tests/linter/rules/naming/empty_library_alias/expected_fixed/test.robot
+++ b/tests/linter/rules/naming/empty_library_alias/expected_fixed/test.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+Resources    library.py
+Library      Collections
+Library      other_library.py  # comment
+Library      other_library.py    WITH NAME  PrettyName  # comment
+Library      other_library.py
+Library      other_library.py    AS    SomeName
+Library      WITH NAME
+Library      other_library.py     arg=1    AS     MyName
+Library      other_library.py     arg=1

--- a/tests/linter/rules/naming/empty_library_alias/multiline.robot
+++ b/tests/linter/rules/naming/empty_library_alias/multiline.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library      Collections
+...    WITH NAME
+Library      other_library.py
+...    arg=1
+...    AS

--- a/tests/linter/rules/naming/empty_library_alias/test_rule.py
+++ b/tests/linter/rules/naming/empty_library_alias/test_rule.py
@@ -15,3 +15,6 @@ class TestRuleAcceptance(RuleAcceptance):
             output_format="extended",
             test_on_version=">=6",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "multiline.robot"], test_on_version=">=6")


### PR DESCRIPTION
Adds automatic fixes for two library alias rules (part of #1631).

### NAME12 `empty-library-alias`
Removes the alias marker that is not followed by an alias name:
```robotframework
Library    Collections    WITH NAME    ->    Library    Collections
```

### NAME13 `duplicated-library-alias`
Removes the alias that is the same as the library name (spaces are ignored):
```robotframework
Library    Collections    AS    Collections    ->    Library    Collections
```

Both fixes are `SOMETIMES` available - imports with the alias split into multiple lines with the `...` continuation
mark are reported but not fixed, since removing the alias would leave a dangling continuation line.
Comments in the fixed line are preserved.
