### PR TITLE
feat: add fixes for the redundant tag rules

### DIFF
--- a/src/robocop/linter/checkers/tags.py
+++ b/src/robocop/linter/checkers/tags.py
@@ -144,7 +144,7 @@ class TagsChecker(VisitorChecker):
             self.tag_already_set_in_keyword_tags.check(node, self.keyword_tags, self.keyword_tags_node)
         else:
             self.tags_in_tests.append(tags)
-            self.tag_already_set_in_test_tags.check(node, self.test_tags, self.test_tags_node)
+            self.tag_already_set_in_test_tags.check(node, self.test_tags, self.test_tags_node, self.suite_default_tags)
 
     def visit_Documentation(self, node: Documentation) -> None:  # noqa: N802
         """
@@ -174,7 +174,7 @@ class TagsChecker(VisitorChecker):
                 col_start += len(tag) + 1  # 1 for ,
                 duplicates[normalized].append(subtoken)
                 self.check_tag(subtoken, node)
-        self.duplicated_tags.check(duplicates)
+        self.duplicated_tags.check(duplicates, node)
 
     def check_tag_names(self, node: TagNode) -> None:
         tags: defaultdict[str, list[Token]] = defaultdict(list)
@@ -182,7 +182,7 @@ class TagsChecker(VisitorChecker):
             normalized_tag = tag.value.lower().replace(" ", "")
             tags[normalized_tag].append(tag)
             self.check_tag(tag, node)
-        self.duplicated_tags.check(tags)
+        self.duplicated_tags.check(tags, node)
 
     def check_tag(self, tag_token: Token, node: TagNode | Documentation) -> None:
         substrings, variable_found = split_tag_on_variables(tag_token.value)

--- a/src/robocop/linter/rules/tags.py
+++ b/src/robocop/linter/rules/tags.py
@@ -7,7 +7,14 @@ from typing import TYPE_CHECKING, ClassVar, TypeAlias
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.fix import FixAvailability, remove_empty_setting_fix, remove_statement_fix
+from robocop.linter.fix import (
+    Fix,
+    FixApplicability,
+    FixAvailability,
+    TextEdit,
+    remove_empty_setting_fix,
+    remove_statement_fix,
+)
 from robocop.linter.rules import FixableRule, Rule, RuleSeverity
 from robocop.parsing.variables import VariableMatches  # type: ignore[attr-defined]
 
@@ -18,13 +25,78 @@ if TYPE_CHECKING:
         Documentation,
         ForceTags,
         KeywordTags,
+        Statement,
         Tags,
     )
 
     from robocop.linter.diagnostics import Diagnostic
-    from robocop.linter.fix import Fix
 
 TagNode: TypeAlias = "ForceTags | DefaultTags | Tags | KeywordTags"
+
+SETTING_WITH_SINGLE_TAG = 2  # the setting name token and a single tag token
+
+
+def _find_reported_tag(node: Statement, diag: Diagnostic) -> Token | None:
+    """Find the tag token reported by the diagnostic using its position."""
+    return next(
+        (
+            token
+            for token in node.data_tokens[1:]
+            if token.lineno == diag.range.start.line and token.col_offset + 1 == diag.range.start.character
+        ),
+        None,
+    )
+
+
+def _lines_without_tag(node: Statement, source_lines: list[str], tag: Token) -> list[str]:
+    """
+    Return the statement lines with the tag removed.
+
+    The separator preceding the tag is removed together with it. If the tag was the only data in its line,
+    the whole line is removed - unless it contains a comment, which is always preserved.
+    """
+    lines = source_lines[node.lineno - 1 : node.end_lineno]
+    index = tag.lineno - node.lineno
+    line = lines[index]
+    lines[index] = line[: tag.col_offset].rstrip() + line[tag.end_col_offset :]
+    only_tag_in_line = not any(token.lineno == tag.lineno for token in node.data_tokens if token is not tag)
+    has_comment = any(token.lineno == tag.lineno for token in node.get_tokens(Token.COMMENT))
+    if only_tag_in_line and not has_comment:
+        lines.pop(index)
+    return lines
+
+
+def remove_tag_fix(rule: FixableRule, diag: Diagnostic, source_lines: list[str], message: str) -> Fix | None:
+    """
+    Create a fix that removes the redundant tag from the tag setting.
+
+    If the removed tag is the only tag in the setting, the whole setting is removed instead. The fix replaces
+    the complete statement, so that only one tag is removed in a single run - the remaining ones are reported
+    and removed in the following runs.
+    """
+    node = diag.node
+    if node is None:
+        return None
+    data_tokens = getattr(node, "data_tokens", [])
+    if len(data_tokens) < SETTING_WITH_SINGLE_TAG:
+        return None
+    tag = _find_reported_tag(node, diag)
+    if tag is None:
+        return None
+    if len(data_tokens) == SETTING_WITH_SINGLE_TAG:
+        if diag.reported_arguments.get("overwrites_suite_setting"):
+            # Removing the setting would apply the Default Tags instead - use the explicit NONE value.
+            edit = TextEdit.replace_at_range(rule.rule_id, rule.name, diag.range, "NONE")
+            return Fix(
+                edits=[edit],
+                message=f"{message} and replace it with an explicit NONE value",
+                applicability=FixApplicability.SAFE,
+            )
+        return remove_statement_fix(rule, node, source_lines, message)
+    edit = TextEdit.replace_lines(
+        rule.rule_id, rule.name, node.lineno, node.end_lineno, "".join(_lines_without_tag(node, source_lines, tag))
+    )
+    return Fix(edits=[edit], message=message, applicability=FixApplicability.SAFE)
 
 
 class TagWithSpaceRule(Rule):
@@ -212,7 +284,7 @@ class CouldBeTestTagsRule(Rule):
         self.report(tags=", ".join(sorted(common_tags)), node=report_node)
 
 
-class TagAlreadySetInTestTagsRule(Rule):  # TODO: support -tag
+class TagAlreadySetInTestTagsRule(FixableRule):  # TODO: support -tag
     """
     Tag is already set in the ``Test Tags`` setting.
 
