### PR TITLE
feat(formatter)!: use concise alignment padding

### DIFF
--- a/src/robocop/formatter/formatters/AlignSettingsSection.py
+++ b/src/robocop/formatter/formatters/AlignSettingsSection.py
@@ -154,12 +154,12 @@ class AlignSettingsSection(Formatter):
             if indent_arg and index != 0:
                 return (
                     max(
-                        (look_up[index] - len(token.value) - arg_indent + 4),
+                        (look_up[index] - len(token.value) - arg_indent + self.formatting_config.space_count),
                         self.formatting_config.space_count,
                     )
                     * " "
                 )
-            return (look_up[index] - len(token.value) + arg_indent + 4) * " "
+            return (look_up[index] - len(token.value) + arg_indent + self.formatting_config.space_count) * " "
         return self.formatting_config.space_count * " "
 
     def create_look_up(self, statements: list[list[list[Token]]]) -> dict[int, int]:
@@ -176,5 +176,8 @@ class AlignSettingsSection(Formatter):
                 for index, token in enumerate(line[:up_to]):
                     look_up[index] = max(look_up[index], len(token.value))
         if self.min_width:
-            look_up = {index: max(length, self.min_width - 4) for index, length in look_up.items()}
-        return {index: misc.round_to_four(length) for index, length in look_up.items()}
+            look_up = {
+                index: max(length, self.min_width - self.formatting_config.space_count)
+                for index, length in look_up.items()
+            }
+        return look_up

--- a/src/robocop/formatter/formatters/AlignTemplatedTestCases.py
+++ b/src/robocop/formatter/formatters/AlignTemplatedTestCases.py
@@ -180,7 +180,6 @@ class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
         self.generic_visit(node)
         if not self.header_with_cols and not self.any_one_line_test and self.widths:
             self.widths[0] = 0
-        self.widths = [misc.round_to_four(length) for length in self.widths]
 
     def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
         for statement in node.body:

--- a/src/robocop/formatter/formatters/AlignVariablesSection.py
+++ b/src/robocop/formatter/formatters/AlignVariablesSection.py
@@ -146,5 +146,5 @@ class AlignVariablesSection(Formatter):
             min_for_token = length + self.formatting_config.space_count
             if self.min_width:
                 min_for_token = max(min_for_token, self.min_width)
-            look_up[index] = misc.round_to_four(min_for_token)
+            look_up[index] = min_for_token
         return look_up

--- a/src/robocop/formatter/formatters/aligners_core.py
+++ b/src/robocop/formatter/formatters/aligners_core.py
@@ -217,9 +217,7 @@ class AlignKeywordsTestsSection(Formatter):
                         first_sep = False
                         continue
                     if width == 0:
-                        separator_len = misc.round_to_four(
-                            len(prev_token.value) + self.formatting_config.space_count  # type: ignore[union-attr]
-                        ) - len(prev_token.value)  # type: ignore[union-attr]
+                        separator_len = self.formatting_config.space_count
                     else:
                         separator_len = max(width - len(prev_token.value), self.formatting_config.space_count)  # type: ignore[union-attr]
                     token.value = " " * separator_len
@@ -408,8 +406,7 @@ class AlignKeywordsTestsSection(Formatter):
         First, empty multiline is return as it can't be aligned.
         Then comments are removed from the line - they will be added at the end of the alignment.
         Afterwards we start to align the tokens.
-        If the configured width is set to 0 it means we don't need to calculate the width of the separator - we should
-        use the length of the token with a minimal separator rounded to the closest multiply of 4.
+        If the configured width is set to 0, use the configured minimum separator width.
         Otherwise, we are calculating if a line fits in the width of the column. In case it will not fit there are
         several options (configurable via ``handle_too_long):
             - ignore_line - the whole line will be separated using fixed, minimal width of the separator
@@ -475,7 +472,7 @@ class AlignKeywordsTestsSection(Formatter):
             aligned.append(token)
             width = self.get_width(column, is_setting=is_setting)
             if width == 0:
-                separator_len = misc.round_to_four(len(token.value) + min_separator) - len(token.value)
+                separator_len = min_separator
             else:
                 separator_len = width - len(token.value) - prev_overflow_len
                 if separator_len >= min_separator:
@@ -506,7 +503,7 @@ class AlignKeywordsTestsSection(Formatter):
                                 separator_len = next_width - prev_overflow_len + min_separator
                                 prev_overflow_len = 0
                     else:  # "overflow"
-                        while misc.round_to_four(len(token.value) + min_separator) > width:
+                        while len(token.value) + min_separator > width:
                             column += 1
                             width += self.get_width(column, override_default_zero=True, is_setting=is_setting)
                         separator_len = width - len(token.value)
@@ -662,7 +659,7 @@ class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
                 if up_to and column == up_to:
                     break
                 max_width = self.get_width(column)
-                token_len = misc.round_to_four(len(token.value) + self.min_separator)
+                token_len = len(token.value) + self.min_separator
                 if max_width == 0 or token_len <= max_width:
                     raw_lens[column] = token_len
                 elif self.handle_too_long == "ignore_line":
@@ -706,7 +703,7 @@ class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
     def visit_Documentation(self, node: Documentation) -> None:  # noqa: N802
         if self.skip_documentation:
             return
-        doc_header_len = misc.round_to_four(len(node.data_tokens[0].value) + self.min_separator)
+        doc_header_len = len(node.data_tokens[0].value) + self.min_separator
         self.settings_raw_widths[0].append(doc_header_len)
 
     @skip_if_disabled

--- a/src/robocop/formatter/utils/misc.py
+++ b/src/robocop/formatter/utils/misc.py
@@ -54,13 +54,6 @@ def after_last_dot(name: str) -> str:
     return name.split(".")[-1]
 
 
-def round_to_four(number: int) -> int:
-    div = number % 4
-    if div:
-        return number + 4 - div
-    return number
-
-
 def any_non_sep(tokens: list[Token]) -> bool:
     return any(token.type not in (Token.EOL, Token.SEPARATOR, Token.EOS) for token in tokens)
 

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/align_settings_separately.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/align_settings_separately.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Keyword
-    [Arguments]     ${argument_name}
-    [Tags]          tag                 tag
-    Log     ${argument_name}
-    Perform Action And Wait     ${argument_name}
+    [Arguments]    ${argument_name}
+    [Tags]         tag                 tag
+    Log    ${argument_name}
+    Perform Action And Wait    ${argument_name}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/blocks_auto.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/blocks_auto.robot
@@ -1,31 +1,31 @@
 *** Keywords ***
 FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
-        Keyword That Goes Over Limit Of The Column              ${short}    ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column        ${short}            ${loooooooooooooooooooooooooooong}
     END
 
 Nested FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}         Keyword             ${var}
+        ${variable}        Keyword           ${var}
         Another Keyword
         FOR  ${var2}  IN  1  2  3
-            Short           1                   2
-            ${assign}       Longer Keyword
-            ...             ${multiline}        ${arg}
+            Short        1                 2
+            ${assign}    Longer Keyword
+            ...          ${multiline}      ${arg}
         END
-        Keyword That Goes Over Limit Of The Column          ${short}    ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column     ${short}            ${loooooooooooooooooooooooooooong}
     END
 
 IF
     IF    ${condition}
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE IF    $flag
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     END

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/blocks_auto_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/blocks_auto_0.robot
@@ -1,31 +1,31 @@
 *** Keywords ***
 FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}                                     Keyword     ${var}
+        ${variable}                                   Keyword     ${var}
         Another Keyword
-        Keyword That Goes Over Limit Of The Column      ${short}    ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column    ${short}    ${loooooooooooooooooooooooooooong}
     END
 
 Nested FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}                                     Keyword             ${var}
+        ${variable}                                   Keyword           ${var}
         Another Keyword
         FOR  ${var2}  IN  1  2  3
-            Short           1                   2
-            ${assign}       Longer Keyword
-            ...             ${multiline}        ${arg}
+            Short        1                 2
+            ${assign}    Longer Keyword
+            ...          ${multiline}      ${arg}
         END
-        Keyword That Goes Over Limit Of The Column      ${short}            ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column    ${short}          ${loooooooooooooooooooooooooooong}
     END
 
 IF
     IF    ${condition}
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE IF    $flag
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     END

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/documentation_auto_align_first_col.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/documentation_auto_align_first_col.robot
@@ -4,27 +4,27 @@ Documentation    Do not touch this.
 
 *** Keywords ***
 Example of alignment to second column of Documentation
