### PR TITLE
feat: add fixes for the empty-variable and undefined-argument-default rules

### DIFF
--- a/src/robocop/linter/rules/arguments.py
+++ b/src/robocop/linter/rules/arguments.py
@@ -67,7 +67,7 @@ class ArgumentOverwrittenBeforeUsageRule(Rule):
     deprecated_names = ("0921",)
 
 
-class UndefinedArgumentDefaultRule(Rule):
+class UndefinedArgumentDefaultRule(FixableRule):
     """
     Keyword arguments can define a default value. Every time you call the keyword, you can
     optionally overwrite this default.
@@ -84,6 +84,8 @@ class UndefinedArgumentDefaultRule(Rule):
         My Amazing Keyword
             [Arguments]    ${argument_name}=
 
+    The fix adds the explicit ``${EMPTY}`` default value.
+
     """
 
     name = "undefined-argument-default"
@@ -95,6 +97,7 @@ class UndefinedArgumentDefaultRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0932",)
+    fix_availability = FixAvailability.ALWAYS
 
     def check(self, node: Arguments) -> None:
         if not self.enabled:
@@ -112,6 +115,25 @@ class UndefinedArgumentDefaultRule(Rule):
                     end_col=token.col_offset + len(token.value) + 1,
                     arg_name=arg_name,
                 )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        """Add the explicit ``${EMPTY}`` default value after the ``=`` sign."""
+        column = diag.range.end.character
+        edit = TextEdit(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            start_line=diag.range.start.line,
+            start_col=column,
+            end_line=diag.range.start.line,
+            end_col=column,
+            replacement="${EMPTY}",
+        )
+        arg_name = diag.reported_arguments["arg_name"]
+        return Fix(
+            edits=[edit],
+            message=f"Add the explicit ${{EMPTY}} default value to the '{arg_name}' argument",
+            applicability=FixApplicability.SAFE,
+        )
 
 
 class UndefinedArgumentValueRule(Rule):

--- a/src/robocop/linter/rules/variables.py
+++ b/src/robocop/linter/rules/variables.py
@@ -5,13 +5,18 @@ from typing import TYPE_CHECKING
 from robot.api import Token
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleParam, RuleSeverity
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, Rule, RuleParam, RuleSeverity
 from robocop.linter.utils import misc as utils
 from robocop.version_handling import TYPE_SUPPORTED
 
 if TYPE_CHECKING:
-    from robot.parsing.model.statements import Node, Var, Variable
+    from robot.parsing.model.statements import Node, Statement, Var, Variable
     from robot.variables.search import SearchResult
+
+    from robocop.linter.diagnostics import Diagnostic
+
+EMPTY_VALUE_SEPARATOR = "    "
 
 RESERVED_VARIABLES = {
     "testname": "${TEST_NAME}",
@@ -56,7 +61,7 @@ def report_non_local_scope(rule: Rule, node: Node) -> None:
     )
 
 
-class EmptyVariableRule(Rule):
+class EmptyVariableRule(FixableRule):
     r"""
     Variable without value.
 
@@ -98,6 +103,10 @@ class EmptyVariableRule(Rule):
     You can configure ``empty-variable`` rule to run only in ```*** Variables ***``` section or on
     ``VAR`` statements using ``variable_source`` parameter.
 
+    The fix adds the explicit empty value, using the variable type to select it: ``${EMPTY}`` for scalars,
+    ``@{EMPTY}`` for lists and ``&{EMPTY}`` for dictionaries. Empty values in a list and the ``\`` values are
+    always replaced with ``${EMPTY}``.
+
     """
 
     name = "empty-variable"
@@ -118,6 +127,7 @@ class EmptyVariableRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0912",)
+    fix_availability = FixAvailability.ALWAYS
 
     def check_variable(self, node: Variable) -> None:
         """Check variable defined in the ``*** Variables ***`` section."""
