### PR TITLE
feat(linter): detect variables in documentation

### DIFF
--- a/src/robocop/linter/checkers/settings.py
+++ b/src/robocop/linter/checkers/settings.py
@@ -8,7 +8,7 @@ from robot.api import Token
 from robot.libraries import STDLIBS
 from robot.parsing.model.blocks import SettingSection, TestCaseSection
 
-from robocop.linter.rules import VisitorChecker, deprecated, errors, imports, lengths, naming
+from robocop.linter.rules import VisitorChecker, deprecated, documentation, errors, imports, lengths, naming
 from robocop.version_handling import ROBOT_VERSION
 
 if TYPE_CHECKING:
@@ -37,6 +37,7 @@ class SettingsChecker(VisitorChecker):
 
     empty_metadata: lengths.EmptyMetadataRule
     empty_documentation: lengths.EmptyDocumentationRule
+    variable_in_documentation: documentation.VariableInDocumentationRule
     empty_force_tags: lengths.EmptyForceTagsRule
     empty_default_tags: lengths.EmptyDefaultTagsRule
     empty_keyword_tags: lengths.EmptyKeywordTagsRule
@@ -172,6 +173,7 @@ class SettingsChecker(VisitorChecker):
 
     def visit_Documentation(self, node: Statement) -> None:  # noqa: N802
         self.empty_documentation.check(node, self.parent_node_name)
+        self.variable_in_documentation.check(node)
         self.check_setting_name(node)
 
     def visit_ForceTags(self, node: Statement) -> None:  # noqa: N802

--- a/src/robocop/linter/rules/documentation.py
+++ b/src/robocop/linter/rules/documentation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from robot.api import Token
+from robot.errors import VariableError
 from robot.parsing.model.statements import Documentation
 
 from robocop.linter import sonar_qube
@@ -12,6 +14,7 @@ from robocop.linter.utils.misc import str2bool
 
 if TYPE_CHECKING:
     from robot.parsing.model import File, Keyword, SettingSection, TestCase
+    from robot.parsing.model.statements import Statement
 
 
 def report_if_documentation_is_missing(rule: Rule, node: Keyword | TestCase) -> None:
@@ -179,3 +182,69 @@ class MissingDocResourceFileRule(Rule):
         if not self.enabled:
             return
         self.report(node=node, lineno=1, col=1)
+
+
+class VariableInDocumentationRule(Rule):
+    r"""
+    Unescaped variable syntax in documentation.
+
+    Robot Framework resolves variables in suite, test case and user keyword documentation when a suite is executed.
+    This includes scalar (``${name}``), list (``@{items}``), dictionary (``&{mapping}``) and environment
+    (``%{NAME}``) variable syntax. Defined variables are replaced with their values. Undefined variables are left
+    unchanged, which can make an unescaped literal example appear correct until a variable with the same name becomes
+    available.
+
+    For example, this documentation changes at runtime if ``${value}`` exists:
+
+        *** Test Cases ***
+        Example
+            [Documentation]    The argument syntax is ${value}.
+            No Operation
+
+    Escape syntax that should be displayed literally:
+
+        *** Test Cases ***
+        Example
+            [Documentation]    Scalar: \${value}; list: \@{items}; dictionary: \&{mapping}; environment: \%{HOME}.
+            No Operation
+
+    The leading backslash prevents substitution and is removed from the rendered documentation. The rule checks suite,
+    test case and user keyword documentation, including continuation lines.
+
+    The rule is disabled by default. Enable it with:
+
+        robocop check --select variable-in-documentation
+
+    There is no automatic fix. Robocop cannot determine whether interpolation is intentional, and escaping an
+    intentionally dynamic value would change the rendered documentation. If interpolation is intended, leave the
+    syntax unescaped and disable the rule locally where needed.
+
+    """
+
+    name = "variable-in-documentation"
+    rule_id = "DOC05"
+    message = "Unescaped variable '{variable}' in documentation"
+    severity = RuleSeverity.INFO
+    enabled = False
+    added_in_version = "9.0.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.CLEAR, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+    fix_suggestion = "If literal variable syntax is intended, escape it with a backslash."
+
+    def check(self, node: Statement) -> None:
+        if not self.enabled:
+            return
+        for token in node.get_tokens(Token.ARGUMENT):
+            try:
+                variables = token.tokenize_variables()
+                for variable in variables:
+                    if variable.type != Token.VARIABLE:
+                        continue
+                    self.report(
+                        variable=variable.value,
+                        node=variable,
+                        end_col=variable.end_col_offset + 1,
+                    )
+            except VariableError:
+                continue