-    [Documentation]     Unselects checkbox value in the data table
-    ...                 note that you must give some unique column/value pair that is used to select the row
+    [Documentation]    Unselects checkbox value in the data table
+    ...                note that you must give some unique column/value pair that is used to select the row
     ...
-    ...                 == Examples ==
-    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
-    ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
+    ...                == Examples ==
+    ...                # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Keyword with documentation and keyword calls
-    [Documentation]     Do stuff.
+    [Documentation]    Do stuff.
     Longer Keyword Call That Ends Here
 
 Keyword with documentation and keyword calls 2
-    [Documentation]         Do stuff.
-    ...                     2nd
-    Longer Keywordsss       ${arg}
+    [Documentation]      Do stuff.
+    ...                  2nd
+    Longer Keywordsss    ${arg}
 
 Keyword With Empty Documentation
     [Documentation]
 
 Keyword with documentation and other settings
-    [Documentation]     Do stuff
-    ...                 Also multiline    Extra whitespace
-    ...                 Only fix indent.
-    [Arguments]         ${arg}      ${arg2}
+    [Documentation]    Do stuff
+    ...                Also multiline    Extra whitespace
+    ...                Only fix indent.
+    [Arguments]        ${arg}    ${arg2}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/documentation_auto_skip.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/documentation_auto_skip.robot
@@ -18,7 +18,7 @@ Keyword with documentation and keyword calls
 Keyword with documentation and keyword calls 2
     [Documentation]    Do stuff.
     ...   2nd
-    Longer Keywordsss       ${arg}
+    Longer Keywordsss    ${arg}
 
 Keyword With Empty Documentation
     [Documentation]
@@ -27,4 +27,4 @@ Keyword with documentation and other settings
     [Documentation]    Do stuff
     ...                   Also multiline    Extra whitespace
     ...                       Only fix indent.
-    [Arguments]     ${arg}      ${arg2}
+    [Arguments]    ${arg}    ${arg2}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_0.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_24_0_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_24_0_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_24_24_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_24_24_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
     ${assign}    Looooooooonger Keyword Name    ${argument}
-    Short       Short       Short
+    Short     Short     Short
     Single
-    Multi       ${arg}
-    ...         ${arg}
+    Multi     ${arg}
+    ...       ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_24_40_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_line_24_40_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_0.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_24_0_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_24_0_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_24_24_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_24_24_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name    ${argument}
-    Short           Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short     Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_24_40_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_ignore_rest_24_40_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_0.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_24_0_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_24_0_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_24_24_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_24_24_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name         ${argument}
-    Short           Short       Short
+    ${assign}    Looooooooonger Keyword Name          ${argument}
+    Short        Short     Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_24_40_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_auto_overflow_24_40_24.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_line_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_line_0.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short       Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
     Single
-    Multi       ${arg}
-    ...     ${arg}
+    Multi    ${arg}
+    ...    ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi       ${arg}  # comment 4
-    ...     ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_line_24_0_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_line_24_0_24.robot
@@ -1,7 +1,7 @@
 *** Keywords ***
 Keyword
-    ${assign}               Looooooooonger Keyword Name     ${argument}
-    Short                   Short       Short
+    ${assign}               Looooooooonger Keyword Name    ${argument}
+    Short                   Short    Short
     Single
     Multi                   ${arg}
     ...                     ${arg}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_rest_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_rest_0.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short       Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
     Single
-    Multi       ${arg}
-    ...     ${arg}
+    Multi    ${arg}
+    ...    ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi       ${arg}  # comment 4
-    ...     ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_rest_24_0_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_ignore_rest_24_0_24.robot
@@ -1,7 +1,7 @@
 *** Keywords ***
 Keyword
-    ${assign}               Looooooooonger Keyword Name     ${argument}
-    Short                   Short       Short
+    ${assign}               Looooooooonger Keyword Name    ${argument}
+    Short                   Short    Short
     Single
     Multi                   ${arg}
     ...                     ${arg}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_overflow_0.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_overflow_0.robot
@@ -1,10 +1,10 @@
 *** Keywords ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short       Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
     Single
-    Multi       ${arg}
-    ...     ${arg}
+    Multi    ${arg}
+    ...    ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi       ${arg}  # comment 4
-    ...     ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_overflow_24_0_24.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/simple_fixed_overflow_24_0_24.robot
@@ -1,7 +1,7 @@
 *** Keywords ***
 Keyword
-    ${assign}               Looooooooonger Keyword Name     ${argument}
-    Short                   Short       Short
+    ${assign}               Looooooooonger Keyword Name    ${argument}
+    Short                   Short    Short
     Single
     Multi                   ${arg}
     ...                     ${arg}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_compact_overflow.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_compact_overflow.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Second Column Should Not Be Counted
     I am too long to be counted    Do not count me
-    Short       Short       Short
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_ignore_line.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_ignore_line.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Second Column Should Not Be Counted
     I am too long to be counted    Do not count me
-    Short       Short       Short
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_ignore_rest.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_ignore_rest.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Second Column Should Not Be Counted
     I am too long to be counted    Do not count me
-    Short       Short       Short
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_overflow.robot
+++ b/tests/formatter/formatters/AlignKeywordsSection/expected/too_long_token_counter_overflow.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Second Column Should Not Be Counted
-    I am too long to be counted         Do not count me
-    Short       Short       Short
+    I am too long to be counted             Do not count me
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignSettingsSection/expected/all_columns.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/all_columns.robot
@@ -1,26 +1,26 @@
 *** Settings ***
 # whole line comment that should be ignored
-Resource            ..${/}resources${/}resource.robot
-Library             SeleniumLibrary
-Library             Mylibrary.py
-Variables           variables.py
-Test Timeout        1 min
+Resource         ..${/}resources${/}resource.robot
+Library          SeleniumLibrary
+Library          Mylibrary.py
+Variables        variables.py
+Test Timeout     1 min
 
 # this should be left aligned
-Library             CustomLibrary                           WITH NAME                                                                       name
-Library             ArgsedLibrary                           ${1}                                                                            ${2}                ${3}
+Library          CustomLibrary                        WITH NAME                                                                     name
+Library          ArgsedLibrary                        ${1}                                                                          ${2}             ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation    Example using the space separated format.
+...              and this documentation is multiline
+...              where this line should go I wonder?
 
-Default Tags        default tag 1                           default tag 2                                                                   default tag 3       default tag 4       default tag 5
-Test Setup          Open Application                        App A
-Test Teardown       Close Application
+Default Tags     default tag 1                        default tag 2                                                                 default tag 3    default tag 4    default tag 5
+Test Setup       Open Application                     App A
+Test Teardown    Close Application
 
-Metadata            Version                                 2.0
-Metadata            More Info                               For more information about *Robot Framework* see http://robotframework.org
-Metadata            Executed At                             {HOST}
+Metadata         Version                              2.0
+Metadata         More Info                            For more information about *Robot Framework* see http://robotframework.org
+Metadata         Executed At                          {HOST}
 # this should be left aligned
 Test Template
 

--- a/tests/formatter/formatters/AlignSettingsSection/expected/argument_indents.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/argument_indents.robot
@@ -1,26 +1,26 @@
 *** Settings ***
 Documentation
-...                 Provides access to all Keywords needed for interaction with Toucan GUI.
-...                 For more details on what must be set to use this library, see documentation
+...               Provides access to all Keywords needed for interaction with Toucan GUI.
+...               For more details on what must be set to use this library, see documentation
 ...
-Library             String
-Library             Collections
-Library             RequestsLibrary
-Library             OperatingSystem
-Library             SensorSwitchRig
-...                     gmswRig    001
-Library             SeleniumLibrary
-...                     timeout=${TIMEOUT}
-...                     implicit_wait=${TIMEOUT}
-...                     run_on_failure=Capture Page Screenshot
-...                     screenshot_root_directory=${OUTPUT DIR}
-...                 WITH NAME    Selenium
-Resource            vertiv_parameter_unicode.robot
-Resource            vertiv_lol_sensor_rig.robot
-Variables           geist_toucan_constants.py
+Library           String
+Library           Collections
+Library           RequestsLibrary
+Library           OperatingSystem
+Library           SensorSwitchRig
+...                   gmswRig    001
+Library           SeleniumLibrary
+...                   timeout=${TIMEOUT}
+...                   implicit_wait=${TIMEOUT}
+...                   run_on_failure=Capture Page Screenshot
+...                   screenshot_root_directory=${OUTPUT DIR}
+...               WITH NAME    Selenium
+Resource          vertiv_parameter_unicode.robot
+Resource          vertiv_lol_sensor_rig.robot
+Variables         geist_toucan_constants.py
 