@@ -230,6 +302,10 @@ class TagAlreadySetInTestTagsRule(Rule):  # TODO: support -tag
     This rule was renamed from ``tag-already-set-in-force-tags`` to ``tag-already-set-in-test-tags`` in
     Robocop 2.6.0.
 
+    The fix removes the redundant tag. If it is the only tag in the ``[Tags]`` setting, the whole setting is
+    removed - unless the suite defines ``Default Tags``, in which case the explicit ``NONE`` value is used
+    instead. Comments are never removed by the fix.
+
     """
 
     name = "tag-already-set-in-test-tags"
@@ -241,8 +317,11 @@ class TagAlreadySetInTestTagsRule(Rule):  # TODO: support -tag
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0606",)
+    fix_availability = FixAvailability.ALWAYS
 
-    def check(self, node: Tags, test_tags: set[str], test_tags_node: ForceTags | None) -> None:
+    def check(
+        self, node: Tags, test_tags: set[str], test_tags_node: ForceTags | None, has_default_tags: bool = False
+    ) -> None:
         if not self.enabled or test_tags_node is None:
             return
         test_force_tags = test_tags_node.data_tokens[0].value
@@ -252,11 +331,16 @@ class TagAlreadySetInTestTagsRule(Rule):  # TODO: support -tag
             self.report(
                 tag=tag.value,
                 test_force_tags=test_force_tags,
+                overwrites_suite_setting=has_default_tags,
                 node=node,
                 lineno=tag.lineno,
                 col=tag.col_offset + 1,
                 end_col=tag.end_col_offset + 1,
             )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        tag = diag.reported_arguments["tag"]
+        return remove_tag_fix(self, diag, source_lines, f"Remove the '{tag}' tag already set in suite settings")
 
 
 class UnnecessaryDefaultTagsRule(FixableRule):
@@ -374,7 +458,7 @@ class EmptyTagsRule(FixableRule):
         return remove_empty_setting_fix(self, diag, source_lines)
 
 
-class DuplicatedTagsRule(Rule):
+class DuplicatedTagsRule(FixableRule):
     """
     Duplicated tags found.
 
