### PR TITLE
feat: add fixes for the duplicated import rules

### DIFF
--- a/src/robocop/linter/rules/duplications.py
+++ b/src/robocop/linter/rules/duplications.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity
+from robocop.linter.fix import FixAvailability, remove_statement_fix
+from robocop.linter.rules import FixableRule, Rule, RuleSeverity
 
 if TYPE_CHECKING:
     from robot.parsing.model.statements import (
@@ -13,7 +14,27 @@ if TYPE_CHECKING:
         SectionHeader,
     )
 
+    from robocop.linter.diagnostics import Diagnostic
+    from robocop.linter.fix import Fix
+
 NodeT = TypeVar("NodeT", bound="Node")
+
+
+class DuplicatedImportRule(FixableRule):
+    """
+    Base class for the rules reporting the same import used more than once.
+
+    The fix removes the duplicated import. Only imports that are exactly the same (including the arguments and
+    the alias) are reported, so removing them does not change the behaviour. Comments are not removed.
+    """
+
+    fix_availability = FixAvailability.ALWAYS
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Remove the duplicated import."""
+        if diag.node is None:
+            return None
+        return remove_statement_fix(self, diag.node, source_lines, "Remove the duplicated import")
 
 
 class DuplicatedTestCaseRule(Rule):
@@ -106,7 +127,7 @@ class DuplicatedVariableRule(Rule):
     deprecated_names = ("0803",)
 
 
-class DuplicatedResourceRule(Rule):
+class DuplicatedResourceRule(DuplicatedImportRule):
     """
     Duplicated resource imports.
 
@@ -118,6 +139,8 @@ class DuplicatedResourceRule(Rule):
         Resource    path.resource
         Resource    other_path.resource
         Resource    path.resource
+
+    The fix removes the duplicated import.
 
     """
 
@@ -132,7 +155,7 @@ class DuplicatedResourceRule(Rule):
     deprecated_names = ("0804",)
 
 
-class DuplicatedLibraryRule(Rule):
+class DuplicatedLibraryRule(DuplicatedImportRule):
     """
     Duplicated library imports.
 
@@ -141,6 +164,8 @@ class DuplicatedLibraryRule(Rule):
         *** Settings ***
         Library  RobotLibrary
         Library  RobotLibrary  AS  OtherRobotLibrary