-Suite Setup         Start Session
-...                     host=${IPADDRESS}
-...                     user=${USERNAME}
-...                     password=${PASSWORD}
-Suite Teardown      Close Session
+Suite Setup       Start Session
+...                   host=${IPADDRESS}
+...                   user=${USERNAME}
+...                   password=${PASSWORD}
+Suite Teardown    Close Session

--- a/tests/formatter/formatters/AlignSettingsSection/expected/blank_line_and_whitespace.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/blank_line_and_whitespace.robot
@@ -1,4 +1,4 @@
 *** Settings ***
-Documentation       Documentation with extra
+Documentation    Documentation with extra
 ...
-...                 spaces
+...              spaces

--- a/tests/formatter/formatters/AlignSettingsSection/expected/blank_line_doc.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/blank_line_doc.robot
@@ -1,8 +1,8 @@
 *** Settings ***
-Documentation       Description of what the file does
+Documentation    Description of what the file does
 ...
-...                 Copyright 2021 by company I am paid by
-Test Template       test
-Force Tags          tag
+...              Copyright 2021 by company I am paid by
+Test Template    test
+Force Tags       tag
 ...
-...                 tag2
+...              tag2

--- a/tests/formatter/formatters/AlignSettingsSection/expected/empty_lines.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/empty_lines.robot
@@ -1,4 +1,4 @@
 *** Settings ***
-Documentation       This is
-...                 multiline line
-...                 docs
+Documentation    This is
+...              multiline line
+...              docs

--- a/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords.robot
@@ -1,16 +1,16 @@
 *** Settings ***
-Documentation       this
-...                 is documentation for comparison longer longer
+Documentation     this
+...               is documentation for comparison longer longer
 
-Force Tags          tag    tag2
+Force Tags        tag    tag2
 
-Suite Setup         Start Session
-...                     host=${IPADDRESS}
-...                     user=${USERNAME}
-...                     password=${PASSWORD}
-Suite Teardown      Close Session
+Suite Setup       Start Session
+...                   host=${IPADDRESS}
+...                   user=${USERNAME}
+...                   password=${PASSWORD}
+Suite Teardown    Close Session
 
-Test Setup          Two Arguments One Line
-...                     ${arg}    ${arg2}
-...                     ${arg3}
-...                     ${arg4}    ${arg5}
+Test Setup        Two Arguments One Line
+...                   ${arg}    ${arg2}
+...                   ${arg3}
+...                   ${arg4}    ${arg5}

--- a/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_0indent.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_0indent.robot
@@ -1,16 +1,16 @@
 *** Settings ***
-Documentation       this
-...                 is documentation for comparison longer longer
+Documentation     this
+...               is documentation for comparison longer longer
 
-Force Tags          tag                         tag2
+Force Tags        tag                       tag2
 
-Suite Setup         Start Session
-...                 host=${IPADDRESS}
-...                 user=${USERNAME}
-...                 password=${PASSWORD}
-Suite Teardown      Close Session
+Suite Setup       Start Session
+...               host=${IPADDRESS}
+...               user=${USERNAME}
+...               password=${PASSWORD}
+Suite Teardown    Close Session
 
-Test Setup          Two Arguments One Line
-...                 ${arg}                      ${arg2}
-...                 ${arg3}
-...                 ${arg4}                     ${arg5}
+Test Setup        Two Arguments One Line
+...               ${arg}                    ${arg2}
+...               ${arg3}
+...               ${arg4}                   ${arg5}

--- a/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_20indent.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_20indent.robot
@@ -1,16 +1,16 @@
 *** Settings ***
-Documentation       this
-...                 is documentation for comparison longer longer
+Documentation     this
+...               is documentation for comparison longer longer
 
-Force Tags          tag                         tag2
+Force Tags        tag                       tag2
 
-Suite Setup         Start Session
-...                                     host=${IPADDRESS}
-...                                     user=${USERNAME}
-...                                     password=${PASSWORD}
-Suite Teardown      Close Session
+Suite Setup       Start Session
+...                                   host=${IPADDRESS}
+...                                   user=${USERNAME}
+...                                   password=${PASSWORD}
+Suite Teardown    Close Session
 
-Test Setup          Two Arguments One Line
-...                                     ${arg}    ${arg2}
-...                                     ${arg3}
-...                                     ${arg4}    ${arg5}
+Test Setup        Two Arguments One Line
+...                                   ${arg}    ${arg2}
+...                                   ${arg3}
+...                                   ${arg4}    ${arg5}

--- a/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_2indent.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_2indent.robot
@@ -1,16 +1,16 @@
 *** Settings ***
-Documentation       this
-...                 is documentation for comparison longer longer
+Documentation     this
+...               is documentation for comparison longer longer
 
-Force Tags          tag                         tag2
+Force Tags        tag                       tag2
 
-Suite Setup         Start Session
-...                   host=${IPADDRESS}
-...                   user=${USERNAME}
-...                   password=${PASSWORD}
-Suite Teardown      Close Session
+Suite Setup       Start Session
+...                 host=${IPADDRESS}
+...                 user=${USERNAME}
+...                 password=${PASSWORD}
+Suite Teardown    Close Session
 
-Test Setup          Two Arguments One Line
-...                   ${arg}                    ${arg2}
-...                   ${arg3}
-...                   ${arg4}                   ${arg5}
+Test Setup        Two Arguments One Line
+...                 ${arg}                  ${arg2}
+...                 ${arg3}
+...                 ${arg4}                 ${arg5}

--- a/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_all_col.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/multiline_keywords_all_col.robot
@@ -1,16 +1,16 @@
 *** Settings ***
-Documentation       this
-...                 is documentation for comparison longer longer
+Documentation     this
+...               is documentation for comparison longer longer
 
-Force Tags          tag                         tag2
+Force Tags        tag                       tag2
 
-Suite Setup         Start Session
-...                     host=${IPADDRESS}
-...                     user=${USERNAME}
-...                     password=${PASSWORD}
-Suite Teardown      Close Session
+Suite Setup       Start Session
+...                   host=${IPADDRESS}
+...                   user=${USERNAME}
+...                   password=${PASSWORD}
+Suite Teardown    Close Session
 
-Test Setup          Two Arguments One Line
-...                     ${arg}                  ${arg2}
-...                     ${arg3}
-...                     ${arg4}                 ${arg5}
+Test Setup        Two Arguments One Line
+...                   ${arg}                ${arg2}
+...                   ${arg3}
+...                   ${arg4}               ${arg5}

--- a/tests/formatter/formatters/AlignSettingsSection/expected/selected_part.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/selected_part.robot
@@ -7,12 +7,12 @@ Variables  variables.py
 Test Timeout  1 min
 
 # this should be left aligned
-Library             CustomLibrary    WITH NAME    name
-Library             ArgsedLibrary    ${1}    ${2}    ${3}
+Library          CustomLibrary    WITH NAME    name
+Library          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation    Example using the space separated format.
+...              and this documentation is multiline
+...              where this line should go I wonder?
 
 Default Tags       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup       Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/selected_whole.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/selected_whole.robot
@@ -1,26 +1,26 @@
 *** Settings ***
 # whole line comment that should be ignored
-Resource            ..${/}resources${/}resource.robot
-Library             SeleniumLibrary
-Library             Mylibrary.py
-Variables           variables.py
-Test Timeout        1 min
+Resource         ..${/}resources${/}resource.robot
+Library          SeleniumLibrary
+Library          Mylibrary.py
+Variables        variables.py
+Test Timeout     1 min
 
 # this should be left aligned
-Library             CustomLibrary    WITH NAME    name
-Library             ArgsedLibrary    ${1}    ${2}    ${3}
+Library          CustomLibrary    WITH NAME    name
+Library          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation    Example using the space separated format.
+...              and this documentation is multiline
+...              where this line should go I wonder?
 
-Default Tags        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
-Test Setup          Open Application    App A
-Test Teardown       Close Application
+Default Tags     default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup       Open Application    App A
+Test Teardown    Close Application
 
-Metadata            Version    2.0
-Metadata            More Info    For more information about *Robot Framework* see http://robotframework.org
-Metadata            Executed At    {HOST}
+Metadata         Version    2.0
+Metadata         More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata         Executed At    {HOST}
 # this should be left aligned
 Test Template
 

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test.robot
@@ -1,26 +1,26 @@
 *** Settings ***
 # whole line comment that should be ignored
-Resource            ..${/}resources${/}resource.robot
-Library             SeleniumLibrary
-Library             Mylibrary.py
-Variables           variables.py
-Test Timeout        1 min
+Resource         ..${/}resources${/}resource.robot
+Library          SeleniumLibrary
+Library          Mylibrary.py
+Variables        variables.py
+Test Timeout     1 min
 
 # this should be left aligned
