### PR TITLE
feat(linter): check automatic variable availability

### DIFF
--- a/src/robocop/linter/checkers/automatic_variables.py
+++ b/src/robocop/linter/checkers/automatic_variables.py
@@ -1,0 +1,102 @@
+"""Checker for automatic variables with context-dependent availability."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from robot.api import Token
+
+from robocop.linter.rules import VisitorChecker, variables
+from robocop.linter.utils import misc as utils
+from robocop.parsing.variables import VariableMatches  # type: ignore[attr-defined]
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from robot.parsing.model.blocks import Keyword, TestCase
+    from robot.parsing.model.statements import Node, Statement
+    from robot.variables.search import VariableMatch
+
+
+class AutomaticVariablesChecker(VisitorChecker):
+    """Check automatic variable references in contexts known without resolving keyword calls."""
+
+    automatic_variable_not_available: variables.AutomaticVariableNotAvailableRule
+
+    def __init__(self) -> None:
+        self.execution_context = "suite context"
+        super().__init__()
+
+    def visit_File(self, node: Node) -> None:  # noqa: N802
+        self.execution_context = "suite context"
+        self.generic_visit(node)
+
+    def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802, ARG002
+        # The caller determines which automatic variables are available in a user keyword.
+        return
+
+    def visit_TestCase(self, node: TestCase) -> None:  # noqa: N802
+        self.visit_in_context(node, "test case body")
+
+    def visit_Setup(self, node: Node) -> None:  # noqa: N802
+        self.check_in_context(node, "test setup")
+
+    visit_TestSetup = visit_Setup  # noqa: N815
+
+    def visit_Teardown(self, node: Node) -> None:  # noqa: N802
+        self.check_in_context(node, "test teardown")
+
+    visit_TestTeardown = visit_Teardown  # noqa: N815
+
+    def visit_SuiteSetup(self, node: Node) -> None:  # noqa: N802
+        self.check_in_context(node, "suite setup")
+
+    def visit_SuiteTeardown(self, node: Node) -> None:  # noqa: N802
+        self.check_in_context(node, "suite teardown")
+
+    def visit_Statement(self, node: Statement) -> None:  # noqa: N802
+        self.check_statement(node)
+
+    def visit_in_context(self, node: Node, context: str) -> None:
+        previous_context = self.execution_context
+        self.execution_context = context
+        self.generic_visit(node)
+        self.execution_context = previous_context
+
+    def check_in_context(self, node: Node, context: str) -> None:
+        previous_context = self.execution_context
+        self.execution_context = context
+        self.check_statement(node)
+        self.execution_context = previous_context
+
+    def check_statement(self, node: Node) -> None:
+        for token in node.data_tokens:
+            if token.type in (Token.ASSIGN, Token.VARIABLE):
+                continue
+            for variable_match, offset in self.iter_variable_matches(token.value):
+                normalized_name = utils.normalize_robot_name(variable_match.base)
+                variable = f"{variable_match.identifier}{{{variable_match.base}}}"
+                self.automatic_variable_not_available.check(
+                    token=token,
+                    variable=variable,
+                    normalized_name=normalized_name,
+                    context=self.execution_context,
+                    offset=offset,
+                )
+
+    @classmethod
+    def iter_variable_matches(cls, value: str, offset: int = 0) -> Iterator[tuple[VariableMatch, int]]:
+        """Yield top-level and nested variable matches with offsets in the original token."""
+        consumed = 0
+        for variable_match in VariableMatches(value, ignore_errors=True):
+            match_offset = offset + consumed + variable_match.start
+            yield variable_match, match_offset
+            yield from cls.iter_variable_matches(variable_match.base, match_offset + 2)
+            item_start = len(variable_match.identifier) + len(variable_match.base) + 2
+            for item in variable_match.items:
+                item_start = variable_match.match.find(item, item_start)
+                if item_start == -1:
+                    continue
+                yield from cls.iter_variable_matches(item, match_offset + item_start)
+                item_start += len(item)
+            consumed += variable_match.end

--- a/src/robocop/linter/rules/variables.py
+++ b/src/robocop/linter/rules/variables.py
@@ -706,3 +706,89 @@ class DuplicatedAssignedVarNameRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.DISTINCT, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     deprecated_names = ("0812",)
+
+
+class AutomaticVariableNotAvailableRule(Rule):
+    """
+    Automatic variable used in a context where Robot Framework does not provide it.
+
+    Robot Framework has several automatic variables whose availability is limited to a specific execution context:
+
+    - ``${TEST NAME}``, ``@{TEST TAGS}``, and ``${TEST DOCUMENTATION}`` are available while a test is running.
+    - ``${TEST STATUS}`` and ``${TEST MESSAGE}`` are available only in a test teardown.
+    - ``${SUITE STATUS}`` and ``${SUITE MESSAGE}`` are available only in a suite teardown.
+    - ``${KEYWORD STATUS}`` and ``${KEYWORD MESSAGE}`` are available only in a user keyword teardown.
+
+    Using one of these variables directly in another context fails at runtime:
+
+        *** Test Cases ***
+        Invalid automatic variables
+            Log    ${KEYWORD STATUS}
+            Log    ${TEST STATUS}
+            [Teardown]    Log    ${SUITE STATUS}
+
+    Use each variable in the context where Robot Framework makes it available:
+
+        *** Settings ***
+        Suite Teardown    Log    ${SUITE STATUS}
+        Test Teardown     Log    ${TEST STATUS}
+
+        *** Test Cases ***
+        Valid automatic variables
+            Log    ${TEST NAME}
+
+        *** Keywords ***
+        Keyword with teardown
+            No Operation
+            [Teardown]    Log    ${KEYWORD STATUS}
+
+    Robocop deliberately does not report these variables inside user keyword definitions. A user keyword can be called
+    from a test, test teardown, suite teardown, or another user keyword teardown, so its actual execution context cannot
+    be determined reliably from the file where it is defined. For example, ``${TEST NAME}`` in a user keyword can be
+    valid when called by a test but invalid when called by a suite setup. This conservative behavior avoids presenting
+    call-context guesses as certain errors.
+
+    See the official
+    [automatic variable scope table](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#automatic-variables).
+    The rule has no automatic fix because choosing a replacement or moving code requires understanding its intent.
+
+    """
+
+    name = "automatic-variable-not-available"
+    rule_id = "VAR13"
+    message = "Automatic variable '{variable}' is not available in {context}; it is only available in {available_in}"
+    severity = RuleSeverity.WARNING
+    added_in_version = "9.0.0"
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.LOGICAL, issue_type=sonar_qube.SonarQubeIssueType.BUG
+    )
+
+    scopes = {
+        "testname": ("test case", frozenset({"test setup", "test case body", "test teardown"})),
+        "testtags": ("test case", frozenset({"test setup", "test case body", "test teardown"})),
+        "testdocumentation": ("test case", frozenset({"test setup", "test case body", "test teardown"})),
+        "teststatus": ("test teardown", frozenset({"test teardown"})),
+        "testmessage": ("test teardown", frozenset({"test teardown"})),
+        "suitestatus": ("suite teardown", frozenset({"suite teardown"})),
+        "suitemessage": ("suite teardown", frozenset({"suite teardown"})),
+        "keywordstatus": ("user keyword teardown", frozenset({"user keyword teardown"})),
+        "keywordmessage": ("user keyword teardown", frozenset({"user keyword teardown"})),
+    }
+
+    def check(self, token: Token, variable: str, normalized_name: str, context: str, offset: int) -> None:
+        scope = self.scopes.get(normalized_name)
+        if scope is None:
+            return
+        available_in, valid_contexts = scope
+        if context in valid_contexts:
+            return
+        col = token.col_offset + offset + 1
+        self.report(
+            variable=variable,
+            context=context,
+            available_in=available_in,
+            node=token,
+            lineno=token.lineno,
+            col=col,
+            end_col=col + len(variable),
+        )

--- a/tests/linter/rules/variables/automatic_variable_not_available/expected_extended.txt
+++ b/tests/linter/rules/variables/automatic_variable_not_available/expected_extended.txt
@@ -1,0 +1,17 @@
+extended.robot:3:19 VAR13 Automatic variable '${TEST STATUS}' is not available in test case body; it is only available in test teardown
+   |
+ 1 | *** Test Cases ***
+ 2 | Multiple And Nested Automatic Variables
+ 3 |     Log    status ${TEST STATUS} and prefix-${outer}[${KEYWORD MESSAGE}]-suffix
+   |                   ^^^^^^^^^^^^^^ VAR13
+   |
+
+extended.robot:3:54 VAR13 Automatic variable '${KEYWORD MESSAGE}' is not available in test case body; it is only available in user keyword teardown
+   |
+ 1 | *** Test Cases ***
+ 2 | Multiple And Nested Automatic Variables
+ 3 |     Log    status ${TEST STATUS} and prefix-${outer}[${KEYWORD MESSAGE}]-suffix
+   |                                                      ^^^^^^^^^^^^^^^^^^ VAR13
+   |
+
+Found 2 issues.

--- a/tests/linter/rules/variables/automatic_variable_not_available/expected_output.txt
+++ b/tests/linter/rules/variables/automatic_variable_not_available/expected_output.txt
@@ -1,0 +1,19 @@
+test.robot:2:32:2:44 [W] VAR13 Automatic variable '${TEST NAME}' is not available in suite setup; it is only available in test case
+test.robot:2:48:2:62 [W] VAR13 Automatic variable '${TEST STATUS}' is not available in suite setup; it is only available in test teardown
+test.robot:2:66:2:81 [W] VAR13 Automatic variable '${SUITE STATUS}' is not available in suite setup; it is only available in suite teardown
+test.robot:2:85:2:102 [W] VAR13 Automatic variable '${KEYWORD STATUS}' is not available in suite setup; it is only available in user keyword teardown
+test.robot:3:71:3:83 [W] VAR13 Automatic variable '${TEST NAME}' is not available in suite teardown; it is only available in test case
+test.robot:3:87:3:105 [W] VAR13 Automatic variable '${KEYWORD MESSAGE}' is not available in suite teardown; it is only available in user keyword teardown
+test.robot:4:89:4:103 [W] VAR13 Automatic variable '${TEST STATUS}' is not available in test setup; it is only available in test teardown
+test.robot:5:85:5:100 [W] VAR13 Automatic variable '${SUITE STATUS}' is not available in test teardown; it is only available in suite teardown
+test.robot:8:41:8:58 [W] VAR13 Automatic variable '${KEYWORD STATUS}' is not available in suite context; it is only available in user keyword teardown
+test.robot:13:44:13:58 [W] VAR13 Automatic variable '${TEST STATUS}' is not available in test setup; it is only available in test teardown
+test.robot:13:62:13:80 [W] VAR13 Automatic variable '${KEYWORD MESSAGE}' is not available in test setup; it is only available in user keyword teardown
+test.robot:14:84:14:100 [W] VAR13 Automatic variable '${SUITE MESSAGE}' is not available in test teardown; it is only available in suite teardown
+test.robot:16:17:16:31 [W] VAR13 Automatic variable '${TEST STATUS}' is not available in test case body; it is only available in test teardown
+test.robot:16:35:16:50 [W] VAR13 Automatic variable '${TEST MESSAGE}' is not available in test case body; it is only available in test teardown
+test.robot:16:54:16:69 [W] VAR13 Automatic variable '${SUITE STATUS}' is not available in test case body; it is only available in suite teardown
+test.robot:16:73:16:90 [W] VAR13 Automatic variable '${KEYWORD STATUS}' is not available in test case body; it is only available in user keyword teardown
+test.robot:17:28:17:46 [W] VAR13 Automatic variable '${KEYWORD MESSAGE}' is not available in test case body; it is only available in user keyword teardown
+
+Found 17 issues.

--- a/tests/linter/rules/variables/automatic_variable_not_available/extended.robot
+++ b/tests/linter/rules/variables/automatic_variable_not_available/extended.robot
@@ -1,0 +1,3 @@
+*** Test Cases ***
+Multiple And Nested Automatic Variables
+    Log    status ${TEST STATUS} and prefix-${outer}[${KEYWORD MESSAGE}]-suffix

--- a/tests/linter/rules/variables/automatic_variable_not_available/test.robot
+++ b/tests/linter/rules/variables/automatic_variable_not_available/test.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Suite Setup        Log Many    ${TEST NAME}    ${TEST STATUS}    ${SUITE STATUS}    ${KEYWORD STATUS}
+Suite Teardown     Log Many    ${SUITE STATUS}    ${SUITE MESSAGE}    ${TEST NAME}    ${KEYWORD MESSAGE}
+Test Setup         Log Many    ${TEST NAME}    @{TEST TAGS}    ${TEST DOCUMENTATION}    ${TEST STATUS}
+Test Teardown      Log Many    ${TEST NAME}    ${TEST STATUS}    ${TEST MESSAGE}    ${SUITE STATUS}
+
+*** Variables ***
+${NESTED_IN_VARIABLE}    value ${outer}[${KEYWORD STATUS}]
+${EVERYWHERE_VARIABLE}    ${SUITE NAME}
+
+*** Test Cases ***
+Automatic Variables In Test Body
+    [Setup]    Log Many    ${TEST NAME}    ${TEST STATUS}    ${KEYWORD MESSAGE}
+    [Teardown]    Log Many    ${TEST NAME}    ${TEST STATUS}    ${TEST MESSAGE}    ${SUITE MESSAGE}
+    Log Many    ${TEST NAME}    @{TEST TAGS}    ${TEST DOCUMENTATION}
+    Log Many    ${TEST STATUS}    ${TEST MESSAGE}    ${SUITE STATUS}    ${KEYWORD STATUS}
+    Log    prefix-${outer}[${KEYWORD MESSAGE}]-suffix
+    Log Many    ${PREV TEST STATUS}    ${SUITE NAME}    ${LOG LEVEL}
+
+*** Keywords ***
+Caller Dependent Automatic Variables
+    Log Many    ${TEST NAME}    ${TEST STATUS}    ${SUITE STATUS}    ${KEYWORD STATUS}
+    [Teardown]    Log Many    ${TEST NAME}    ${TEST STATUS}    ${SUITE STATUS}    ${KEYWORD STATUS}

--- a/tests/linter/rules/variables/automatic_variable_not_available/test_rule.py
+++ b/tests/linter/rules/variables/automatic_variable_not_available/test_rule.py
@@ -1,0 +1,9 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col")
+
+    def test_extended(self):
+        self.check_rule(src_files=["extended.robot"], expected_file="expected_extended.txt", output_format="extended")


### PR DESCRIPTION
## Summary

- add `VAR13` (`automatic-variable-not-available`) for automatic variables used in definitively invalid suite/test syntactic contexts
- follow Robot Framework's official scope table for test, test teardown, suite teardown, and user keyword teardown variables
- detect nested references and preserve exact diagnostic ranges when multiple variables occur in one token
- skip user keyword definitions conservatively because their runtime call context can make limited-scope variables valid
- document why neither a project advisory rule nor an automatic fix is included

## Validation

- acceptance tests on Robot Framework 5.0.1, 6.1.1, and 7.0.1
- all variable-rule tests
- Ruff check and format
- strict mypy for changed implementation files

Closes #1173