### PR TITLE
fix(linter): match library keywords with embedded arguments

### DIFF
--- a/src/robocop/project/__init__.py
+++ b/src/robocop/project/__init__.py
@@ -21,6 +21,7 @@ from robocop.project.definitions import (
     Location,
     ResolvedImport,
     VariableDefinition,
+    embedded_name_pattern,
     parse_embedded_arguments,
 )
 from robocop.project.imports import ImportResolver
@@ -45,5 +46,6 @@ __all__ = [
     "VariableDefinition",
     "VariableScope",
     "build_project_context",
+    "embedded_name_pattern",
     "parse_embedded_arguments",
 ]

--- a/src/robocop/project/collector.py
+++ b/src/robocop/project/collector.py
@@ -21,7 +21,7 @@ from robocop.project.definitions import (
     KeywordUsage,
     Location,
     VariableDefinition,
-    parse_embedded_arguments,
+    embedded_name_pattern,
 )
 
 if TYPE_CHECKING:
@@ -124,14 +124,14 @@ class ProjectFileCollector(ModelVisitor):  # type: ignore[misc]
     def visit_Keyword(self, node: Keyword) -> None:  # noqa: N802
         if not node.name:
             return
-        embedded = parse_embedded_arguments(node.name)
+        embedded = embedded_name_pattern(node.name)
         self.collected.keywords.append(
             KeywordDefinition(
                 name=node.name,
                 normalized_name=normalize_robot_name(node.name),
                 location=self._location(node.header, name_length=len(node.name)),
                 arguments=self._keyword_arguments(node),
-                embedded=embedded.name if embedded is not None else None,
+                embedded=embedded,
                 is_private=self._is_private(node),
             )
         )

--- a/src/robocop/project/definitions.py
+++ b/src/robocop/project/definitions.py
@@ -39,6 +39,18 @@ def parse_embedded_arguments(name: str) -> EmbeddedArguments | None:
     return None
 
 
+def embedded_name_pattern(name: str) -> re.Pattern[str] | None:
+    """
+    Build a pattern matching keyword names that can be called using keyword with embedded arguments.
+
+    Returns:
+        Compiled pattern, or None if the name does not contain embedded arguments.
+
+    """
+    embedded = parse_embedded_arguments(name)
+    return embedded.name if embedded is not None else None
+
+
 def usage_name_pattern(name: str) -> re.Pattern[str] | None:
     """
     Build a pattern matching keyword names that a dynamic call may refer to.

--- a/src/robocop/project/libraries.py
+++ b/src/robocop/project/libraries.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from robocop.linter.utils.misc import normalize_robot_name
-from robocop.project.definitions import ArgumentsSpec, KeywordDefinition, Location, parse_embedded_arguments
+from robocop.project.definitions import ArgumentsSpec, KeywordDefinition, Location, embedded_name_pattern
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -131,7 +131,7 @@ def _keyword_definition(data: dict[str, Any], library_name: str, fallback_source
             var_named=arguments.get("var_named"),
             named_only=tuple(arguments.get("named_only", ())),
         ),
-        embedded=parse_embedded_arguments(name),
+        embedded=embedded_name_pattern(name),
         library_name=library_name,
     )
 

--- a/tests/linter/rules/imports/unused_library_import/embedded/EmbeddedLibrary.py
+++ b/tests/linter/rules/imports/unused_library_import/embedded/EmbeddedLibrary.py
@@ -1,0 +1,6 @@
+from robot.api.deco import keyword
+
+
+@keyword("Add ${number} to ${other_number}")
+def add(number, other_number):
+    return int(number) + int(other_number)

--- a/tests/linter/rules/imports/unused_library_import/embedded/test.robot
+++ b/tests/linter/rules/imports/unused_library_import/embedded/test.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library    EmbeddedLibrary.py
+
+*** Test Cases ***
+Test
+    Add 1 to 2

--- a/tests/linter/rules/imports/unused_library_import/test_rule.py
+++ b/tests/linter/rules/imports/unused_library_import/test_rule.py
@@ -23,3 +23,12 @@ class TestRuleAcceptance(RuleAcceptance):
             ignored_library=["OperatingSystem", "DateTime"],
             exit_code=0,
         )
+
+    def test_library_keywords_with_embedded_arguments(self):
+        self.check_rule(
+            src_files=["."],
+            expected_file=None,
+            test_dir=self.test_class_dir / "embedded",
+            project_check=True,
+            exit_code=0,
+        )


### PR DESCRIPTION
Running project-level checks on a project that imports a library with embedded-argument keywords crashed with `AttributeError: 'EmbeddedArguments' object has no attribute 'fullmatch'`.

`KeywordDefinition.embedded` is declared as a compiled `re.Pattern`, and both `KeywordDefinition.matches()` and the cache serialization rely on that. The file collector stored `EmbeddedArguments.name` (the pattern) correctly, but the library loader stored the raw `EmbeddedArguments` object, so any library keyword with embedded arguments blew up as soon as `unused-library-import` looked it up (and would also have broken cache serialization, which reads `.pattern` / `.flags`).

Fix: added a small `embedded_name_pattern()` helper in `robocop/project/definitions.py` that returns the compiled pattern, and use it in both the collector and the library loader so there is a single source of truth.

Regression test: `tests/linter/rules/imports/unused_library_import/embedded/` adds a Python library exposing `Add ${number} to ${other_number}` plus a suite that calls it. The new test runs the project check over that directory and expects no issues; it fails with the original `AttributeError` without the fix.