-Library             CustomLibrary    WITH NAME    name
-Library             ArgsedLibrary    ${1}    ${2}    ${3}
+Library          CustomLibrary    WITH NAME    name
+Library          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation    Example using the space separated format.
+...              and this documentation is multiline
+...              where this line should go I wonder?
 
-Default Tags        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
-Test Setup          Open Application    App A
-Test Teardown       Close Application
+Default Tags     default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup       Open Application    App A
+Test Teardown    Close Application
 
-Metadata            Version    2.0
-Metadata            More Info    For more information about *Robot Framework* see http://robotframework.org
-Metadata            Executed At    {HOST}
+Metadata         Version    2.0
+Metadata         More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata         Executed At    {HOST}
 # this should be left aligned
 Test Template
 

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_disablers.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_disablers.robot
@@ -1,10 +1,10 @@
 *** Settings ***
 # whole line comment that should be ignored
-Resource            ..${/}resources${/}resource.robot
-Library             SeleniumLibrary
-Library             Mylibrary.py
-Variables           variables.py
-Test Timeout        1 min
+Resource         ..${/}resources${/}resource.robot
+Library          SeleniumLibrary
+Library          Mylibrary.py
+Variables        variables.py
+Test Timeout     1 min
 
 # robocop: fmt: off
     # this should be left aligned
@@ -12,17 +12,17 @@ Library    CustomLibrary   WITH NAME  name
 Library    ArgsedLibrary   ${1}  ${2}  ${3}
 # robocop: fmt: on
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation    Example using the space separated format.
+...              and this documentation is multiline
+...              where this line should go I wonder?
 
 Default Tags       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5  # robocop: fmt: off
-Test Setup          Open Application    App A
-Test Teardown       Close Application
+Test Setup       Open Application    App A
+Test Teardown    Close Application
 
-Metadata            Version    2.0
-Metadata            More Info    For more information about *Robot Framework* see http://robotframework.org
-Metadata            Executed At    {HOST}
+Metadata         Version    2.0
+Metadata         More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata         Executed At    {HOST}
 # this should be left aligned
 Test Template
 

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_49_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_49_width.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+# whole line comment that should be ignored
+Resource                                         ..${/}resources${/}resource.robot
+Library                                          SeleniumLibrary
+Library                                          Mylibrary.py
+Variables                                        variables.py
+Test Timeout                                     1 min
+
+# this should be left aligned
+Library                                          CustomLibrary    WITH NAME    name
+Library                                          ArgsedLibrary    ${1}    ${2}    ${3}
+
+Documentation                                    Example using the space separated format.
+...                                              and this documentation is multiline
+...                                              where this line should go I wonder?
+
+Default Tags                                     default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup                                       Open Application    App A
+Test Teardown                                    Close Application
+
+Metadata                                         Version    2.0
+Metadata                                         More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata                                         Executed At    {HOST}
+# this should be left aligned
+Test Template
+
+*** Keywords ***
+Keyword
+    Keyword  A
+    Keyword    B

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_50_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_50_width.robot
@@ -1,26 +1,26 @@
 *** Settings ***
 # whole line comment that should be ignored
-Resource                                            ..${/}resources${/}resource.robot
-Library                                             SeleniumLibrary
-Library                                             Mylibrary.py
-Variables                                           variables.py
-Test Timeout                                        1 min
+Resource                                          ..${/}resources${/}resource.robot
+Library                                           SeleniumLibrary
+Library                                           Mylibrary.py
+Variables                                         variables.py
+Test Timeout                                      1 min
 
 # this should be left aligned
-Library                                             CustomLibrary    WITH NAME    name
-Library                                             ArgsedLibrary    ${1}    ${2}    ${3}
+Library                                           CustomLibrary    WITH NAME    name
+Library                                           ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation                                       Example using the space separated format.
-...                                                 and this documentation is multiline
-...                                                 where this line should go I wonder?
+Documentation                                     Example using the space separated format.
+...                                               and this documentation is multiline
+...                                               where this line should go I wonder?
 
-Default Tags                                        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
-Test Setup                                          Open Application    App A
-Test Teardown                                       Close Application
+Default Tags                                      default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup                                        Open Application    App A
+Test Teardown                                     Close Application
 
-Metadata                                            Version    2.0
-Metadata                                            More Info    For more information about *Robot Framework* see http://robotframework.org
-Metadata                                            Executed At    {HOST}
+Metadata                                          Version    2.0
+Metadata                                          More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata                                          Executed At    {HOST}
 # this should be left aligned
 Test Template
 

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_51_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_51_width.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+# whole line comment that should be ignored
+Resource                                           ..${/}resources${/}resource.robot
+Library                                            SeleniumLibrary
+Library                                            Mylibrary.py
+Variables                                          variables.py
+Test Timeout                                       1 min
+
+# this should be left aligned
+Library                                            CustomLibrary    WITH NAME    name
+Library                                            ArgsedLibrary    ${1}    ${2}    ${3}
+
+Documentation                                      Example using the space separated format.
+...                                                and this documentation is multiline
+...                                                where this line should go I wonder?
+
+Default Tags                                       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup                                         Open Application    App A
+Test Teardown                                      Close Application
+
+Metadata                                           Version    2.0
+Metadata                                           More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata                                           Executed At    {HOST}
+# this should be left aligned
+Test Template
+
+*** Keywords ***
+Keyword
+    Keyword  A
+    Keyword    B

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_52_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_52_width.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+# whole line comment that should be ignored
+Resource                                            ..${/}resources${/}resource.robot
+Library                                             SeleniumLibrary
+Library                                             Mylibrary.py
+Variables                                           variables.py
+Test Timeout                                        1 min
+
+# this should be left aligned
+Library                                             CustomLibrary    WITH NAME    name
+Library                                             ArgsedLibrary    ${1}    ${2}    ${3}
+
+Documentation                                       Example using the space separated format.
+...                                                 and this documentation is multiline
+...                                                 where this line should go I wonder?
+
+Default Tags                                        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup                                          Open Application    App A
+Test Teardown                                       Close Application
+
+Metadata                                            Version    2.0
+Metadata                                            More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata                                            Executed At    {HOST}
+# this should be left aligned
+Test Template
+
+*** Keywords ***
+Keyword
+    Keyword  A
+    Keyword    B

--- a/tests/formatter/formatters/AlignSettingsSection/expected/three_columns.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/three_columns.robot
@@ -1,26 +1,26 @@
 *** Settings ***
 # whole line comment that should be ignored
-Resource            ..${/}resources${/}resource.robot
-Library             SeleniumLibrary
-Library             Mylibrary.py
-Variables           variables.py
-Test Timeout        1 min
+Resource         ..${/}resources${/}resource.robot
+Library          SeleniumLibrary
+Library          Mylibrary.py
+Variables        variables.py
+Test Timeout     1 min
 
 # this should be left aligned
-Library             CustomLibrary                           WITH NAME    name
-Library             ArgsedLibrary                           ${1}    ${2}    ${3}
+Library          CustomLibrary                        WITH NAME    name
+Library          ArgsedLibrary                        ${1}    ${2}    ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation    Example using the space separated format.
+...              and this documentation is multiline
+...              where this line should go I wonder?
 
-Default Tags        default tag 1                           default tag 2    default tag 3    default tag 4    default tag 5
-Test Setup          Open Application                        App A
-Test Teardown       Close Application
+Default Tags     default tag 1                        default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup       Open Application                     App A
+Test Teardown    Close Application
 
-Metadata            Version                                 2.0
-Metadata            More Info                               For more information about *Robot Framework* see http://robotframework.org
-Metadata            Executed At                             {HOST}
+Metadata         Version                              2.0
+Metadata         More Info                            For more information about *Robot Framework* see http://robotframework.org
+Metadata         Executed At                          {HOST}
 # this should be left aligned
 Test Template
 

--- a/tests/formatter/formatters/AlignSettingsSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignSettingsSection/test_formatter.py
@@ -72,11 +72,14 @@ class TestAlignSettingsSection(FormatterAcceptanceTest):
     def test_argument_indents(self):
         self.compare(source="argument_indents.robot")
 
-    @pytest.mark.parametrize("min_width", [0, 1, 20])
-    def test_min_width_shorter(self, min_width):
+    @pytest.mark.parametrize(
+        ("min_width", "expected"),
+        [(0, "test.robot"), (1, "test.robot"), (20, "test_min_width.robot")],
+    )
+    def test_min_width_shorter(self, min_width, expected):
         self.compare(
             source="test.robot",
-            expected="test_min_width.robot",
+            expected=expected,
             configure=[f"{self.FORMATTER_NAME}.min_width={min_width}"],
         )
 