@@ -387,6 +471,9 @@ class DuplicatedTagsRule(Rule):
         Test
             [Tags]    Tag    TAG    tag    t a g
 
+    The fix removes the duplicated tags and leaves only the first occurrence. Tags defined in the keyword
+    documentation are not fixed. Comments are never removed by the fix.
+
     """
 
     name = "duplicated-tags"
@@ -398,8 +485,9 @@ class DuplicatedTagsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0609",)
+    fix_availability = FixAvailability.SOMETIMES
 
-    def check(self, tags: dict[str, list[Token]]) -> None:
+    def check(self, tags: dict[str, list[Token]], node: TagNode | Documentation | None = None) -> None:
         if not self.enabled:
             return
         for nodes in tags.values():
@@ -408,10 +496,18 @@ class DuplicatedTagsRule(Rule):
                     name=duplicate.value,
                     line=nodes[0].lineno,
                     column=nodes[0].col_offset + 1,
-                    node=duplicate,
+                    node=node,
+                    lineno=duplicate.lineno,
                     col=duplicate.col_offset + 1,
                     end_col=duplicate.end_col_offset + 1,
                 )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        node = diag.node
+        if node is None or node.type == Token.DOCUMENTATION:
+            return None  # tags listed in the documentation are plain text and are not fixed
+        name = diag.reported_arguments["name"]
+        return remove_tag_fix(self, diag, source_lines, f"Remove the duplicated '{name}' tag")
 
 
 class CouldBeKeywordTagsRule(Rule):
@@ -455,7 +551,7 @@ class CouldBeKeywordTagsRule(Rule):
         self.report(tags=", ".join(sorted(common_tags)), node=report_node)
 
 
-class TagAlreadySetInKeywordTagsRule(Rule):
+class TagAlreadySetInKeywordTagsRule(FixableRule):
     """
     Tag is already set in the ``Test Keyword`` setting.
 
@@ -469,6 +565,9 @@ class TagAlreadySetInKeywordTagsRule(Rule):
         Keyword
             [Tags]  sanity  common_tag
 