+
+    The fix removes the duplicated import. Only imports with the same name, arguments and alias are reported.
 
     """
 
@@ -172,8 +197,12 @@ class DuplicatedMetadataRule(Rule):
     deprecated_names = ("0806",)
 
 
-class DuplicatedVariablesImportRule(Rule):
-    """Duplicated variables import."""
+class DuplicatedVariablesImportRule(DuplicatedImportRule):
+    """
+    Duplicated variables import.
+
+    The fix removes the duplicated import.
+    """
 
     name = "duplicated-variables-import"
     rule_id = "DUP07"

--- a/tests/linter/rules/duplications/duplicated_library/expected_extended.txt
+++ b/tests/linter/rules/duplications/duplicated_library/expected_extended.txt
@@ -28,3 +28,4 @@ test.robot:12:12 DUP05 Multiple library imports with name 'MyLib' and identical 
     |
 
 Found 3 issues.
+3 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_library/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/duplications/duplicated_library/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 3 issues:
+- actual_fixed${/}test.robot:
+    3 x DUP05 (duplicated-library)
+
+Found 3 issues (3 fixed, 0 remaining).

--- a/tests/linter/rules/duplications/duplicated_library/expected_fixed/test.robot
+++ b/tests/linter/rules/duplications/duplicated_library/expected_fixed/test.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation  doc
+Library    MyLib
+Library    OtherLib
+Library
+Resource  some_resource.robot
+Library    MyLib    arg
+Library    MyLib  WITH NAME    MyLib2
+Library    MyLib  AS    MyLib3
+Library    MyLib    argument    AS    MyLib2
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/duplications/duplicated_library/expected_output_pre_rf6.txt
+++ b/tests/linter/rules/duplications/duplicated_library/expected_output_pre_rf6.txt
@@ -2,3 +2,4 @@ test.robot:7:12 [W] DUP05 Multiple library imports with name 'MyLib' and identic
 test.robot:9:12 [W] DUP05 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 8)
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_library/expected_output_rf6.txt
+++ b/tests/linter/rules/duplications/duplicated_library/expected_output_rf6.txt
@@ -3,3 +3,4 @@ test.robot:9:12 [W] DUP05 Multiple library imports with name 'MyLib' and identic
 test.robot:12:12 [W] DUP05 Multiple library imports with name 'MyLib' and identical arguments (first occurrence in line 10)
 
 Found 3 issues.
+3 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_library/test_rule.py
+++ b/tests/linter/rules/duplications/duplicated_library/test_rule.py
@@ -17,4 +17,4 @@ class TestRuleAcceptance(RuleAcceptance):
         )
 
     def test_fix(self):
-        self.check_rule_fix(src_files=["test.robot"])
+        self.check_rule_fix(src_files=["test.robot"], test_on_version=">=6.0")

--- a/tests/linter/rules/duplications/duplicated_library/test_rule.py
+++ b/tests/linter/rules/duplications/duplicated_library/test_rule.py
@@ -6,7 +6,15 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6.txt", test_on_version="<6.0")
 
     def test_rule_rf6(self):
-        self.check_rule(expected_file="expected_output_rf6.txt", test_on_version=">=6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6.txt", test_on_version=">=6.0")
 
     def test_extended(self):
-        self.check_rule(expected_file="expected_extended.txt", output_format="extended", test_on_version=">=6.0")
+        self.check_rule(
+            src_files=["test.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=6.0",
+        )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/duplications/duplicated_resource/expected_extended.txt
+++ b/tests/linter/rules/duplications/duplicated_resource/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:5:1 DUP04 Multiple resource imports with path 'resource.robot' (first
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_resource/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/duplications/duplicated_resource/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 1 issue:
+- actual_fixed${/}test.robot:
+    1 x DUP04 (duplicated-resource)
+
+Found 1 issue (1 fixed, 0 remaining).

--- a/tests/linter/rules/duplications/duplicated_resource/expected_fixed/test.robot
+++ b/tests/linter/rules/duplications/duplicated_resource/expected_fixed/test.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation  doc
+Resource  resource.robot
+Resource  other_file.robot
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/duplications/duplicated_resource/expected_output.txt
+++ b/tests/linter/rules/duplications/duplicated_resource/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:5:1 [W] DUP04 Multiple resource imports with path 'resource.robot' (first occurrence in line 3)
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_resource/test_rule.py
+++ b/tests/linter/rules/duplications/duplicated_resource/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/duplications/duplicated_variables_import/expected_extended.txt
+++ b/tests/linter/rules/duplications/duplicated_variables_import/expected_extended.txt
@@ -46,3 +46,4 @@ test.robot:16:1 DUP07 Duplicated variables import with path 'variables.robot' (f
     |
 
 Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_variables_import/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/duplications/duplicated_variables_import/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 5 issues:
+- actual_fixed${/}test.robot:
+    5 x DUP07 (duplicated-variables-import)
+
+Found 5 issues (5 fixed, 0 remaining).

--- a/tests/linter/rules/duplications/duplicated_variables_import/expected_fixed/test.robot
+++ b/tests/linter/rules/duplications/duplicated_variables_import/expected_fixed/test.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Documentation  doc
+Variables  variables.py
+Variables  other.robot
+
+Variables  other.py    arg1
+Variables  other.py    arg2
+Variables  other1.py    arg1
+Variables  vars.yaml    arg1
+Variables  vars2.yaml
+Variables  variables.robot
+Variables  variables.robot    arg
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/duplications/duplicated_variables_import/expected_output.txt
+++ b/tests/linter/rules/duplications/duplicated_variables_import/expected_output.txt
@@ -5,3 +5,4 @@ test.robot:15:1 [W] DUP07 Duplicated variables import with path 'variables.robot
 test.robot:16:1 [W] DUP07 Duplicated variables import with path 'variables.robot' (first occurrence in line 14)
 
 Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/duplications/duplicated_variables_import/test_rule.py
+++ b/tests/linter/rules/duplications/duplicated_variables_import/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])


### PR DESCRIPTION
Adds automatic fixes for the duplicated import rules (part of #1631):

- DUP04 `duplicated-resource`
- DUP05 `duplicated-library`
- DUP07 `duplicated-variables-import`

All three now share a `DuplicatedImportRule` base class with the fix that removes the duplicated import statement.
Only imports that are exactly the same (the same path/name, arguments and alias) are reported, so removing the
later occurrence does not change the behaviour. Comments placed in the removed lines are preserved.