@@ -84,7 +87,7 @@ class TestAlignSettingsSection(FormatterAcceptanceTest):
     def test_min_width_longer(self, min_width):
         self.compare(
             source="test.robot",
-            expected="test_min_width_50_width.robot",
+            expected=f"test_min_width_{min_width}_width.robot",
             configure=[f"{self.FORMATTER_NAME}.min_width={min_width}"],
         )
 

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/partly_templated.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/partly_templated.robot
@@ -2,13 +2,13 @@
 Test Template       Test Commit Message
 
 
-*** Test Cases ***                  UNLINTED FILE               LINTED FILE
-Misplaced Git Trailer               misplaced_trailer.txt       misplaced_trailer_linted.txt
-Mixed Unordered List Symbols        mixed_unordered.txt         mixed_unordered_linted.txt
-Incorrectly Ordered List            ordered.txt                 ordered_linted.txt
-Unaligned List Item Indention       unaligned.txt               unaligned_linted.txt
-Garbage Commit Message              garbage.txt                 garbage_linted.txt
-Valid Commit Message                unchanged.txt               unchanged_linted.txt            ${type trailer}     ${type trailer}\n${trailer block}
+*** Test Cases ***               UNLINTED FILE            LINTED FILE
+Misplaced Git Trailer            misplaced_trailer.txt    misplaced_trailer_linted.txt
+Mixed Unordered List Symbols     mixed_unordered.txt      mixed_unordered_linted.txt
+Incorrectly Ordered List         ordered.txt              ordered_linted.txt
+Unaligned List Item Indention    unaligned.txt            unaligned_linted.txt
+Garbage Commit Message           garbage.txt              garbage_linted.txt
+Valid Commit Message             unchanged.txt            unchanged_linted.txt            ${type trailer}    ${type trailer}\n${trailer block}
 Header Validation
     [Template]    NONE
     ${valid header} =    Validate Header    ${header}

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/tags_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/tags_settings.robot
@@ -1,19 +1,19 @@
 *** Settings ***
-Test Template       Login with invalid credentials should fail
+Test Template    Login with invalid credentials should fail
 
 
-*** Test Cases ***                  USERNAME            PASSWORD
-Invalid User Name                   [Tags]              foo
-                                    invalid             ${VALID PASSWORD}
+*** Test Cases ***                USERNAME         PASSWORD
+Invalid User Name                 [Tags]           foo
+                                  invalid          ${VALID PASSWORD}
 Invalid Password
-                                    [Tags]              bar
-                                    ${VALID USER}       invalid
-Invalid User Name and Password      [Tags]              baz
-                                    invalid             invalid
-Empty User Name                     ${EMPTY}            ${VALID PASSWORD}
-Empty Password                      [Tags]              spam                    eggs
-                                    ${VALID USER}       ${EMPTY}
-Empty User Name and Password        ${EMPTY}            ${EMPTY}
+                                  [Tags]           bar
+                                  ${VALID USER}    invalid
+Invalid User Name and Password    [Tags]           baz
+                                  invalid          invalid
+Empty User Name                   ${EMPTY}         ${VALID PASSWORD}
+Empty Password                    [Tags]           spam                 eggs
+                                  ${VALID USER}    ${EMPTY}
+Empty User Name and Password      ${EMPTY}         ${EMPTY}
 
 
 *** Keywords ***

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without.robot
@@ -4,13 +4,13 @@ Test Template    Dummy
 *** Test Cases ***
 Template with for loop
     FOR    ${item}    IN    @{ITEMS}
-                            ${item}     2nd arg
+                          ${item}     2nd arg
     END
     FOR    ${index}    IN RANGE    42
-                            1st arg     ${index}
+                          1st arg     ${index}
     END
-                            test        ${arg}
+                          test        ${arg}
 
 # some comment
-test1                       hi          hello
-test2 long test name        asdfasdf    asdsdfgsdfg
+test1                     hi          hello
+test2 long test name      asdfasdf    asdsdfgsdfg

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without_fixed.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without_fixed.robot
@@ -4,13 +4,13 @@ Test Template    Dummy
 *** Test Cases ***
 Template with for loop
     FOR    ${item}    IN    @{ITEMS}
-                            ${item}                  2nd arg
+                          ${item}                  2nd arg
     END
     FOR    ${index}    IN RANGE    42
-                            1st arg                  ${index}
+                          1st arg                  ${index}
     END
-                            test                     ${arg}
+                          test                     ${arg}
 
 # some comment
-test1                       hi                       hello
-test2 long test name        asdfasdf                 asdsdfgsdfg
+test1                     hi                       hello
+test2 long test name      asdfasdf                 asdsdfgsdfg

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_header_cols.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_header_cols.robot
@@ -1,11 +1,11 @@
 *** Settings ***
 Test Template    Dummy
 
-*** Test Cases ***          foo         bar
+*** Test Cases ***        foo        bar
 Template with for loop
     FOR    ${item}    IN    @{ITEMS}
-                            ${item}     2nd arg
+                          ${item}    2nd arg
     END
     FOR    ${index}    IN RANGE    42
-                            1st arg     ${index}
+                          1st arg    ${index}
     END

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/with_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/with_settings.robot
@@ -2,15 +2,15 @@
 Test Template    Dummy
 
 *** Test Cases ***
-Test1       ARG1
-            [Tags]              sanity
-            [Documentation]     Validate Test1
-Test2       ARG2
-            [Tags]              smoke
-            [Documentation]     Validate Test2
-Test3       ARG3
-            [Tags]              valid
-            [Documentation]     Validate Test3
-Test4       ARG4
-            [Tags]              sanity
-            [Documentation]     Validate Test4
+Test1    ARG1
+         [Tags]             sanity
+         [Documentation]    Validate Test1
+Test2    ARG2
+         [Tags]             smoke
+         [Documentation]    Validate Test2
+Test3    ARG3
+         [Tags]             valid
+         [Documentation]    Validate Test3
+Test4    ARG4
+         [Tags]             sanity
+         [Documentation]    Validate Test4

--- a/tests/formatter/formatters/AlignTemplatedTestCases/test_formatter.py
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/test_formatter.py
@@ -18,7 +18,7 @@ class TestAlignTemplatedTestCases(FormatterAcceptanceTest):
         ],
     )
     def test_formatter(self, source):
-        self.compare(source=source, expected=source)
+        self.compare(source=source, expected=source, not_modified=source == "templated_for_loops.robot")
 
     @pytest.mark.parametrize("source", ["for_loops.robot", "empty_line.robot"])
     def test_should_not_modify(self, source):

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/blocks_auto.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/blocks_auto.robot
@@ -1,31 +1,31 @@
 *** Test Cases ***
 FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
-        Keyword That Goes Over Limit Of The Column              ${short}    ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column        ${short}            ${loooooooooooooooooooooooooooong}
     END
 
 Nested FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}         Keyword             ${var}
+        ${variable}        Keyword           ${var}
         Another Keyword
         FOR  ${var2}  IN  1  2  3
-            Short           1                   2
-            ${assign}       Longer Keyword
-            ...             ${multiline}        ${arg}
+            Short        1                 2
+            ${assign}    Longer Keyword
+            ...          ${multiline}      ${arg}
         END
-        Keyword That Goes Over Limit Of The Column          ${short}    ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column     ${short}            ${loooooooooooooooooooooooooooong}
     END
 
 IF
     IF    ${condition}
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE IF    $flag
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     END

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/blocks_auto_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/blocks_auto_0.robot
@@ -1,31 +1,31 @@
 *** Test Cases ***
 FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}                                     Keyword     ${var}
+        ${variable}                                   Keyword     ${var}
         Another Keyword
-        Keyword That Goes Over Limit Of The Column      ${short}    ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column    ${short}    ${loooooooooooooooooooooooooooong}
     END
 
 Nested FOR loop
     FOR  ${var}  IN  1  2  3
-        ${variable}                                     Keyword             ${var}
+        ${variable}                                   Keyword           ${var}
         Another Keyword
         FOR  ${var2}  IN  1  2  3
-            Short           1                   2
-            ${assign}       Longer Keyword
-            ...             ${multiline}        ${arg}
+            Short        1                 2
+            ${assign}    Longer Keyword
+            ...          ${multiline}      ${arg}
         END