--- a/src/robocop/linter/rules/documentation.py
+++ b/src/robocop/linter/rules/documentation.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from robot.api import Token
-from robot.errors import VariableError
 from robot.parsing.model.statements import Documentation
 
 from robocop.linter import sonar_qube
 from robocop.linter.rules import Rule, RuleParam, RuleSeverity
 from robocop.linter.utils.misc import str2bool
+from robocop.parsing.variables import VariableMatches  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from robot.parsing.model import File, Keyword, SettingSection, TestCase
-    from robot.parsing.model.statements import Statement
 
 
 def report_if_documentation_is_missing(rule: Rule, node: Keyword | TestCase) -> None:
@@ -34,6 +34,123 @@ def report_if_suite_documentation_is_missing(rule: Rule, node: SettingSection) -
     if any(isinstance(statement, Documentation) for statement in node.body):
         return
     rule.report(node=node)
+
+
+@dataclass(frozen=True)
+class SourcePosition:
+    line: int
+    col: int
+
+
+def _remove_trailing_backslash(value: str) -> str:
+    """Match Robot Framework's handling of line-continuation backslashes in documentation."""
+    trailing_backslashes = len(value) - len(value.rstrip("\\"))
+    return value[:-1] if trailing_backslashes % 2 else value
+
+
+def _has_trailing_backslash_or_newline(value: str) -> bool:
+    value_before_optional_n = value.removesuffix("n")
+    trailing_backslashes = len(value_before_optional_n) - len(value_before_optional_n.rstrip("\\"))
+    return trailing_backslashes % 2 == 1
+
+
+def _append_synthetic(value_parts: list[str], positions: list[SourcePosition | None], value: str) -> None:
+    value_parts.append(value)
+    positions.extend([None] * len(value))
+
+
+def _append_token(
+    value_parts: list[str],
+    positions: list[SourcePosition | None],
+    token: Token,
+    *,
+    remove_trailing_backslash: bool = True,
+) -> None:
+    token_value = _remove_trailing_backslash(token.value) if remove_trailing_backslash else token.value
+    value_parts.append(token_value)
+    positions.extend(SourcePosition(token.lineno, token.col_offset + index + 1) for index in range(len(token_value)))
+
+
+def _documentation_argument_lines(node: Documentation) -> list[list[Token]]:
+    lines: list[list[Token]] = []
+    line: list[Token] = []
+    lineno = -1
+    for token in node.get_tokens(Token.ARGUMENT, Token.EOL):
+        is_eol = token.type == Token.EOL
+        if token.lineno != lineno or is_eol:
+            if line:
+                lines.append(line)
+            line = []
+        if not is_eol:
+            line.append(token)
+        lineno = token.lineno
+    if line:
+        lines.append(line)
+    return lines
+
+
+def _modern_documentation_source_positions(node: Documentation) -> tuple[str, list[SourcePosition | None]]:
+    value_parts: list[str] = []
+    positions: list[SourcePosition | None] = []
+    base_offset = -1
+    for tokens in _documentation_argument_lines(node):
+        offset = base_offset
+        for index, token in enumerate(tokens):
+            if token.col_offset > offset > 0:
+                _append_synthetic(value_parts, positions, " " * (token.col_offset - offset))
+            elif index > 0:
+                _append_synthetic(value_parts, positions, " ")
+            _append_token(value_parts, positions, token)
+            offset = token.end_col_offset
+        last = tokens[-1]
+        if not _has_trailing_backslash_or_newline(last.value):
+            _append_synthetic(value_parts, positions, "\n")
+        first = tokens[0]
+        if base_offset < 0 or (0 < first.col_offset < base_offset and first.value):
+            base_offset = first.col_offset
+    value = "".join(value_parts).rstrip()
+    del positions[len(value) :]
+    return value, positions
+
+
+def _legacy_documentation_source_positions(node: Documentation) -> tuple[str, list[SourcePosition | None]]:
+    value_parts: list[str] = []
+    positions: list[SourcePosition | None] = []
+    lines = _documentation_argument_lines(node)
+    for line_index, tokens in enumerate(lines):
+        for token_index, token in enumerate(tokens):
+            if token_index:
+                _append_synthetic(value_parts, positions, " ")
+            _append_token(value_parts, positions, token, remove_trailing_backslash=False)
+        if line_index < len(lines) - 1 and not _has_trailing_backslash_or_newline(tokens[-1].value):
+            _append_synthetic(value_parts, positions, "\n")
+    return "".join(value_parts), positions
+
+
+def _documentation_source_positions(node: Documentation) -> tuple[str, list[SourcePosition | None]]:
+    """Map characters in the joined documentation value back to source positions."""
+    for value, positions in (
+        _modern_documentation_source_positions(node),
+        _legacy_documentation_source_positions(node),
+    ):
+        if value == node.value:
+            return value, positions
+    return node.value, [None] * len(node.value)
+
+
+def _source_range(
+    positions: list[SourcePosition | None],
+    start: int,
+    end: int,
+    node: Documentation,
+) -> tuple[int, int, int, int]:
+    """Return the exact source range, or the narrowest mapped range when a boundary is synthetic."""
+    mapped_positions = [position for position in positions[start:end] if position is not None]
+    if not mapped_positions:
+        return node.lineno, node.col_offset + 1, node.end_lineno, node.end_col_offset + 1
+    first = mapped_positions[0]
+    last = mapped_positions[-1]
+    return first.line, first.col, last.line, last.col + 1
 
 
 class MissingDocKeywordRule(Rule):
