### PR TITLE
feat: add fix for the unnecessary-default-tags rule

### DIFF
--- a/src/robocop/linter/rules/tags.py
+++ b/src/robocop/linter/rules/tags.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, ClassVar, TypeAlias
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.fix import FixAvailability, remove_empty_setting_fix
+from robocop.linter.fix import FixAvailability, remove_empty_setting_fix, remove_statement_fix
 from robocop.linter.rules import FixableRule, Rule, RuleSeverity
 from robocop.parsing.variables import VariableMatches  # type: ignore[attr-defined]
 
@@ -259,7 +259,7 @@ class TagAlreadySetInTestTagsRule(Rule):  # TODO: support -tag
             )
 
 
-class UnnecessaryDefaultTagsRule(Rule):
+class UnnecessaryDefaultTagsRule(FixableRule):
     """
     ``Default Tags`` setting is always overwritten and is unnecessary.
 
@@ -279,6 +279,8 @@ class UnnecessaryDefaultTagsRule(Rule):
 
     Since ``Test`` and ``Test 2`` have the ``[Tags]`` section, the ``Default Tags`` setting is never used.
 
+    The fix removes the ``Default Tags`` setting. Comments are not removed.
+
     """
 
     name = "unnecessary-default-tags"
@@ -290,6 +292,7 @@ class UnnecessaryDefaultTagsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0607",)
+    fix_availability = FixAvailability.ALWAYS
 
     def check(self, node: File, default_tags_node: DefaultTags | None) -> None:
         if not self.enabled:
@@ -300,6 +303,13 @@ class UnnecessaryDefaultTagsRule(Rule):
             col=report_node.col_offset + 1,
             end_col=report_node.get_token(Token.DEFAULT_TAGS).end_col_offset + 1,
         )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Remove the ``Default Tags`` setting that is always overwritten."""
+        node = diag.node
+        if node is None or not node.data_tokens or node.data_tokens[0].type != Token.DEFAULT_TAGS:
+            return None
+        return remove_statement_fix(self, node, source_lines, "Remove the unnecessary 'Default Tags' setting")
 
 
 class EmptyTagsRule(FixableRule):

--- a/tests/linter/rules/tags/unnecessary_default_tags/expected_extended.txt
+++ b/tests/linter/rules/tags/unnecessary_default_tags/expected_extended.txt
@@ -7,3 +7,4 @@ test.robot:3:1 TAG07 Tags defined in Default Tags are always overwritten
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/unnecessary_default_tags/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/tags/unnecessary_default_tags/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 2 issues:
+- actual_fixed${/}test.robot:
+    1 x TAG07 (unnecessary-default-tags)
+- actual_fixed${/}with_comments.robot:
+    1 x TAG07 (unnecessary-default-tags)
+
+Found 2 issues (2 fixed, 0 remaining).

--- a/tests/linter/rules/tags/unnecessary_default_tags/expected_fixed/test.robot
+++ b/tests/linter/rules/tags/unnecessary_default_tags/expected_fixed/test.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Documentation  doc
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag  tag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/tags/unnecessary_default_tags/expected_fixed/with_comments.robot
+++ b/tests/linter/rules/tags/unnecessary_default_tags/expected_fixed/with_comments.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Documentation    doc
+# comment
+
+
+*** Test Cases ***
+Test
+    [Tags]    sometag
+    No Operation
+
+Test 2
+    [Tags]    other
+    No Operation

--- a/tests/linter/rules/tags/unnecessary_default_tags/expected_output.txt
+++ b/tests/linter/rules/tags/unnecessary_default_tags/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:3:1 [I] TAG07 Tags defined in Default Tags are always overwritten
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/unnecessary_default_tags/test_rule.py
+++ b/tests/linter/rules/tags/unnecessary_default_tags/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "with_comments.robot"])

--- a/tests/linter/rules/tags/unnecessary_default_tags/with_comments.robot
+++ b/tests/linter/rules/tags/unnecessary_default_tags/with_comments.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Documentation    doc
+Default Tags    tag    # comment
+...    othertag
+
+
+*** Test Cases ***
+Test
+    [Tags]    sometag
+    No Operation
+
+Test 2
+    [Tags]    other
+    No Operation


### PR DESCRIPTION
Adds an automatic fix for the TAG07 `unnecessary-default-tags` rule (part of #1631).

The `Default Tags` setting is removed when every test in the suite defines its own `[Tags]`, so the setting is
never used. Multiline settings are handled and comments placed in the removed lines are preserved.
