### PR TITLE
feat(linter): add fixes for malformed separators

### DIFF
--- a/src/robocop/linter/checkers/errors.py
+++ b/src/robocop/linter/checkers/errors.py
@@ -98,7 +98,13 @@ class ParsingErrorChecker(VisitorChecker):
     def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
         if node.keyword and node.keyword.startswith("..."):
             col = node.data_tokens[0].col_offset + 1
-            self.report(self.not_enough_whitespace_after_newline_marker, node=node, col=col, end_col=col + 3)
+            self.report(
+                self.not_enough_whitespace_after_newline_marker,
+                name_end_col=col + 3,
+                node=node,
+                col=col,
+                end_col=col + 3,
+            )
         self.generic_visit(node)
 
     def visit_Statement(self, node: Statement) -> None:  # noqa: N802
@@ -254,6 +260,7 @@ class ParsingErrorChecker(VisitorChecker):
                         self.report(
                             self.not_enough_whitespace_after_suite_setting,
                             setting_name=self.suite_settings[setting],
+                            name_end_col=self.get_setting_name_end_col(token.value, setting, token.col_offset),
                             node=token,
                             end_col=token.end_col_offset + 1,
                         )
@@ -283,6 +290,7 @@ class ParsingErrorChecker(VisitorChecker):
                 self.report(
                     self.not_enough_whitespace_after_variable,
                     variable_name=variable_token.value,
+                    name_end_col=variable_token.col_offset + variables[0][1] + 1,
                     node=variable_token,
                     col=variable_token.col_offset + 1,
                     end_col=variable_token.end_col_offset + 1,
@@ -306,10 +314,22 @@ class ParsingErrorChecker(VisitorChecker):
                 col = name.find(".") + 1
                 self.report(
                     self.not_enough_whitespace_after_newline_marker,
+                    name_end_col=col + 3,
                     node=node,
                     col=col,
                     end_col=col + 3,
                 )
+
+    @staticmethod
+    def get_setting_name_end_col(value: str, normalized_setting: str, col_offset: int) -> int:
+        """Return the first column after a setting name, accounting for internal spaces."""
+        remaining = len(normalized_setting)
+        for index, char in enumerate(value):
+            if not char.isspace():
+                remaining -= 1
+                if remaining == 0:
+                    return col_offset + index + 2
+        return col_offset + len(value) + 1
 
     def handle_unsupported_settings_in_init_file(self, node: Node) -> None:
         if ROBOT_VERSION.major < 6 and "__init__" not in self.source_file.path.name:

--- a/src/robocop/linter/rules/whitespace.py
+++ b/src/robocop/linter/rules/whitespace.py
@@ -11,13 +11,46 @@ import re
 from typing import TYPE_CHECKING, ClassVar
 
 from robocop.linter import sonar_qube
-from robocop.linter.rules import Rule, RuleSeverity
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.rules import FixableRule, RuleSeverity
 
 if TYPE_CHECKING:
     from robot.parsing.model.statements import KeywordCall
 
+    from robocop.linter.diagnostics import Diagnostic
 
-class NotEnoughWhitespaceAfterSettingRule(Rule):
+
+def expand_separator_fix(rule: FixableRule, diag: Diagnostic, source_lines: list[str]) -> Fix:
+    """Replace a malformed separator after a name with the standard four spaces."""
+    separator_col = diag.reported_arguments["name_end_col"]
+    if not isinstance(separator_col, int):
+        msg = f"Expected integer name_end_col, got {type(separator_col).__name__}"
+        raise TypeError(msg)
+    line = source_lines[diag.range.start.line - 1]
+    separator_end_col = separator_col + 1 if line[separator_col - 1 : separator_col] in {" ", "\t"} else separator_col
+    start_col = separator_col
+    replacement = "    "
+    canonical_name = diag.reported_arguments.get("setting_name")
+    current_name = line[diag.range.start.character - 1 : separator_col - 1]
+    if (
+        isinstance(canonical_name, str)
+        and re.sub(r"\s", "", current_name).casefold() == re.sub(r"\s", "", canonical_name).casefold()
+    ):
+        start_col = diag.range.start.character
+        replacement = f"{canonical_name}    "
+    edit = TextEdit(
+        rule_id=rule.rule_id,
+        rule_name=rule.name,
+        start_line=diag.range.start.line,
+        start_col=start_col,
+        end_line=diag.range.start.line,
+        end_col=separator_end_col,
+        replacement=replacement,
+    )
+    return Fix(edits=[edit], message="Expand separator to four spaces", applicability=FixApplicability.SAFE)
+
+
+class NotEnoughWhitespaceAfterSettingRule(FixableRule):
     """
     Not enough whitespace after setting.
 
@@ -49,6 +82,8 @@ class NotEnoughWhitespaceAfterSettingRule(Rule):
             [Arguments]    ${var}
             Should Be True  ${var}
 
+    The separator can be expanded automatically with the ``--fix`` option.
+
     """
 
     name = "not-enough-whitespace-after-setting"
@@ -56,6 +91,7 @@ class NotEnoughWhitespaceAfterSettingRule(Rule):
     message = "Not enough whitespace after '{setting_name}' setting"
     severity = RuleSeverity.ERROR
     added_in_version = "1.0.0"
+    fix_availability = FixAvailability.ALWAYS
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
@@ -82,13 +118,17 @@ class NotEnoughWhitespaceAfterSettingRule(Rule):
         if match.group(1).lower() in self.headers:
             self.report(
                 setting_name=match.group(0),
+                name_end_col=node.data_tokens[0].col_offset + match.end() + 1,
                 node=node,
                 col=node.data_tokens[0].col_offset + 1,
                 end_col=node.data_tokens[0].end_col_offset + 1,
             )
 
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        return expand_separator_fix(self, diag, source_lines)
 
-class NotEnoughWhitespaceAfterNewlineMarkerRule(Rule):
+
+class NotEnoughWhitespaceAfterNewlineMarkerRule(FixableRule):
     """
     Not enough whitespace after a newline marker.
 
@@ -108,6 +148,8 @@ class NotEnoughWhitespaceAfterNewlineMarkerRule(Rule):
         ...  2
         ...  3
 
+    The separator can be expanded automatically with the ``--fix`` option.
+
     """
 
     name = "not-enough-whitespace-after-newline-marker"
@@ -115,13 +157,17 @@ class NotEnoughWhitespaceAfterNewlineMarkerRule(Rule):
     message = "Not enough whitespace after '...' marker"
     severity = RuleSeverity.ERROR
     added_in_version = "1.11.0"
+    fix_availability = FixAvailability.ALWAYS
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("0406",)
 
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        return expand_separator_fix(self, diag, source_lines)
 
-class NotEnoughWhitespaceAfterVariableRule(Rule):
+
+class NotEnoughWhitespaceAfterVariableRule(FixableRule):
     """
     Not enough whitespace after variable.
 
@@ -139,6 +185,8 @@ class NotEnoughWhitespaceAfterVariableRule(Rule):
         ${variable}  1
         ${other_var}  2
 
+    The separator can be expanded automatically with the ``--fix`` option.
+
     """
 
     name = "not-enough-whitespace-after-variable"
@@ -147,13 +195,17 @@ class NotEnoughWhitespaceAfterVariableRule(Rule):
     severity = RuleSeverity.ERROR
     version = ">=4.0"
     added_in_version = "1.11.0"
+    fix_availability = FixAvailability.ALWAYS
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("0410",)
 
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        return expand_separator_fix(self, diag, source_lines)
 
-class NotEnoughWhitespaceAfterSuiteSettingRule(Rule):
+
+class NotEnoughWhitespaceAfterSuiteSettingRule(FixableRule):
     """
     Not enough whitespace after suite setting.
 
@@ -175,6 +227,8 @@ class NotEnoughWhitespaceAfterSuiteSettingRule(Rule):
         ...  tag2
         Suite Setup    Keyword
 
+    The separator can be expanded automatically with the ``--fix`` option.
+
     """
 
     name = "not-enough-whitespace-after-suite-setting"
@@ -182,7 +236,11 @@ class NotEnoughWhitespaceAfterSuiteSettingRule(Rule):
     message = "Not enough whitespace after '{setting_name}' setting"
     severity = RuleSeverity.ERROR
     added_in_version = "1.11.0"
+    fix_availability = FixAvailability.ALWAYS
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.COMPLETE, issue_type=sonar_qube.SonarQubeIssueType.BUG
     )
     deprecated_names = ("0411",)
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        return expand_separator_fix(self, diag, source_lines)

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_extended.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_extended.txt
@@ -43,3 +43,4 @@ variable_errors.robot:13:1 SPC20 Not enough whitespace after '...' marker
     |
 
 Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/expected_output.txt