@@ -232,19 +349,24 @@ class VariableInDocumentationRule(Rule):
     )
     fix_suggestion = "If literal variable syntax is intended, escape it with a backslash."
 
-    def check(self, node: Statement) -> None:
+    def check(self, node: Documentation) -> None:
         if not self.enabled:
             return
-        for token in node.get_tokens(Token.ARGUMENT):
-            try:
-                variables = token.tokenize_variables()
-                for variable in variables:
-                    if variable.type != Token.VARIABLE:
-                        continue
-                    self.report(
-                        variable=variable.value,
-                        node=variable,
-                        end_col=variable.end_col_offset + 1,
-                    )
-            except VariableError:
+        value, positions = _documentation_source_positions(node)
+        value_offset = 0
+        for match in VariableMatches(value, ignore_errors=True):
+            variable = match.match
+            if not variable:
                 continue
+            start = value_offset + len(match.before)
+            end = start + len(variable)
+            lineno, col, end_lineno, end_col = _source_range(positions, start, end, node)
+            self.report(
+                variable=variable.replace("\r", "\\r").replace("\n", "\\n"),
+                node=node,
+                lineno=lineno,
+                col=col,
+                end_lineno=end_lineno,
+                end_col=end_col,
+            )
+            value_offset = end

--- a/tests/linter/rules/documentation/variable_in_documentation/expected_extended.txt
+++ b/tests/linter/rules/documentation/variable_in_documentation/expected_extended.txt
@@ -1,0 +1,19 @@
+extended.robot:2:41 DOC05 Unescaped variable '${value}' in documentation
+   |
+ 1 | *** Settings ***
+ 2 | Documentation    Literal scalar example ${value}.
+   |                                         ^^^^^^^^ DOC05
+ 3 | ...              Escaped \${literal}; environment %{ENV}.
+   | Suggestion: If literal variable syntax is intended, escape it with a backslash.
+   |
+
+extended.robot:3:51 DOC05 Unescaped variable '%{ENV}' in documentation
+   |
+ 1 | *** Settings ***
+ 2 | Documentation    Literal scalar example ${value}.
+ 3 | ...              Escaped \${literal}; environment %{ENV}.
+   |                                                   ^^^^^^ DOC05
+   | Suggestion: If literal variable syntax is intended, escape it with a backslash.
+   |
+
+Found 2 issues.

--- a/tests/linter/rules/documentation/variable_in_documentation/expected_output.txt
+++ b/tests/linter/rules/documentation/variable_in_documentation/expected_output.txt
@@ -1,0 +1,20 @@
+test.robot:2:36 [I] DOC05 Unescaped variable '${SCALAR}' in documentation
+test.robot:2:60 [I] DOC05 Unescaped variable '${UNDEFINED}' in documentation
+test.robot:3:34 [I] DOC05 Unescaped variable '@{LIST}' in documentation
+test.robot:3:54 [I] DOC05 Unescaped variable '&{DICT}' in documentation
+test.robot:3:79 [I] DOC05 Unescaped variable '%{ROBOCOP_DOC_ENV}' in documentation
+test.robot:5:45 [I] DOC05 Unescaped variable '${message}' in documentation
+test.robot:14:31 [I] DOC05 Unescaped variable '${test scalar}' in documentation
+test.robot:15:29 [I] DOC05 Unescaped variable '@{test list}' in documentation
+test.robot:15:54 [I] DOC05 Unescaped variable '&{test dict}' in documentation
+test.robot:15:80 [I] DOC05 Unescaped variable '%{TEST_ENV}' in documentation
+test.robot:21:31 [I] DOC05 Unescaped variable '${keyword scalar}' in documentation
+test.robot:22:29 [I] DOC05 Unescaped variable '@{keyword list}' in documentation
+test.robot:22:57 [I] DOC05 Unescaped variable '&{keyword dict}' in documentation
+test.robot:22:86 [I] DOC05 Unescaped variable '%{KEYWORD_ENV}' in documentation
+test.robot:23:58 [I] DOC05 Unescaped variable '${example}' in documentation
+test.robot:23:70 [I] DOC05 Unescaped variable '@{example}' in documentation
+test.robot:23:82 [I] DOC05 Unescaped variable '&{example}' in documentation
+test.robot:23:94 [I] DOC05 Unescaped variable '%{EXAMPLE}' in documentation
+
+Found 18 issues.