@@ -127,7 +137,7 @@ class EmptyVariableRule(Rule):
             self.report(node=node, end_col=node.end_col_offset)
         for token in node.get_tokens(Token.ARGUMENT):
             if not token.value or token.value == "\\":
-                self.report(node=token, lineno=token.lineno, col=1, end_col=token.end_col_offset + 1)
+                self.report(node=node, lineno=token.lineno, col=1, end_col=token.end_col_offset + 1)
 
     def check_var(self, node: Var) -> None:
         """Check variable defined with the ``VAR`` syntax."""
@@ -136,18 +146,64 @@ class EmptyVariableRule(Rule):
         if not node.value:  # catch variable declaration without any value
             first_data = node.data_tokens[0]
             self.report(
-                node=first_data,
+                node=node,
                 col=first_data.col_offset + 1,
                 end_col=first_data.end_col_offset + 1,
             )
         for token in node.get_tokens(Token.ARGUMENT):
             if not token.value or token.value == "\\":
                 self.report(
-                    node=token,
+                    node=node,
                     lineno=token.lineno,
                     col=token.col_offset + 1,
                     end_col=token.end_col_offset + 1,
                 )
+
+    @staticmethod
+    def _find_empty_value(node: Statement, diag: Diagnostic) -> Token | None:
+        """Find the empty argument token reported by the diagnostic using its end position."""
+        return next(
+            (
+                token
+                for token in node.get_tokens(Token.ARGUMENT)
+                if (not token.value or token.value == "\\")
+                and token.lineno == diag.range.start.line
+                and token.end_col_offset + 1 == diag.range.end.character
+            ),
+            None,
+        )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        """Replace the empty value with the explicit ``${EMPTY}`` variable."""
+        node = diag.node
+        if node is None:
+            return None
+        empty_value = self._find_empty_value(node, diag)
+        if empty_value is not None:
+            # empty values are zero-width tokens and require the separator, the backslash is replaced in place
+            start_col = empty_value.col_offset + 1
+            end_col = empty_value.end_col_offset + 1
+            separator = "" if empty_value.value else EMPTY_VALUE_SEPARATOR
+            replacement = f"{separator}${{EMPTY}}"
+            message = "Replace the empty value with ${EMPTY}"
+        else:
+            name = node.get_token(Token.VARIABLE)
+            if name is None or not name.value:
+                return None
+            start_col = end_col = name.end_col_offset + 1
+            replacement = f"{EMPTY_VALUE_SEPARATOR}{name.value[0]}{{EMPTY}}"
+            message = f"Add the explicit {name.value[0]}{{EMPTY}} value"
+            empty_value = name
+        edit = TextEdit(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            start_line=empty_value.lineno,
+            start_col=start_col,
+            end_line=empty_value.lineno,
+            end_col=end_col,
+            replacement=replacement,
+        )
+        return Fix(edits=[edit], message=message, applicability=FixApplicability.SAFE)
 
 
 class UnusedVariableRule(Rule):

--- a/tests/linter/rules/arguments/undefined_argument_default/expected_extended.txt
+++ b/tests/linter/rules/arguments/undefined_argument_default/expected_extended.txt
@@ -45,3 +45,4 @@ test.robot:35:27 ARG03 Undefined argument default, use ${bar}=${EMPTY} instead
     |
 
 Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/arguments/undefined_argument_default/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/arguments/undefined_argument_default/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 5 issues:
+- actual_fixed${/}test.robot:
+    5 x ARG03 (undefined-argument-default)
+
+Found 5 issues (5 fixed, 0 remaining).