+    The fix removes the redundant tag. If it is the only tag in the ``[Tags]`` setting, the whole setting is
+    removed. Comments are never removed by the fix.
+
     """
 
     name = "tag-already-set-in-keyword-tags"
@@ -481,6 +580,7 @@ class TagAlreadySetInKeywordTagsRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0611",)
+    fix_availability = FixAvailability.ALWAYS
 
     def check(self, node: Tags, keyword_tags: set[str], keyword_tags_node: KeywordTags | None) -> None:
         if not self.enabled or keyword_tags_node is None:
@@ -497,6 +597,10 @@ class TagAlreadySetInKeywordTagsRule(Rule):
                 col=tag.col_offset + 1,
                 end_col=tag.end_col_offset + 1,
             )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        tag = diag.reported_arguments["tag"]
+        return remove_tag_fix(self, diag, source_lines, f"Remove the '{tag}' tag already set in suite settings")
 
 
 def split_tag_on_variables(tag_value: str) -> tuple[list[str], bool]:

--- a/tests/linter/rules/tags/duplicated_tags/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/tags/duplicated_tags/expected_fixed/expected_output.txt
@@ -1,0 +1,14 @@
+actual_fixed${/}fix_duplicated_tags.robot:22:51 TAG09 Multiple tags with name 'tag' (first occurrence at line 22 column 33)
+    |
+ 20 | *** Keywords ***
+ 21 | Duplicated Tags In Documentation
+ 22 |     [Documentation]    Tags:    tag,    other,    tag
+    |                                                   ^^^ TAG09
+ 23 |     Step
+    |
+
+Fixed 7 issues:
+- actual_fixed${/}fix_duplicated_tags.robot:
+    7 x TAG09 (duplicated-tags)
+
+Found 8 issues (7 fixed, 1 remaining).

--- a/tests/linter/rules/tags/duplicated_tags/expected_fixed/fix_duplicated_tags.robot
+++ b/tests/linter/rules/tags/duplicated_tags/expected_fixed/fix_duplicated_tags.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Force Tags    tag    other
+
+
+*** Test Cases ***
+Duplicated Tags
+    [Tags]    tag    dummy
+    Step
+
+Duplicated Tags With Comment
+    [Tags]    tag    # comment
+    Step
+
+Multiline Duplicated Tags
+    [Tags]    tag    other
+    ...    own
+    Step
+
+
+*** Keywords ***
+Duplicated Tags In Documentation
+    [Documentation]    Tags:    tag,    other,    tag
+    Step

--- a/tests/linter/rules/tags/duplicated_tags/fix_duplicated_tags.robot
+++ b/tests/linter/rules/tags/duplicated_tags/fix_duplicated_tags.robot
@@ -1,0 +1,24 @@
+*** Settings ***
+Force Tags    tag    TAG    t ag    other
+
+
+*** Test Cases ***
+Duplicated Tags
+    [Tags]    tag    dummy    TAG    t a g
+    Step
+
+Duplicated Tags With Comment
+    [Tags]    tag    tag    # comment
+    Step
+
+Multiline Duplicated Tags
+    [Tags]    tag    other
+    ...    TAG
+    ...    t ag    own
+    Step
+
+
+*** Keywords ***
+Duplicated Tags In Documentation
+    [Documentation]    Tags:    tag,    other,    tag
+    Step

--- a/tests/linter/rules/tags/duplicated_tags/test_rule.py
+++ b/tests/linter/rules/tags/duplicated_tags/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["fix_duplicated_tags.robot"])

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_extended.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_extended.txt
@@ -17,3 +17,4 @@ keyword_tags.robot:12:13 TAG11 Tag 'tag' is already set by Keyword Tags in suite
     |
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 4 issues:
+- actual_fixed${/}fix_keyword_tags.robot:
+    4 x TAG11 (tag-already-set-in-keyword-tags)
+
+Found 4 issues (4 fixed, 0 remaining).

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_fixed/fix_keyword_tags.robot
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_fixed/fix_keyword_tags.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Keyword Tags    common    shared
+
+
+*** Keywords ***
+Only Redundant Tag
+    Step
+
+Redundant And Own Tags
+    [Tags]    own
+    Step
+
+Multiline Tags
+    [Tags]    own
+    ...    own2
+    Step

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_output.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/expected_output.txt
@@ -2,3 +2,4 @@ keyword_tags.robot:8:13 [I] TAG11 Tag 'tag' is already set by Keyword Tags in su
 keyword_tags.robot:12:13 [I] TAG11 Tag 'tag' is already set by Keyword Tags in suite settings
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/fix_keyword_tags.robot
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/fix_keyword_tags.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Keyword Tags    common    shared
+
+
+*** Keywords ***
+Only Redundant Tag
+    [Tags]    common
+    Step
+
+Redundant And Own Tags
+    [Tags]    common    own
+    Step
+
+Multiline Tags
+    [Tags]    own
+    ...    common
+    ...    shared    own2
+    Step

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/test_rule.py
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/test_rule.py
@@ -1,9 +1,19 @@
 from tests.linter.utils import RuleAcceptance
 
+SRC_FILES = ["keyword_tags.robot", "no_tags_in_keywords.robot"]
+
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", test_on_version=">=6")
+        self.check_rule(src_files=SRC_FILES, expected_file="expected_output.txt", test_on_version=">=6")
 
     def test_extended(self):
-        self.check_rule(expected_file="expected_extended.txt", output_format="extended", test_on_version=">=6")
+        self.check_rule(
+            src_files=SRC_FILES,
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=6",
+        )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["fix_keyword_tags.robot"], test_on_version=">=6")

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_extended.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_extended.txt
@@ -9,3 +9,4 @@ test.robot:9:13 TAG06 Tag 'sometag' is already set by Force Tags in suite settin
    |
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 8 issues:
+- actual_fixed${/}fix_default_tags.robot:
+    2 x TAG06 (tag-already-set-in-test-tags)
+- actual_fixed${/}fix_tags.robot:
+    6 x TAG06 (tag-already-set-in-test-tags)
+
+Found 8 issues (8 fixed, 0 remaining).

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_fixed/fix_default_tags.robot
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_fixed/fix_default_tags.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Default Tags    default
+Force Tags    common
+
+
+*** Test Cases ***
+Only Redundant Tag
+    [Tags]    NONE
+    Step
+
+Redundant And Own Tags
+    [Tags]    own
+    Step

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_fixed/fix_tags.robot
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_fixed/fix_tags.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Force Tags    common    shared
+
+
+*** Test Cases ***
+Only Redundant Tag
+    Step
+
+Redundant And Own Tags
+    [Tags]    own
+    Step
+
+Redundant Tag With Comment
+    [Tags]    own    # comment
+    Step
+
+Only Redundant Tag With Comment
+    # comment
+    Step
+
+Multiline Tags
+    [Tags]    own
+    ...    own2
+    Step
+
+No Redundant Tags
+    [Tags]    own
+    Step

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_output.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_output.txt
@@ -1,3 +1,4 @@
 test.robot:9:13 [I] TAG06 Tag 'sometag' is already set by Force Tags in suite settings
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_output_test_tags.txt
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/expected_output_test_tags.txt
@@ -1,3 +1,4 @@
 test_tags.robot:9:13 [I] TAG06 Tag 'sometag' is already set by Test Tags in suite settings
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/fix_default_tags.robot
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/fix_default_tags.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Default Tags    default
+Force Tags    common
+
+
+*** Test Cases ***
+Only Redundant Tag
+    [Tags]    common
+    Step
+
+Redundant And Own Tags
+    [Tags]    common    own
+    Step

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/fix_tags.robot
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/fix_tags.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Force Tags    common    shared
+
+
+*** Test Cases ***
+Only Redundant Tag
+    [Tags]    common
+    Step
+
+Redundant And Own Tags
+    [Tags]    common    own
+    Step
+
+Redundant Tag With Comment
+    [Tags]    own    common    # comment
+    Step
+
+Only Redundant Tag With Comment
+    [Tags]    common    # comment
+    Step
+
+Multiline Tags
+    [Tags]    own
+    ...    common
+    ...    shared    own2
+    Step
+
+No Redundant Tags
+    [Tags]    own
+    Step

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/test_rule.py
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/test_rule.py
@@ -17,3 +17,6 @@ class TestRuleAcceptance(RuleAcceptance):
             output_format="extended",
             test_on_version=">=6",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["fix_tags.robot", "fix_default_tags.robot"])


### PR DESCRIPTION
Implement fixes for the three rules reporting a redundant tag:

- `TAG06` `tag-already-set-in-test-tags` (`ALWAYS`)
- `TAG09` `duplicated-tags` (`SOMETIMES`)
- `TAG11` `tag-already-set-in-keyword-tags` (`ALWAYS`)

All three share a new `remove_tag_fix` helper that removes the reported tag together with its preceding separator.

### Behaviour

- If the removed tag was the only tag in the `[Tags]` setting, the whole setting is removed instead.
- Unless the suite defines `Default Tags` - removing `[Tags]` would then apply the default tags to the test,
  so the explicit `NONE` value is used to keep the resulting tags identical.
- If the tag was the only data in a continuation (`...`) line, the line is removed as well.
- Comments are never removed.
- Tags listed in the keyword `[Documentation]` (`Tags: a, b`) are plain text, so `duplicated-tags` does not fix
  them - hence `SOMETIMES`.

The fix replaces the whole statement, so only one tag is removed per run; the remaining ones are reported and
removed in the following runs of the fix loop.

Part of #1631.