--- a/tests/linter/rules/documentation/variable_in_documentation/expected_split.txt
+++ b/tests/linter/rules/documentation/variable_in_documentation/expected_split.txt
@@ -1,0 +1,12 @@
+split.robot:2:30:2:47 [I] DOC05 Unescaped variable '${cell    scalar}' in documentation
+split.robot:3:18:3:33 [I] DOC05 Unescaped variable '@{cell    list}' in documentation
+split.robot:4:24:4:45 [I] DOC05 Unescaped variable '&{cell    dictionary}' in documentation
+split.robot:5:25:5:39 [I] DOC05 Unescaped variable '%{CELL    ENV}' in documentation
+split.robot:6:19:7:15 [I] DOC05 Unescaped variable '${row\nscalar}' in documentation
+split.robot:8:17:9:13 [I] DOC05 Unescaped variable '@{row\nlist}' in documentation
+split.robot:10:23:11:19 [I] DOC05 Unescaped variable '&{row\ndictionary}' in documentation
+split.robot:12:24:13:12 [I] DOC05 Unescaped variable '%{ROW\nENV}' in documentation
+split.robot:26:35:26:42 [I] DOC05 Unescaped variable '${same}' in documentation
+split.robot:27:31:27:38 [I] DOC05 Unescaped variable '${same}' in documentation
+
+Found 10 issues.

--- a/tests/linter/rules/documentation/variable_in_documentation/expected_split_legacy.txt
+++ b/tests/linter/rules/documentation/variable_in_documentation/expected_split_legacy.txt
@@ -1,0 +1,12 @@
+split.robot:2:30:2:47 [I] DOC05 Unescaped variable '${cell scalar}' in documentation
+split.robot:3:18:3:33 [I] DOC05 Unescaped variable '@{cell list}' in documentation
+split.robot:4:24:4:45 [I] DOC05 Unescaped variable '&{cell dictionary}' in documentation
+split.robot:5:25:5:39 [I] DOC05 Unescaped variable '%{CELL ENV}' in documentation
+split.robot:6:19:7:15 [I] DOC05 Unescaped variable '${row\nscalar}' in documentation
+split.robot:8:17:9:13 [I] DOC05 Unescaped variable '@{row\nlist}' in documentation
+split.robot:10:23:11:19 [I] DOC05 Unescaped variable '&{row\ndictionary}' in documentation
+split.robot:12:24:13:12 [I] DOC05 Unescaped variable '%{ROW\nENV}' in documentation
+split.robot:26:35:26:42 [I] DOC05 Unescaped variable '${same}' in documentation
+split.robot:27:31:27:38 [I] DOC05 Unescaped variable '${same}' in documentation
+
+Found 10 issues.

--- a/tests/linter/rules/documentation/variable_in_documentation/extended.robot
+++ b/tests/linter/rules/documentation/variable_in_documentation/extended.robot
@@ -1,0 +1,3 @@
+*** Settings ***
+Documentation    Literal scalar example ${value}.
+...              Escaped \${literal}; environment %{ENV}.

--- a/tests/linter/rules/documentation/variable_in_documentation/split.robot
+++ b/tests/linter/rules/documentation/variable_in_documentation/split.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Documentation    Cell scalar ${cell    scalar}
+...    Cell list @{cell    list}
+...    Cell dictionary &{cell    dictionary}
+...    Cell environment %{CELL    ENV}
+...    Row scalar ${row
+...    scalar}
+...    Row list @{row
+...    list}
+...    Row dictionary &{row
+...    dictionary}
+...    Row environment %{ROW
+...    ENV}
+...    Escaped cell scalar \${escaped    scalar}
+...    Escaped cell list \@{escaped    list}
+...    Escaped cell dictionary \&{escaped    dictionary}
+...    Escaped cell environment \%{ESCAPED    ENV}
+...    Escaped row scalar \${escaped
+...    scalar}
+...    Escaped row list \@{escaped
+...    list}
+...    Escaped row dictionary \&{escaped
+...    dictionary}
+...    Escaped row environment \%{ESCAPED
+...    ENV}
+...    Removed continuation slash ${same}\
+...    Later identical prefix ${same}\inside