-        Keyword That Goes Over Limit Of The Column      ${short}            ${loooooooooooooooooooooooooooong}
+        Keyword That Goes Over Limit Of The Column    ${short}          ${loooooooooooooooooooooooooooong}
     END
 
 IF
     IF    ${condition}
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE IF    $flag
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     ELSE
-        ${variable}         Keyword     ${var}
+        ${variable}        Keyword    ${var}
         Another Keyword
     END

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/documentation_auto_align_first_col.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/documentation_auto_align_first_col.robot
@@ -4,27 +4,27 @@ Documentation    Do not touch this.
 
 *** Test Cases ***
 Example of alignment to second column of Documentation
-    [Documentation]     Unselects checkbox value in the data table
-    ...                 note that you must give some unique column/value pair that is used to select the row
+    [Documentation]    Unselects checkbox value in the data table
+    ...                note that you must give some unique column/value pair that is used to select the row
     ...
-    ...                 == Examples ==
-    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
-    ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
+    ...                == Examples ==
+    ...                # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Test with documentation and keyword calls
-    [Documentation]     Do stuff.
+    [Documentation]    Do stuff.
     Longer Keyword Call That Ends Here
 
 Test with documentation and keyword calls 2
-    [Documentation]         Do stuff.
-    ...                     2nd
-    Longer Keywordsss       ${arg}
+    [Documentation]      Do stuff.
+    ...                  2nd
+    Longer Keywordsss    ${arg}
 
 Test With Empty Documentation
     [Documentation]
 
 Test with documentation and other settings
-    [Documentation]     Do stuff
-    ...                 Also multiline    Extra whitespace
-    ...                 Only fix indent.
-    [Tags]              ${arg}      ${arg2}
+    [Documentation]    Do stuff
+    ...                Also multiline    Extra whitespace
+    ...                Only fix indent.
+    [Tags]             ${arg}    ${arg2}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/settings_auto_separate_settings.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/settings_auto_separate_settings.robot
@@ -2,12 +2,12 @@
 Keyword With Settings
     [Documentation]  Docs should be left alone
     ...  even misaligned.
-    [Tags]          1234        1234  # comment
-    [Teardown]      Keyword
-    [Timeout]       1min
+    [Tags]        1234       1234  # comment
+    [Teardown]    Keyword
+    [Timeout]     1min
     Short
-    Keyword Arg         ${arg}
+    Keyword Arg      ${arg}
     FOR    ${var}   IN RANGE    10
-        Keyword Arg         ${arg}
-        Other Keyword       ${arg}
+        Keyword Arg      ${arg}
+        Other Keyword    ${arg}
     END

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_0.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_24_0_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_24_0_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_24_24_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_24_24_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
     ${assign}    Looooooooonger Keyword Name    ${argument}
-    Short       Short       Short
+    Short     Short     Short
     Single
-    Multi       ${arg}
-    ...         ${arg}
+    Multi     ${arg}
+    ...       ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_24_40_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_line_24_40_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_0.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_24_0_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_24_0_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_24_24_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_24_24_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name    ${argument}
-    Short           Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short     Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_24_40_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_ignore_rest_24_40_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_0.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_24_0_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_24_0_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_24_24_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_24_24_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name         ${argument}
-    Short           Short       Short
+    ${assign}    Looooooooonger Keyword Name          ${argument}
+    Short        Short     Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_24_40_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_auto_overflow_24_40_24.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short           Short                           Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short        Short                          Short
     Single
-    Multi           ${arg}
-    ...             ${arg}
+    Multi        ${arg}
+    ...          ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi           ${arg}  # comment 4
-    ...             ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi         ${arg}  # comment 4
+    ...           ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_line_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_line_0.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short       Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
     Single
-    Multi       ${arg}
-    ...     ${arg}
+    Multi    ${arg}
+    ...    ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi       ${arg}  # comment 4
-    ...     ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_line_24_0_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_line_24_0_24.robot
@@ -1,7 +1,7 @@
 *** Test Cases ***
 Keyword
-    ${assign}               Looooooooonger Keyword Name     ${argument}
-    Short                   Short       Short
+    ${assign}               Looooooooonger Keyword Name    ${argument}
+    Short                   Short    Short
     Single
     Multi                   ${arg}
     ...                     ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_rest_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_rest_0.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short       Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
     Single
-    Multi       ${arg}
-    ...     ${arg}
+    Multi    ${arg}
+    ...    ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi       ${arg}  # comment 4
-    ...     ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_rest_24_0_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_ignore_rest_24_0_24.robot
@@ -1,7 +1,7 @@
 *** Test Cases ***
 Keyword
-    ${assign}               Looooooooonger Keyword Name     ${argument}
-    Short                   Short       Short
+    ${assign}               Looooooooonger Keyword Name    ${argument}
+    Short                   Short    Short
     Single
     Multi                   ${arg}
     ...                     ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_overflow_0.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_overflow_0.robot
@@ -1,10 +1,10 @@
 *** Test Cases ***
 Keyword
-    ${assign}       Looooooooonger Keyword Name     ${argument}
-    Short       Short       Short
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
     Single
-    Multi       ${arg}
-    ...     ${arg}
+    Multi    ${arg}
+    ...    ${arg}
 
 Second Keyword
     Looooooooonger Keyword Name
@@ -12,6 +12,6 @@ Second Keyword
 With Comments
     Single  # comment 1
     With Arg  # comment 2  comment 3
-    Multi       ${arg}  # comment 4
-    ...     ${arg}  # comment 5
-    Three Args      argument    argument
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_overflow_24_0_24.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/simple_fixed_overflow_24_0_24.robot
@@ -1,7 +1,7 @@
 *** Test Cases ***
 Keyword
-    ${assign}               Looooooooonger Keyword Name     ${argument}
-    Short                   Short       Short
+    ${assign}               Looooooooonger Keyword Name    ${argument}
+    Short                   Short    Short
     Single
     Multi                   ${arg}
     ...                     ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/templated_with_settings_auto.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/templated_with_settings_auto.robot
@@ -1,46 +1,46 @@
 *** Test Cases ***
 Testing Random List
-    [Template]      Validate Random List Selection
-    # collection        nbr items
-    ${SIMPLE LIST}      2
-    ${MIXED LIST}       3
-    ${NESTED LIST}      4
-    ${SIMPLE LIST}      10
-    ${MIXED LIST}       11
-    ${NESTED LIST}      12
+    [Template]    Validate Random List Selection
+    # collection      nbr items
+    ${SIMPLE LIST}    2
+    ${MIXED LIST}     3
+    ${NESTED LIST}    4
+    ${SIMPLE LIST}    10
+    ${MIXED LIST}     11
+    ${NESTED LIST}    12
 
 Testing Random Item
-    [Template]      Validate Random Item Selection
+    [Template]    Validate Random Item Selection
     # collection
     ${SIMPLE LIST}
     ${MIXED LIST}
     ${NESTED LIST}
 
 Testing Random Dict
-    [Template]      Validate Random Dict Selection
-    # collection        nbr items
-    ${SIMPLE DICT}      2
-    ${MIXED DICT}       3
-    ${NESTED DICT}      4
-    ${SIMPLE DICT}      10
-    ${MIXED DICT}       11
-    ${NESTED DICT}      12
+    [Template]    Validate Random Dict Selection
+    # collection      nbr items
+    ${SIMPLE DICT}    2
+    ${MIXED DICT}     3
+    ${NESTED DICT}    4
+    ${SIMPLE DICT}    10
+    ${MIXED DICT}     11
+    ${NESTED DICT}    12
 
 Testing Random Sleep
-    [Template]      Validate Random Sleep Duration
-    # max expected      min delay       add delay
-    1.1s                1s              ${EMPTY}        # Default Add Delay
-    1.2s                1s              20%             # Percentage Add Delay
-    2s                  1s              100%            # Percentage Limits
-    2.2s                1s              120%            # Percentage Overlimit
-    1.1s                1.0             1e-1            # Number Format
-    1.1s                1s              100ms           # Time Format
-    1.1s                1000ms          0.1             # Mixed Format
-    1s                  1s              0               # Zero additional Delay
-    1s                  1s              0%              # Zero Percent
+    [Template]    Validate Random Sleep Duration
+    # max expected    min delay    add delay
+    1.1s              1s           ${EMPTY}     # Default Add Delay
+    1.2s              1s           20%          # Percentage Add Delay
+    2s                1s           100%         # Percentage Limits
+    2.2s              1s           120%         # Percentage Overlimit
+    1.1s              1.0          1e-1         # Number Format
+    1.1s              1s           100ms        # Time Format
+    1.1s              1000ms       0.1          # Mixed Format
+    1s                1s           0            # Zero additional Delay
+    1s                1s           0%           # Zero Percent
 
 Testing Random Number
