### PR TITLE
feat(linter): add empty template data line rule

### DIFF
--- a/src/robocop/linter/checkers/spacing.py
+++ b/src/robocop/linter/checkers/spacing.py
@@ -66,6 +66,7 @@ class EmptyLinesChecker(VisitorChecker):
     empty_line_after_section: spacing.EmptyLineAfterSectionRule
     consecutive_empty_lines: spacing.ConsecutiveEmptyLinesRule
     empty_lines_in_statement: spacing.EmptyLinesInStatementRule
+    empty_line_in_test_template: spacing.EmptyLineInTestTemplateRule
 
     def verify_consecutive_empty_lines(
         self, lines: list[Node], check_leading: bool = True, check_trailing: bool = False
@@ -167,6 +168,10 @@ class EmptyLinesChecker(VisitorChecker):
     def visit_TestCaseSection(self, node: Node) -> None:  # noqa: N802
         allowed_lines = -1 if self.templated_suite else self.empty_lines_between_test_cases.empty_lines
         self.verify_empty_lines_between_nodes(node, TestCase, self.empty_lines_between_test_cases, allowed_lines)
+
+    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
+        self.empty_line_in_test_template.check(node)
+        self.generic_visit(node)
 
     def visit_KeywordSection(self, node: Node) -> None:  # noqa: N802
         self.verify_empty_lines_between_nodes(

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -9,10 +9,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 from robot.api import Token
 from robot.parsing.model.blocks import TestCase
-from robot.parsing.model.statements import Comment, EmptyLine
+from robot.parsing.model.statements import Comment, EmptyLine, TemplateArguments
 
 from robocop.linter import sonar_qube
-from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
+from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit, remove_lines_fix
 from robocop.linter.rules import (
     FixableRule,
     Rule,
@@ -839,6 +839,76 @@ class FirstArgumentInNewLineRule(Rule):
                         end_col=token.end_col_offset,
                     )
                 return
+
+
+class EmptyLineInTestTemplateRule(FixableRule):
+    """
+    Empty line in test template data.
+
+    Robot Framework ignores empty lines between data rows in templated tests. Remove these lines so that the test data
+    does not contain rows that have no effect.
+
+    Incorrect code example:
+
+        *** Test Cases ***
+        Example
+            [Template]    Template Keyword
+            first argument
+
+            second argument
+
+    Correct code:
+
+        *** Test Cases ***
+        Example
+            [Template]    Template Keyword
+            first argument
+            second argument
+
+    The rule reports only empty lines between consecutive template data rows. Blank lines next to settings or comments
+    and blank lines separating test cases are preserved.
+
+    The fix removes the ignored empty line.
+    """
+
+    name = "empty-line-in-test-template"
+    rule_id = "SPC23"
+    message = "Empty line in test template data"
+    severity = RuleSeverity.WARNING
+    version = ">=5.0"
+    added_in_version = "9.0.0"
+    fix_availability = FixAvailability.ALWAYS
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.FORMATTED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+
+    def check(self, node: TestCase) -> None:
+        if not self.enabled:
+            return
+        empty_lines: list[EmptyLine] = []
+        template_data_row_seen = False
+        for statement in node.body:
+            if isinstance(statement, TemplateArguments):
+                if template_data_row_seen:
+                    for empty_line in empty_lines:
+                        self.report(node=empty_line, col=1)
+                template_data_row_seen = True
+                empty_lines = []
+            elif isinstance(statement, EmptyLine) and template_data_row_seen:
+                empty_lines.append(statement)
+            else:
+                template_data_row_seen = False
+                empty_lines = []
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        if diag.node is None:
+            return None
+        return remove_lines_fix(
+            self,
+            start_line=diag.node.lineno,
+            end_line=diag.node.end_lineno,
+            message="Remove the ignored empty line",
+        )
 
 
 def get_indent(node: Node) -> int:

--- a/src/robocop/linter/rules/spacing.py
+++ b/src/robocop/linter/rules/spacing.py
@@ -865,8 +865,8 @@ class EmptyLineInTestTemplateRule(FixableRule):
             first argument
             second argument
 
-    The rule reports only empty lines between consecutive template data rows. Blank lines next to settings or comments
-    and blank lines separating test cases are preserved.
+    The rule reports only empty lines between consecutive template data rows, including rows nested in control
+    structures. Blank lines next to settings or comments and blank lines separating test cases are preserved.
 
     The fix removes the ignored empty line.
     """
@@ -885,9 +885,12 @@ class EmptyLineInTestTemplateRule(FixableRule):
     def check(self, node: TestCase) -> None:
         if not self.enabled:
             return
+        self.check_body(node.body)
+
+    def check_body(self, body: list[Node]) -> None:
         empty_lines: list[EmptyLine] = []
         template_data_row_seen = False
-        for statement in node.body:
+        for statement in body:
             if isinstance(statement, TemplateArguments):
                 if template_data_row_seen:
                     for empty_line in empty_lines:
@@ -899,6 +902,14 @@ class EmptyLineInTestTemplateRule(FixableRule):
             else:
                 template_data_row_seen = False
                 empty_lines = []
+            nested_body = getattr(statement, "body", None)
+            if nested_body is not None:
+                self.check_body(nested_body)
+            for branch_attr in ("orelse", "next"):
+                branch = getattr(statement, branch_attr, None)
+                while branch is not None:
+                    self.check_body(branch.body)
+                    branch = getattr(branch, branch_attr, None)
 
     def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
         if diag.node is None:

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_extended.txt
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_extended.txt
@@ -31,6 +31,35 @@ test.robot:30:1 SPC23 Empty line in test template data
  31 |     second
     |
 
+test.robot:44:1 SPC23 Empty line in test template data
+    |
+ 42 |     FOR    ${item}    IN    first    second
+ 43 |         loop first
+ 44 |
+    | ^ SPC23
+ 45 |         loop second
+    |
+
+test.robot:52:1 SPC23 Empty line in test template data
+    |
+ 50 |         IF    $condition
+ 51 |             if first
+ 52 |
+    | ^ SPC23
+ 53 |             if second
+ 54 |         ELSE
+    |
+
+test.robot:56:1 SPC23 Empty line in test template data
+    |
+ 54 |         ELSE
+ 55 |             else first
+ 56 |
+    | ^ SPC23
+ 57 |             else second
+ 58 |         END
+    |
+
 local_template.robot:8:1 SPC23 Empty line in test template data
    |
  6 |
@@ -40,5 +69,5 @@ local_template.robot:8:1 SPC23 Empty line in test template data
  9 |     second
    |
 
-Found 5 issues.
-5 fixable with the '--fix' option.
+Found 8 issues.
+8 fixable with the '--fix' option.

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_extended.txt
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_extended.txt
@@ -1,0 +1,44 @@
+test.robot:8:1 SPC23 Empty line in test template data
+   |
+ 6 | Suite template
+ 7 |     first
+ 8 |
+   | ^ SPC23
+ 9 |     second
+   |
+
+test.robot:14:1 SPC23 Empty line in test template data
+    |
+ 12 | Multiple ignored lines
+ 13 |     first
+ 14 |
+    | ^ SPC23
+    |
+
+test.robot:15:1 SPC23 Empty line in test template data
+    |
+ 15 |
+    | ^ SPC23
+ 16 |     third
+    |
+
+test.robot:30:1 SPC23 Empty line in test template data
+    |
+ 28 |     first
+ 29 |     ...    continued
+ 30 |
+    | ^ SPC23
+ 31 |     second
+    |
+
+local_template.robot:8:1 SPC23 Empty line in test template data
+   |
+ 6 |
+ 7 |     first
+ 8 |
+   | ^ SPC23
+ 9 |     second
+   |
+
+Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/expected_output.txt
@@ -1,7 +1,7 @@
-Fixed 5 issues:
+Fixed 8 issues:
 - actual_fixed${/}local_template.robot:
     1 x SPC23 (empty-line-in-test-template)
 - actual_fixed${/}test.robot:
-    4 x SPC23 (empty-line-in-test-template)
+    7 x SPC23 (empty-line-in-test-template)
 
-Found 5 issues (5 fixed, 0 remaining).
+Found 8 issues (8 fixed, 0 remaining).

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/expected_output.txt
@@ -1,0 +1,7 @@
+Fixed 5 issues:
+- actual_fixed${/}local_template.robot:
+    1 x SPC23 (empty-line-in-test-template)
+- actual_fixed${/}test.robot:
+    4 x SPC23 (empty-line-in-test-template)
+
+Found 5 issues (5 fixed, 0 remaining).

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/local_template.robot
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/local_template.robot
@@ -1,0 +1,16 @@
+*** Test Cases ***
+Per-test template
+    [Documentation]    Blank lines around settings are meaningful.
+
+    [Template]    Template Keyword
+
+    first
+    second
+
+    [Teardown]    Cleanup
+
+
+Non-templated test
+    First Keyword
+
+    Second Keyword

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/test.robot
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/test.robot
@@ -32,3 +32,21 @@ Locally disabled template
     First Keyword
 
     Second Keyword
+
+
+Nested control structures
+    FOR    ${item}    IN    first    second
+        loop first
+        loop second
+
+        # This comment and the blank lines around it are meaningful.
+
+        loop third
+        IF    $condition
+            if first
+            if second
+        ELSE
+            else first
+            else second
+        END
+    END

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/test.robot
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_fixed/test.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Test Template    Template Keyword
+
+
+*** Test Cases ***
+Suite template
+    first
+    second
+
+
+Multiple ignored lines
+    first
+    third
+
+
+Commented groups
+    first
+
+    # This comment and the blank lines around it are meaningful.
+
+    second
+
+
+Multiline data
+    first
+    ...    continued
+    second
+
+
+Locally disabled template
+    [Template]    NONE
+    First Keyword
+
+    Second Keyword

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_output.txt
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_output.txt
@@ -2,7 +2,10 @@ test.robot:8:1 [W] SPC23 Empty line in test template data
 test.robot:14:1 [W] SPC23 Empty line in test template data
 test.robot:15:1 [W] SPC23 Empty line in test template data
 test.robot:30:1 [W] SPC23 Empty line in test template data
+test.robot:44:1 [W] SPC23 Empty line in test template data
+test.robot:52:1 [W] SPC23 Empty line in test template data
+test.robot:56:1 [W] SPC23 Empty line in test template data
 local_template.robot:8:1 [W] SPC23 Empty line in test template data
 
-Found 5 issues.
-5 fixable with the '--fix' option.
+Found 8 issues.
+8 fixable with the '--fix' option.

--- a/tests/linter/rules/spacing/empty_line_in_test_template/expected_output.txt
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/expected_output.txt
@@ -1,0 +1,8 @@
+test.robot:8:1 [W] SPC23 Empty line in test template data
+test.robot:14:1 [W] SPC23 Empty line in test template data
+test.robot:15:1 [W] SPC23 Empty line in test template data
+test.robot:30:1 [W] SPC23 Empty line in test template data
+local_template.robot:8:1 [W] SPC23 Empty line in test template data
+
+Found 5 issues.
+5 fixable with the '--fix' option.

--- a/tests/linter/rules/spacing/empty_line_in_test_template/local_template.robot
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/local_template.robot
@@ -1,0 +1,17 @@
+*** Test Cases ***
+Per-test template
+    [Documentation]    Blank lines around settings are meaningful.
+
+    [Template]    Template Keyword
+
+    first
+
+    second
+
+    [Teardown]    Cleanup
+
+
+Non-templated test
+    First Keyword
+
+    Second Keyword

--- a/tests/linter/rules/spacing/empty_line_in_test_template/test.robot
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/test.robot
@@ -36,3 +36,24 @@ Locally disabled template
     First Keyword
 
     Second Keyword
+
+
+Nested control structures
+    FOR    ${item}    IN    first    second
+        loop first
+
+        loop second
+
+        # This comment and the blank lines around it are meaningful.
+
+        loop third
+        IF    $condition
+            if first
+
+            if second
+        ELSE
+            else first
+
+            else second
+        END
+    END

--- a/tests/linter/rules/spacing/empty_line_in_test_template/test.robot
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/test.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Test Template    Template Keyword
+
+
+*** Test Cases ***
+Suite template
+    first
+
+    second
+
+
+Multiple ignored lines
+    first
+
+    
+    third
+
+
+Commented groups
+    first
+
+    # This comment and the blank lines around it are meaningful.
+
+    second
+
+
+Multiline data
+    first
+    ...    continued
+
+    second
+
+
+Locally disabled template
+    [Template]    NONE
+    First Keyword
+
+    Second Keyword

--- a/tests/linter/rules/spacing/empty_line_in_test_template/test_rule.py
+++ b/tests/linter/rules/spacing/empty_line_in_test_template/test_rule.py
@@ -1,0 +1,21 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(
+            src_files=["test.robot", "local_template.robot"],
+            expected_file="expected_output.txt",
+            test_on_version=">=5",
+        )
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["test.robot", "local_template.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=5",
+        )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot", "local_template.robot"], test_on_version=">=5")


### PR DESCRIPTION
## Summary
- add `SPC23` (`empty-line-in-test-template`) for empty rows Robot Framework ignores between template data rows
- provide an `ALWAYS`/`SAFE` fix that removes only those ignored rows
- preserve blank-line grouping around comments, settings, test boundaries, multiline continuations, disabled templates, and non-templated tests

Closes #999

## Validation
- `uv run pytest tests/linter/rules/spacing/empty_line_in_test_template/test_rule.py -q`
- `uv run --with robotframework==5.0.1 pytest tests/linter/rules/spacing/empty_line_in_test_template/test_rule.py -q`
- `uv run pytest tests/linter/rules/spacing -q`
- `uv run pytest tests -q` (2,139 passed, 76 skipped)
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy --config-file=pyproject.toml ./src/robocop/linter/`

Full-project mypy was also run and reaches seven unrelated existing errors in `config/manager.py` and `OrderSettingsSection.py`; the complete linter package and changed modules pass strict typing.