@@ -1,0 +1,9 @@
+Fixed 5 issues:
+- actual_fixed${/}settings_errors.robot:
+    1 x SPC20 (not-enough-whitespace-after-newline-marker)
+- actual_fixed${/}test.robot:
+    2 x SPC20 (not-enough-whitespace-after-newline-marker)
+- actual_fixed${/}variable_errors.robot:
+    2 x SPC20 (not-enough-whitespace-after-newline-marker)
+
+Found 5 issues (5 fixed, 0 remaining).

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/settings_errors.robot
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/settings_errors.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Default Tags  tag
+...    tag2
+
+Force Tags  tag
+..    tag2

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/test.robot
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/test.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More  ${var}
+    ...    ${var2}
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    ...    and new line
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/variable_errors.robot
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_fixed/variable_errors.robot
@@ -1,0 +1,18 @@
+*** Variables ***
+${var}
+...    val
+ .... val
+value
+
+&{dict}    1
+
+@{variable}    a
+...    b
+....   c
+...
+...    d
+
+*** Keywords ***
+    [Arguments]     1
+    value    My Keyword
+    My Keyword     ${var}    ${value}

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/expected_output.txt
@@ -5,3 +5,4 @@ variable_errors.robot:3:1 [E] SPC20 Not enough whitespace after '...' marker
 variable_errors.robot:13:1 [E] SPC20 Not enough whitespace after '...' marker
 
 Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/test_rule.py
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_newline_marker/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "settings_errors.robot", "variable_errors.robot"])

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_extended.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_extended.txt
@@ -19,3 +19,4 @@ test.robot:20:5 SPC19 Not enough whitespace after '[Arguments]' setting
     |
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 2 issues:
+- actual_fixed${/}test.robot:
+    2 x SPC19 (not-enough-whitespace-after-setting)
+
+Found 2 issues (2 fixed, 0 remaining).

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_fixed/test.robot
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_fixed/test.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]    doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+Test without keyword
+    ${a}    ${b}    # no Keyword here!!!
+
+
+*** Keywords ***
+Keyword
+    [Documentation]  this is doc
+    [Arguments]    ${var}
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Invalid Documentation
+    [Doc Umentation]

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/expected_output.txt
@@ -2,3 +2,4 @@ test.robot:7:5 [E] SPC19 Not enough whitespace after '[Documentation]' setting
 test.robot:20:5 [E] SPC19 Not enough whitespace after '[Arguments]' setting
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/test_rule.py
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_setting/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_extended.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_extended.txt
@@ -99,3 +99,4 @@ test.robot:21:1 SPC22 Not enough whitespace after 'Metadata' setting
     |
 
 Found 12 issues.