--- a/tests/linter/rules/documentation/variable_in_documentation/test.robot
+++ b/tests/linter/rules/documentation/variable_in_documentation/test.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Documentation       Defined scalar ${SCALAR} and undefined ${UNDEFINED}.
+...                 Defined list @{LIST}, dictionary &{DICT}, and environment %{ROBOCOP_DOC_ENV}.
+...                 Escaped literals \${SCALAR}, \@{LIST}, \&{DICT}, and \%{ROBOCOP_DOC_ENV}.
+...                 Literal example: Log    ${message}
+
+*** Variables ***
+${SCALAR}           value
+@{LIST}             first    second
+&{DICT}             key=value
+
+*** Test Cases ***
+Variable syntax in test documentation
+    [Documentation]    Scalar ${test scalar}.
+    ...                List @{test list}, dictionary &{test dict}, environment %{TEST_ENV}.
+    ...                Escaped \${test scalar}, \@{test list}, \&{test dict}, \%{TEST_ENV}.
+    No Operation
+
+*** Keywords ***
+Variable syntax in keyword documentation
+    [Documentation]    Scalar ${keyword scalar}.
+    ...                List @{keyword list}, dictionary &{keyword dict}, environment %{KEYWORD_ENV}.
+    ...                Literal examples remain findings: ${example}, @{example}, &{example}, %{EXAMPLE}.
+    ...                Escaped examples do not: \${example}, \@{example}, \&{example}, \%{EXAMPLE}.
+    No Operation

--- a/tests/linter/rules/documentation/variable_in_documentation/test_rule.py
+++ b/tests/linter/rules/documentation/variable_in_documentation/test_rule.py
@@ -1,0 +1,18 @@
+from robocop.linter.rules.documentation import VariableInDocumentationRule
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule_on_all_supported_versions(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5")
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["extended.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=5",
+        )
+
+    def test_disabled_by_default(self):
+        assert not VariableInDocumentationRule.enabled

--- a/tests/linter/rules/documentation/variable_in_documentation/test_rule.py
+++ b/tests/linter/rules/documentation/variable_in_documentation/test_rule.py
@@ -14,5 +14,22 @@ class TestRuleAcceptance(RuleAcceptance):
             test_on_version=">=5",
         )
 
-    def test_disabled_by_default(self):
+    def test_split_variables_with_legacy_joining(self):
+        self.check_rule(
+            src_files=["split.robot"],
+            expected_file="expected_split_legacy.txt",
+            issue_format="end_col",
+            test_on_version="<6.1",
+        )
+
+    def test_split_variables_with_modern_joining(self):
+        self.check_rule(
+            src_files=["split.robot"],
+            expected_file="expected_split.txt",
+            issue_format="end_col",
+            test_on_version=">=6.1",
+        )
+
+    def test_disabled_and_not_fixable(self):
         assert not VariableInDocumentationRule.enabled
+        assert not VariableInDocumentationRule.fixable


### PR DESCRIPTION
## Summary

- add opt-in `DOC05` (`variable-in-documentation`) diagnostics for unescaped `${...}`, `@{...}`, `&{...}`, and `%{...}` syntax
- inspect suite, test case, and user keyword documentation, including continuation lines, while ignoring escaped literals
- keep the rule disabled by default and non-fixable

## Robot Framework semantics researched

Experiments on Robot Framework 5.0.1, 6.0.2, 6.1.1, 7.0.1, 7.1.1, 7.2.2, 7.3.2, and 7.4.2 showed consistent behavior:

- defined scalar, list, dictionary, and environment variables are replaced in rendered suite/test/keyword documentation
- undefined variables remain unchanged because documentation replacement ignores resolution errors
- a leading backslash prevents replacement and is removed from rendered documentation

An automatic escaping fix is therefore unsafe: it would change intentionally dynamic documentation. The rule provides only a conditional suggestion for literal examples.

## Validation

- `uv run pytest tests/linter/rules/documentation/variable_in_documentation`
- RF 5.0.1 compatibility run for the new acceptance tests
- `uv run pytest tests/linter` (822 passed, 66 skipped)
- `uv run ruff check`
- `uv run ruff format --check`
- changed modules pass strict mypy; the repository-wide command retains seven pre-existing errors in `src/robocop/config/manager.py` and `src/robocop/formatter/formatters/OrderSettingsSection.py`

Closes #1060