-    [Template]      Validate Random Integer/Number Choice
+    [Template]    Validate Random Integer/Number Choice
     # method    min                 max
     number      30e-10              5.26                # positive
     number      26e3                15                  # positive max under min
@@ -51,26 +51,26 @@ Testing Random Number
     number      5.0                 5                   # no range
 
 Testing Random Integer
-    [Template]      Validate Random Integer/Number Choice
-    # method    min         max
-    integer     198564      265489865       # positive
-    integer     3221564     325             # positive max under min
-    integer     -231        -10             # negative
-    integer     -2          -212            # negative max under min
-    integer     -56         56              # mixed
-    integer     23          -15             # mixed max under min
-    integer     -2          -2              # no range
+    [Template]    Validate Random Integer/Number Choice
+    # method    min        max
+    integer     198564     265489865    # positive
+    integer     3221564    325          # positive max under min
+    integer     -231       -10          # negative
+    integer     -2         -212         # negative max under min
+    integer     -56        56           # mixed
+    integer     23         -15          # mixed max under min
+    integer     -2         -2           # no range
 
 Test Password Policy Minimum Length Input Errors
     [Documentation]    This Keyword Verifies Password Policy Minimum Length Input Errors
-    [Tags]          SERVICE-12345
-    [Setup]         Login With Random User
-    [Teardown]      Test Teardown For User "${CURRENT_USER}"
-    [Template]      Test Password Policy Minimum Length Error With Input
-    ${SPACE}        Required
-    5               Invalid
-    15              Invalid
-    0               Invalid
-    65.90           Invalid
-    hgsjaADC        Invalid
-    $$ywu_%&#       Invalid
+    [Tags]        SERVICE-12345
+    [Setup]       Login With Random User
+    [Teardown]    Test Teardown For User "${CURRENT_USER}"
+    [Template]    Test Password Policy Minimum Length Error With Input
+    ${SPACE}     Required
+    5            Invalid
+    15           Invalid
+    0            Invalid
+    65.90        Invalid
+    hgsjaADC     Invalid
+    $$ywu_%&#    Invalid

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_compact_overflow.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_compact_overflow.robot
@@ -1,6 +1,6 @@
 *** Test Cases ***
 Second Column Should Not Be Counted
     I am too long to be counted    Do not count me
-    Short       Short       Short
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_ignore_line.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_ignore_line.robot
@@ -1,6 +1,6 @@
 *** Test Cases ***
 Second Column Should Not Be Counted
     I am too long to be counted    Do not count me
-    Short       Short       Short
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_ignore_rest.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_ignore_rest.robot
@@ -1,6 +1,6 @@
 *** Test Cases ***
 Second Column Should Not Be Counted
     I am too long to be counted    Do not count me
-    Short       Short       Short
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_overflow.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/too_long_token_counter_overflow.robot
@@ -1,6 +1,6 @@
 *** Test Cases ***
 Second Column Should Not Be Counted
-    I am too long to be counted         Do not count me
-    Short       Short       Short
+    I am too long to be counted             Do not count me
+    Short     Short     Short
     Longer
-    ...         ${arg}      ${arg}
+    ...       ${arg}    ${arg}

--- a/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_auto.robot
+++ b/tests/formatter/formatters/AlignTestCasesSection/expected/var_syntax_auto.robot
@@ -12,31 +12,31 @@ VAR without =
     Click              Cancel
 
 VAR with long variable names
-    VAR                ${variable_name_that_affects_something}     My value 1
+    VAR                ${variable_name_that_affects_something}               My value 1
     VAR    ${var_2}    My value 2
     GoTo               ${URL}
     Click              Cancel
 
 VAR with long variable names and long keyword name
-    VAR                ${variable_name_that_affects_something}     My value 1
+    VAR                ${variable_name_that_affects_something}               My value 1
     VAR    ${var_2}    My value 2
-    Click On The Button And Input Text Into Field                  ${URL}
+    Click On The Button And Input Text Into Field              ${URL}
     Click              Cancel
 
 VAR without value
     VAR    ${var_1}
-    Should Be Equal     ${c}        123
+    Should Be Equal    ${c}        123
 
 VAR with errors
     VAR
     VAR    ${var
     VAR    $var    value
-    Should Be Equal     ${c}    123
+    Should Be Equal    ${c}    123
 
 VAR multiline
     VAR    ${var}
-    ...                 value
-    Should Be Equal     ${c}        123
+    ...                value
+    Should Be Equal    ${c}      123
 
 Only VAR
     VAR    ${a}    ${1}

--- a/tests/formatter/formatters/AlignVariablesSection/expected/align_selected_part.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/align_selected_part.robot
@@ -7,11 +7,11 @@ Documentation    This is doc
 
 ${VARIABLE 1}  10  # comment
 @{LIST}  a  b  c  d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
  ${invalid}
   ${invalid_more}
 

--- a/tests/formatter/formatters/AlignVariablesSection/expected/align_selected_skip.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/align_selected_skip.robot
@@ -6,12 +6,12 @@ Documentation    This is doc
 # some comment
 
 ${VARIABLE 1}  10  # comment
-@{LIST}             a    b    c    d
+@{LIST}            a    b    c    d
 ${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}        a=b
-...                 b=c
-...                 d=1
+&{MULTILINE}       a=b
+...                b=c
+...                d=1
 ${invalid}
 ${invalid_more}
 

--- a/tests/formatter/formatters/AlignVariablesSection/expected/align_selected_whole.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/align_selected_whole.robot
@@ -5,13 +5,13 @@ Documentation    This is doc
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10    # comment
-@{LIST}                                 a    b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${VARIABLE 1}                        10    # comment
+@{LIST}                              a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}
 

--- a/tests/formatter/formatters/AlignVariablesSection/expected/all_columns.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/all_columns.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10                                  # comment
-@{LIST}                                 a                                   b               c       d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${VARIABLE 1}                        10                                 # comment
+@{LIST}                              a                                  b            c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                             1
+${variable}                          1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/long_comment.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/long_comment.robot
@@ -1,12 +1,12 @@
 *** Variables ***
 # some comment that is longer than usual and can go and go and ends     here
 
-${VARIABLE 1}                           10    # comment
-@{LIST}                                 a    b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${VARIABLE 1}                        10    # comment
+@{LIST}                              a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}

--- a/tests/formatter/formatters/AlignVariablesSection/expected/multiline_skip.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/multiline_skip.robot
@@ -1,8 +1,8 @@
 *** Variables ***
-${VARIABLE 1}                           10    # comment
+${VARIABLE 1}                        10    # comment
 @{LIST}  a
 ...    b
 ...    c
 ...    d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 &{SOME_DICT}    key=value  key2=value

--- a/tests/formatter/formatters/AlignVariablesSection/expected/multiline_with_blank.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/multiline_with_blank.robot
@@ -1,6 +1,6 @@
 *** Variables ***
-${VARIABLE}             1
-...                     2
+${VARIABLE}            1
+...                    2
 ...
-...                     3
-${OTHER_AND_LONGER}     a
+...                    3
+${OTHER_AND_LONGER}    a

--- a/tests/formatter/formatters/AlignVariablesSection/expected/optional_equal_sign.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/optional_equal_sign.robot
@@ -1,10 +1,10 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}=                          10    # comment
-@{LIST}                                 a    b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES} =     longer value that goes and goes
+${VARIABLE 1}=                         10    # comment
+@{LIST}                                a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES} =    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                           a=b
+...                                    b=c
+...                                    d=1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/single_var_2space_sep.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/single_var_2space_sep.robot
@@ -2,7 +2,7 @@
 Documentation               Test
 
 *** Variables ***
-${VAR_NAME_25_CHARACTERS}    Test
+${VAR_NAME_25_CHARACTERS}  Test
 
 *** Test Cases ***
 Test1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10    # comment
-@{LIST}                                 a    b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${VARIABLE 1}                        10    # comment
+@{LIST}                              a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                             1
+${variable}                          1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_2space_sep.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_2space_sep.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                       10  # comment
-@{LIST}                             a  b  c  d
-${LONGER_NAME_THAT_GOES_AND_GOES}   longer value that goes and goes
+${VARIABLE 1}                      10  # comment
+@{LIST}                            a  b  c  d
+${LONGER_NAME_THAT_GOES_AND_GOES}  longer value that goes and goes
 
-&{MULTILINE}                        a=b
-...                                 b=c
-...                                 d=1
+&{MULTILINE}                       a=b
+...                                b=c
+...                                d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                         1
+${variable}                        1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_disablers.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_disablers.robot
@@ -1,9 +1,9 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10    # comment
+${VARIABLE 1}                        10    # comment
 @{LIST}  a  b  c  d  # robocop: fmt: off
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
 # robocop: fmt: off
            &{MULTILINE}  a=b