+12 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 12 issues:
+- actual_fixed${/}test.robot:
+    12 x SPC22 (not-enough-whitespace-after-suite-setting)
+
+Found 12 issues (12 fixed, 0 remaining).

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_fixed/test.robot
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_fixed/test.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Library    Collections
+Resource    file.robot
+Variables    vars.yaml
+
+Force Tags    tag
+...    tag2
+Default Tags    tag1    tag2
+
+Invalid  ${argument}
+
+Timeout 1min
+Suite Setup    Keyword
+Suite Teardown    Keyword2
+
+Test Setup    Keyword
+Test Teardown    Keyword2
+Test Timeout    1min
+Documentation    this is doc
+
+Metadata    key value
+
+*** Keywords ***
+Keyword With Invalid Setting
+    [Doc Umentation]

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/expected_output.txt
@@ -12,3 +12,4 @@ test.robot:19:1 [E] SPC22 Not enough whitespace after 'Documentation' setting
 test.robot:21:1 [E] SPC22 Not enough whitespace after 'Metadata' setting
 
 Found 12 issues.
+12 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/test_rule.py
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_suite_setting/test_rule.py
@@ -7,3 +7,6 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_extended.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_extended.txt
@@ -15,3 +15,4 @@ test.robot:7:1 SPC21 Not enough whitespace after '@{LIST} value' variable name
    |
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 2 issues:
+- actual_fixed${/}test.robot:
+    2 x SPC21 (not-enough-whitespace-after-variable)
+
+Found 2 issues (2 fixed, 0 remaining).

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_fixed/test.robot
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_fixed/test.robot
@@ -1,0 +1,8 @@
+*** Variables ***
+${VAR}    1
+ ${VAR}  1
+  ${VAR}  1
+VALUE  1
+
+@{LIST}    value
+...  value2

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_output.txt
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/expected_output.txt
@@ -2,3 +2,4 @@ test.robot:2:1 [E] SPC21 Not enough whitespace after '${VAR} 1' variable name
 test.robot:7:1 [E] SPC21 Not enough whitespace after '@{LIST} value' variable name
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/test_rule.py
+++ b/tests/linter/rules/whitespace/not_enough_whitespace_after_variable/test_rule.py
@@ -12,3 +12,6 @@ class TestRuleAcceptance(RuleAcceptance):
             output_format="extended",
             test_on_version=">=4",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"], test_on_version=">=4")


### PR DESCRIPTION
## Summary
- add safe `--fix` support for SPC19–SPC22
- expand missing or one-character separators to four spaces
- canonicalize merged suite setting names when required for Robot Framework to parse the fixed line
- add acceptance coverage and fixed-output fixtures for all four rules

## Validation
- `uv run pytest tests\linter\rules\whitespace`
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy --config-file=pyproject.toml src\robocop\linter\rules\whitespace.py src\robocop\linter\checkers\errors.py`