--- a/tests/linter/rules/arguments/undefined_argument_default/expected_fixed/test.robot
+++ b/tests/linter/rules/arguments/undefined_argument_default/expected_fixed/test.robot
@@ -1,0 +1,36 @@
+*** Keywords ***
+Keyword with undefined arg
+    [Arguments]    ${foo}    ${bar}=${EMPTY}    ${baz}=123
+    No Operation
+
+Keyword with undefined arg multiline
+    [Arguments]
+    ...  ${foo}
+    ...  ${bar}=123
+    ...  ${baz}=${EMPTY}
+    ...  ${lorum}=${ipsum}
+    No Operation
+
+Keyword with valid defined defaults
+    [Arguments]    ${foo}=something}=    ${bar}=hello}=world    ${ba=z}= 123
+    No Operation
+
+Keyword with valid empty defaults
+    [Arguments]    ${foo}=${EMPTY}    ${bar}=@{EMPTY}    ${ba=z}=&{EMPTY}
+    No Operation
+
+Keyword with multiple violations in one line
+    [Arguments]    ${arg}=${EMPTY}    ${arg2}=${EMPTY}
+    No Operation
+
+Keyword with invalid syntax
+    [Arguments]    ${arg
+    No Operation
+
+Keyword with invalid syntax including equal sign
+    [Arguments]    ${arg=
+    No Operation
+
+Keyword with named-only arguments
+    [Arguments]    @{}    ${bar}=${EMPTY}    ${foo}=${None}
+    No Operation

--- a/tests/linter/rules/arguments/undefined_argument_default/expected_output.txt
+++ b/tests/linter/rules/arguments/undefined_argument_default/expected_output.txt
@@ -5,3 +5,4 @@ test.robot:23:31 [E] ARG03 Undefined argument default, use ${arg2}=${EMPTY} inst
 test.robot:35:27 [E] ARG03 Undefined argument default, use ${bar}=${EMPTY} instead
 
 Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/arguments/undefined_argument_default/test_rule.py
+++ b/tests/linter/rules/arguments/undefined_argument_default/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/variables/empty_variable/expected_extended.txt
+++ b/tests/linter/rules/variables/empty_variable/expected_extended.txt
@@ -179,3 +179,4 @@ test.robot:62:8 VAR01 Empty variable value
     |
 
 Found 18 issues.
+18 fixable with the '--fix' option.

--- a/tests/linter/rules/variables/empty_variable/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/variables/empty_variable/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 18 issues:
+- actual_fixed${/}test.robot:
+    18 x VAR01 (empty-variable)
+
+Found 18 issues (18 fixed, 0 remaining).

--- a/tests/linter/rules/variables/empty_variable/expected_fixed/test.robot
+++ b/tests/linter/rules/variables/empty_variable/expected_fixed/test.robot
@@ -1,0 +1,65 @@
+*** Variables ***
+{VAR_WITH_NO_TYPE}
+${VAR_NO_VALUE}    ${EMPTY}
+@{LIST_NO_VALUE}    @{EMPTY}
+&{DICT_NO_VALUE}    &{EMPTY}
+@{LIST_NO_VALUE}
+...    ${EMPTY}
+&{DICT_NO_VALUE}
+...
+${VAR_WITH_EMPTY}       ${EMPTY}
+@{VAR_WITH_EMPTY}       @{EMPTY}
+&{VAR_WITH_EMPTY}       &{EMPTY}
+${VAR_WITH_VALUE}       Value
+${VAR_WITH_INT}         ${1}
+${VAR_WIH_STR}          1
+${VAR_WITH_LIST}        one     two     three
+${MULTILINE_WITH_EMPTY}
+...    ${EMPTY}
+${MULTILINE_NO_VALUE}
+...    ${EMPTY}
+@{MULTILINE_EMPTY_WITH_COMMENT}   value
+...    ${EMPTY}    # I think it should be just empty line, without value - but I'm not sure
+...    ${EMPTY}
+@{MULTILINE_FIRST_EMPTY}
+...    ${EMPTY}
+...  value
+@{MULTILINE_WITH_MULTIPLE_EMPTIES}
+...  1
+...  2
+...    ${EMPTY}
+...  a
+...  b
+...    ${EMPTY}
+...  3
+${EMPTY_WITH_BACKSLASH}  ${EMPTY}
+@{MULTILINE_EMPTY_WITH_BACKSLASH}  ${EMPTY}
+...  ${EMPTY}
+@{MIXED_EMPTY}  ${EMPTY}
+...    ${EMPTY}
+...  ${EMPTY}
+...  @{EMPTY}
+
+... invalid
+{also_invalid}  2
+...
+
+
+*** Keywords ***
+VAR Syntax
+    VAR    ${variable}    value
+    VAR    ${variable}    ${EMPTY}
+    IF    ${variable}
+        VAR    @{variable}    @{EMPTY}
+        VAR    &{variable}    &{EMPTY}    scope=GLOBAL
+    END
+    VAR    $variable  # error
+    VAR
+    # VAR FIXME - uncomment after RF fix error (reported at https://github.com/robotframework/robotframework/issues/4995)
+    # ...
+    VAR    @{list}
+    ...    value
+    ...    ${EMPTY}
+    ...    scope=SUITE
+    VAR
+    ...    scope=local

--- a/tests/linter/rules/variables/empty_variable/expected_output.txt
+++ b/tests/linter/rules/variables/empty_variable/expected_output.txt
@@ -18,3 +18,4 @@ test.robot:54:9 [I] VAR01 Empty variable value
 test.robot:62:8 [I] VAR01 Empty variable value
 
 Found 18 issues.
+18 fixable with the '--fix' option.

--- a/tests/linter/rules/variables/empty_variable/expected_output_pre_var.txt
+++ b/tests/linter/rules/variables/empty_variable/expected_output_pre_var.txt
@@ -14,3 +14,4 @@ test.robot:38:1 [I] VAR01 Empty variable value
 test.robot:39:1 [I] VAR01 Empty variable value
 
 Found 14 issues.
+14 fixable with the '--fix' option.

--- a/tests/linter/rules/variables/empty_variable/expected_output_var.txt
+++ b/tests/linter/rules/variables/empty_variable/expected_output_var.txt
@@ -4,3 +4,4 @@ test.robot:54:9 [I] VAR01 Empty variable value
 test.robot:62:8 [I] VAR01 Empty variable value
 
 Found 4 issues.
+4 fixable with the '--fix' option.

--- a/tests/linter/rules/variables/empty_variable/test_rule.py
+++ b/tests/linter/rules/variables/empty_variable/test_rule.py
@@ -31,3 +31,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_rule_pre_var(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_var.txt", test_on_version="<7")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"], test_on_version=">=7")


### PR DESCRIPTION
Implement fixes for two rules that ask for an explicit empty value:

- `VAR01` `empty-variable` (`ALWAYS`)
- `ARG03` `undefined-argument-default` (`ALWAYS`)

### `empty-variable`

The added value depends on the variable type, so that the fix works for all of them:

```robotframework
*** Variables ***
${SCALAR}                 # -> ${SCALAR}    ${EMPTY}
@{LIST}                   # -> @{LIST}    @{EMPTY}
&{DICT}                   # -> &{DICT}    &{EMPTY}
@{LIST_WITH_EMPTY}
...                       # -> ...    ${EMPTY}
...    value
${BACKSLASH}    \         # -> ${BACKSLASH}    ${EMPTY}
```

Empty values *inside* a list and the `\` values are always replaced with `${EMPTY}`, since they are single
elements. `VAR` statements are handled the same way:

```robotframework
VAR    @{variable}                  # -> VAR    @{variable}    @{EMPTY}
VAR    &{variable}    scope=GLOBAL  # -> VAR    &{variable}    &{EMPTY}    scope=GLOBAL
```

### `undefined-argument-default`

`${bar}=` becomes `${bar}=${EMPTY}`. Multiple violations in a single `[Arguments]` line are all fixed in one run.

The `empty-variable` fix covers everything the `ReplaceEmptyValues` formatter does (and additionally the `VAR`
syntax), so the formatter can be removed - in a separate PR.

Part of #1631.