@@ -15,4 +15,4 @@ ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                             1
+${variable}                          1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10    # comment
-@{LIST}                                 a    b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${VARIABLE 1}                        10    # comment
+@{LIST}                              a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                             1
+${variable}                          1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_49_width.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_49_width.robot
@@ -1,0 +1,16 @@
+*** Variables ***
+# some comment
+
+${VARIABLE 1}                                    10    # comment
+@{LIST}                                          a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}                longer value that goes and goes
+
+&{MULTILINE}                                     a=b
+...                                              b=c
+...                                              d=1
+${invalid}
+${invalid_more}
+
+# should be left aligned
+# should be left aligned
+${variable}                                      1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_50_width.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_50_width.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                                       10    # comment
-@{LIST}                                             a    b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES}                   longer value that goes and goes
+${VARIABLE 1}                                     10    # comment
+@{LIST}                                           a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}                 longer value that goes and goes
 
-&{MULTILINE}                                        a=b
-...                                                 b=c
-...                                                 d=1
+&{MULTILINE}                                      a=b
+...                                               b=c
+...                                               d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                                         1
+${variable}                                       1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_51_width.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_51_width.robot
@@ -1,0 +1,16 @@
+*** Variables ***
+# some comment
+
+${VARIABLE 1}                                      10    # comment
+@{LIST}                                            a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}                  longer value that goes and goes
+
+&{MULTILINE}                                       a=b
+...                                                b=c
+...                                                d=1
+${invalid}
+${invalid_more}
+
+# should be left aligned
+# should be left aligned
+${variable}                                        1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_52_width.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_min_width_52_width.robot
@@ -1,0 +1,16 @@
+*** Variables ***
+# some comment
+
+${VARIABLE 1}                                       10    # comment
+@{LIST}                                             a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}                   longer value that goes and goes
+
+&{MULTILINE}                                        a=b
+...                                                 b=c
+...                                                 d=1
+${invalid}
+${invalid_more}
+
+# should be left aligned
+# should be left aligned
+${variable}                                         1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/tests_skip.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/tests_skip.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10    # comment
+${VARIABLE 1}                        10    # comment
 @{LIST}  a  b  c  d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                             1
+${variable}                          1

--- a/tests/formatter/formatters/AlignVariablesSection/expected/three_columns.robot
+++ b/tests/formatter/formatters/AlignVariablesSection/expected/three_columns.robot
@@ -1,16 +1,16 @@
 *** Variables ***
 # some comment
 
-${VARIABLE 1}                           10                                  # comment
-@{LIST}                                 a                                   b    c    d
-${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+${VARIABLE 1}                        10                                 # comment
+@{LIST}                              a                                  b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
 
-&{MULTILINE}                            a=b
-...                                     b=c
-...                                     d=1
+&{MULTILINE}                         a=b
+...                                  b=c
+...                                  d=1
 ${invalid}
 ${invalid_more}
 
 # should be left aligned
 # should be left aligned
-${variable}                             1
+${variable}                          1

--- a/tests/formatter/formatters/AlignVariablesSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignVariablesSection/test_formatter.py
@@ -88,11 +88,13 @@ class TestAlignVariablesSection(FormatterAcceptanceTest):
     def test_min_width_longer(self, min_width):
         self.compare(
             source="tests.robot",
-            expected="tests_min_width_50_width.robot",
+            expected=f"tests_min_width_{min_width}_width.robot",
             configure=[f"{self.FORMATTER_NAME}.min_width={min_width}"],
         )
 
-    @pytest.mark.parametrize("space_count", [2, 4])
-    def test_single_var(self, space_count):
-        not_modified = space_count == 4
-        self.compare(source="single_var.robot", not_modified=not_modified, space_count=space_count)
+    @pytest.mark.parametrize(
+        ("space_count", "expected"),
+        [(2, "single_var_2space_sep.robot"), (4, "single_var.robot")],
+    )
+    def test_single_var(self, space_count, expected):
+        self.compare(source="single_var.robot", expected=expected, space_count=space_count)

--- a/tests/formatter/formatters/ExternalTransformer/expected/tests_module_load.robot
+++ b/tests/formatter/formatters/ExternalTransformer/expected/tests_module_load.robot
@@ -1,5 +1,5 @@
 *** settings ***
-Library     KeywordLibrary
+Library    KeywordLibrary
 
 
 *** Test Cases ***

--- a/tests/formatter/formatters/ExternalTransformer/expected/tests_with_defaults.robot
+++ b/tests/formatter/formatters/ExternalTransformer/expected/tests_with_defaults.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library     KeywordLibrary
+Library    KeywordLibrary
 
 
 

--- a/tests/formatter/formatters/ExternalTransformer/expected/tests_with_defaults_lowercase.robot
+++ b/tests/formatter/formatters/ExternalTransformer/expected/tests_with_defaults_lowercase.robot
@@ -1,5 +1,5 @@
 *** settings ***
-Library     KeywordLibrary
+Library    KeywordLibrary
 
 
 *** test cases ***

--- a/tests/formatter/formatters/SplitTooLongLine/expected/comments.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/comments.robot
@@ -1,7 +1,7 @@
 *** Variables ***
-${VARIABLE_01}      a_value    # a short one-liner description for variable
-${VARIABLE_02}      a_value    # a short one-liner description for variable
-${VARIABLE_03}      a_value    # a short one-liner description for variable
-${VARIABLE_04}      a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
-${VARIABLE_05}      a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
-${VARIABLE_06}      a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
+${VARIABLE_01}    a_value    # a short one-liner description for variable
+${VARIABLE_02}    a_value    # a short one-liner description for variable
+${VARIABLE_03}    a_value    # a short one-liner description for variable
+${VARIABLE_04}    a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
+${VARIABLE_05}    a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
+${VARIABLE_06}    a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes

--- a/tests/formatter/formatters/SplitTooLongLine/expected/comments_skip_comments.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/comments_skip_comments.robot
@@ -1,7 +1,7 @@
 *** Variables ***
-${VARIABLE_01}      a_value    # a short one-liner description for variable
-${VARIABLE_02}      a_value    # a short one-liner description for variable
-${VARIABLE_03}      a_value    # a short one-liner description for variable
-${VARIABLE_04}      a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
-${VARIABLE_05}      a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
-${VARIABLE_06}      a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
+${VARIABLE_01}    a_value    # a short one-liner description for variable
+${VARIABLE_02}    a_value    # a short one-liner description for variable
+${VARIABLE_03}    a_value    # a short one-liner description for variable
+${VARIABLE_04}    a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
+${VARIABLE_05}    a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
+${VARIABLE_06}    a_value    # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes

--- a/tests/formatter/formatters/SplitTooLongLine/expected/comments_split_scalar.robot
+++ b/tests/formatter/formatters/SplitTooLongLine/expected/comments_split_scalar.robot
@@ -1,7 +1,7 @@
 *** Variables ***
-${VARIABLE_01}      a_value    # a short one-liner description for variable
-${VARIABLE_02}      a_value    # a short one-liner description for variable
-${VARIABLE_03}      a_value    # a short one-liner description for variable
+${VARIABLE_01}    a_value    # a short one-liner description for variable
+${VARIABLE_02}    a_value    # a short one-liner description for variable
+${VARIABLE_03}    a_value    # a short one-liner description for variable
 # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes
 ${VARIABLE_04}    a_value
 # a longer one-liner description for variable maybe with an URL https://github.com/MarketSquare/robotframework-tidy/pull/454 and some notes

--- a/tests/formatter/test_data/good_bad_files/good.robot
+++ b/tests/formatter/test_data/good_bad_files/good.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Documentation       Documentation
+Documentation    Documentation


### PR DESCRIPTION
## Summary
- calculate automatic alignment widths as the widest cell plus the configured separator width
- apply the policy consistently across settings, variables, templated tests, keyword/test aligners, documentation, and overflow handling
- update direct and indirect formatter fixtures, including distinct `min_width` expectations

## Breaking change
Aligned output is more concise and no longer rounds column positions to multiples of four.

## Validation
- `uv run pytest -q tests\formatter --tb=short` (578 passed, 6 skipped)
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy --config-file=pyproject.toml src\robocop\formatter\formatters\AlignSettingsSection.py src\robocop\formatter\formatters\AlignTemplatedTestCases.py src\robocop\formatter\formatters\AlignVariablesSection.py src\robocop\formatter\formatters\aligners_core.py src\robocop\formatter\utils\misc.py`

Closes #1511