### PR TITLE
fix: resolve strict mypy baseline

### DIFF
--- a/src/robocop/config/manager.py
+++ b/src/robocop/config/manager.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pathspec
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from robocop import exceptions, files
 from robocop.cache import RobocopCache
@@ -17,14 +18,15 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
 CONFIG_NAMES = ("robocop.toml", "robot.toml", "pyproject.toml")
+GitIgnorePathSpec = pathspec.PathSpec[GitWildMatchPattern]
 
 
 class GitIgnoreResolver:
     def __init__(self) -> None:
-        self.cached_ignores: dict[Path, tuple[Path, pathspec.PathSpec]] = {}
+        self.cached_ignores: dict[Path, tuple[Path, GitIgnorePathSpec]] = {}
         self.ignore_dirs: set[Path] = set()
 
-    def path_excluded(self, path: Path, gitignores: list[tuple[Path, pathspec.PathSpec]]) -> bool:
+    def path_excluded(self, path: Path, gitignores: list[tuple[Path, GitIgnorePathSpec]]) -> bool:
         """Find path gitignores and check if file is excluded."""
         if not gitignores:
             return False
@@ -38,13 +40,13 @@ class GitIgnoreResolver:
                 return True
         return False
 
-    def read_gitignore(self, path: Path) -> pathspec.PathSpec:
+    def read_gitignore(self, path: Path) -> GitIgnorePathSpec:
         """Return a PathSpec loaded from the file."""
         with path.open(encoding="utf-8") as gf:
             lines = gf.readlines()
-        return pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, lines)  # type: ignore[attr-defined]
+        return pathspec.PathSpec.from_lines(GitWildMatchPattern, lines)
 
-    def resolve_path_ignores(self, path: Path) -> list[tuple[Path, pathspec.PathSpec]]:
+    def resolve_path_ignores(self, path: Path) -> list[tuple[Path, GitIgnorePathSpec]]:
         """
         Visit all parent directories and find all gitignores.
 
@@ -60,7 +62,7 @@ class GitIgnoreResolver:
         # TODO: respect nogitignore flag
         if path.is_file():
             path = path.parent
-        gitignores: list[tuple[Path, pathspec.PathSpec]] = []
+        gitignores: list[tuple[Path, GitIgnorePathSpec]] = []
         search_paths = (parent for parent in [path, *path.parents])
         for parent_path in search_paths:
             if parent_path in self.ignore_dirs:  # dir that does not have .gitignore (marked as such)

--- a/src/robocop/formatter/formatters/OrderSettingsSection.py
+++ b/src/robocop/formatter/formatters/OrderSettingsSection.py
@@ -148,8 +148,9 @@ class OrderSettingsSection(Formatter):
     def visit_SettingSection(self, node: SettingSection) -> SettingSection | None:  # noqa: N802
         if not node.body:
             return None
-        if node is self.last_section and not isinstance(node.body[-1], EmptyLine):
-            node.body[-1] = self.fix_eol(node.body[-1])
+        last_section = self.last_section
+        if last_section is not None and node is last_section and not isinstance(last_section.body[-1], EmptyLine):
+            last_section.body[-1] = self.fix_eol(last_section.body[-1])
         comments: list[Comment] = []
         errors: list[Statement] = []
         groups: dict[str, list[tuple[list[Comment], Statement]]] = defaultdict(list)
@@ -206,7 +207,7 @@ class OrderSettingsSection(Formatter):
             new_body.extend([empty_line] * self.new_lines_between_groups)
             new_body.extend(errors)
         new_body.extend(comments)
-        if node is not self.last_section:
+        if node is not last_section:
             new_body.append(empty_line)
         node.body = new_body
         return node


### PR DESCRIPTION
## Summary

- parameterize all five `pathspec.PathSpec` annotations with the concrete `GitWildMatchPattern` type
- replace the stale `pathspec.patterns` attribute suppression with the library's typed direct import
- explicitly narrow `OrderSettingsSection.last_section` before accessing its body, preserving existing formatting behavior

## Baseline errors resolved

- 5 × `[type-arg]` in `src/robocop/config/manager.py` caused by pathspec 1.1 making `PathSpec` generic
- 2 × `[union-attr]` in `src/robocop/formatter/formatters/OrderSettingsSection.py` caused by the optional cached last section being accessed without an explicit non-`None` narrowing

No mypy configuration ignores, `Any`, or casts were added. The existing `# type: ignore[attr-defined]` around the pathspec pattern lookup was removed because the direct typed import expresses the dependency safely.

## Validation

- `uv run mypy --config-file=pyproject.toml .\src\robocop\`
- `uv run pytest tests\config\test_config_manager.py tests\formatter\formatters\OrderSettingsSection\test_formatter.py`
- `uv run ruff check`
- `uv run ruff format --check`