### PR TITLE
feat(linter): load libraries in process unless --library-workers is used

### DIFF
--- a/docs/configuration/configuration_reference.md
+++ b/docs/configuration/configuration_reference.md
@@ -476,8 +476,8 @@ The project context is always built from the project root, even if only selected
 
 ``robocop check`` imports Robot Framework libraries to find out what keywords they provide and what
 arguments those keywords accept. **Importing a library executes its code**, which is why it only happens when
-project level rules are enabled. Every library is imported once, in a separate process with a timeout, and any
-failure is silently ignored - a library that cannot be imported simply provides no keywords.
+project level rules are enabled. Every library is imported once and any failure is silently ignored - a library
+that cannot be imported simply provides no keywords.
 
 Use ``--no-analyze-libraries`` to disable it completely:
 
@@ -496,9 +496,35 @@ Use ``--no-analyze-libraries`` to disable it completely:
 
 ---
 
+#### ``library-workers``
+
+By default libraries are imported synchronously, directly in the Robocop process. It is the fastest option, but
+Robocop cannot stop a library that never finishes importing.
+
+Use ``--library-workers`` to import every library in a separate process instead. Several libraries are then
+imported at the same time and every import is stopped after
+[load-library-timeout](#load-library-timeout) seconds. It is useful for projects with libraries that hang or
+crash the interpreter on import.
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --library-workers
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop]
+    library-workers = true
+    ```
+
+---
+
 #### ``load-library-timeout``
 
-Maximum time in seconds for importing a single library. Default is ``10``.
+Maximum time in seconds for importing a single library. Default is ``10``. Only used together with
+[library-workers](#library-workers), since a library imported in the Robocop process cannot be interrupted.
 
 === ":octicons-command-palette-24: cli"
 

--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -118,9 +118,9 @@ robocop check --no-project
 
     To find out what keywords libraries provide, Robocop imports them. Python variable files provided with the
     ``--variablefile`` option are imported as well. Both **execute the code** of the imported file. Libraries are
-    imported in a separate process with a timeout, and failures are ignored, so a broken library never breaks the
+    imported directly in the Robocop process, and failures are ignored, so a broken library never breaks the
     analysis. Library analysis can be disabled with ``--no-analyze-libraries`` and single libraries can be skipped
-    with ``--ignored-library``.
+    with ``--ignored-library``. Use ``--library-workers`` to import libraries in separate processes with a timeout.
 
 Keywords of the successfully imported libraries are stored in the [cache](../user_guide/intro.md#caching), so the
 next run does not have to import them again.
@@ -176,15 +176,23 @@ See [variables](../configuration/configuration_reference.md#variables),
 [variable-files](../configuration/configuration_reference.md#variable-files) and
 [python-path](../configuration/configuration_reference.md#python-path) for more details.
 
-Libraries are imported to check the keywords they provide. Every library is imported only once, in a separate
-process which is stopped if it takes longer than ``--load-library-timeout`` seconds (10 by default):
+Libraries are imported to check the keywords they provide. Every library is imported only once, by default
+synchronously in the Robocop process:
 
 ```bash
 robocop check --no-analyze-libraries
-robocop check --ignored-library SeleniumLibrary --load-library-timeout 30
+robocop check --ignored-library SeleniumLibrary
+```
+
+With ``--library-workers`` libraries are imported in parallel, each in a separate process which is stopped if it
+takes longer than ``--load-library-timeout`` seconds (10 by default):
+
+```bash
+robocop check --library-workers --load-library-timeout 30
 ```
 
 See [analyze-libraries](../configuration/configuration_reference.md#analyze-libraries),
+[library-workers](../configuration/configuration_reference.md#library-workers),
 [load-library-timeout](../configuration/configuration_reference.md#load-library-timeout) and
 [ignored-libraries](../configuration/configuration_reference.md#ignored-libraries) for more details.
 

--- a/src/robocop/config/builder.py
+++ b/src/robocop/config/builder.py
@@ -95,6 +95,7 @@ class ConfigBuilder:
         project = resolve(cli_raw, file_raw, "project", defaults.PROJECT)
         analyze_libraries = resolve(cli_raw, file_raw, "analyze_libraries", defaults.ANALYZE_LIBRARIES)
         load_library_timeout = resolve(cli_raw, file_raw, "load_library_timeout", defaults.LOAD_LIBRARY_TIMEOUT)
+        library_workers = resolve(cli_raw, file_raw, "library_workers", defaults.LIBRARY_WORKERS)
         ignored_libraries: list[str] = merge_lists(file_raw, cli_raw, "ignored_libraries")
         force_exclude = resolve(cli_raw, file_raw, "force_exclude", defaults.FORCE_EXCLUDE)
         verbose = resolve(cli_raw, file_raw, "verbose", defaults.VERBOSE)
@@ -147,6 +148,7 @@ class ConfigBuilder:
             project=project,
             analyze_libraries=analyze_libraries,
             load_library_timeout=load_library_timeout,
+            library_workers=library_workers,
             ignored_libraries=ignored_libraries,
             force_exclude=force_exclude,
             verbose=verbose,

--- a/src/robocop/config/defaults.py
+++ b/src/robocop/config/defaults.py
@@ -33,6 +33,7 @@ SILENT = False
 PROJECT: bool | None = None  # None: run project checks only if any project rule is enabled
 ANALYZE_LIBRARIES = True
 LOAD_LIBRARY_TIMEOUT = 10
+LIBRARY_WORKERS = False
 
 # cache
 

--- a/src/robocop/config/schema.py
+++ b/src/robocop/config/schema.py
@@ -323,6 +323,7 @@ class RawConfig:
     project: bool | None = None
     analyze_libraries: bool | None = None
     load_library_timeout: int | None = None
+    library_workers: bool | None = None
     ignored_libraries: list[str] | None = None
     force_exclude: bool | None = None
     verbose: bool | None = None
@@ -346,6 +347,7 @@ class RawConfig:
             "project",
             "analyze_libraries",
             "load_library_timeout",
+            "library_workers",
             "ignored_libraries",
             "force_exclude",
             "verbose",
@@ -394,6 +396,7 @@ class Config:
     project: bool | None
     analyze_libraries: bool
     load_library_timeout: int
+    library_workers: bool
     ignored_libraries: list[str]
     force_exclude: bool
     verbose: bool
@@ -424,6 +427,7 @@ class Config:
             and self.project == other.project
             and self.analyze_libraries == other.analyze_libraries
             and self.load_library_timeout == other.load_library_timeout
+            and self.library_workers == other.library_workers
             and self.ignored_libraries == other.ignored_libraries
             and self.verbose == other.verbose
             and self.silent == other.silent

--- a/src/robocop/project/_libdoc_worker.py
+++ b/src/robocop/project/_libdoc_worker.py
@@ -1,11 +1,12 @@
 """
-Worker process used to import Robot Framework libraries and read their keywords.
+Worker used to import Robot Framework libraries and read their keywords.
 
 Importing a library executes user code, which can be slow, can fail in unexpected ways or can even never finish.
-Because of that the import always happens in a separate process started with
-``python -m robocop.project._libdoc_worker`` and communicating with Robocop over JSON. The request is read from the
-standard input and the response is written to the file provided in the request, so that anything the library prints
-during the import does not corrupt the response. The parent process can safely kill this process on timeout.
+By default Robocop calls :func:`load_library` directly, but with the ``--library-workers`` option the import happens
+in a separate process started with ``python -m robocop.project._libdoc_worker`` and communicating with Robocop over
+JSON. The request is read from the standard input and the response is written to the file provided in the request,
+so that anything the library prints during the import does not corrupt the response. The parent process can safely
+kill this process on timeout.
 
 The module does not import Robocop, so that it can be started even if the inspected library modifies ``sys.path``.
 """

--- a/src/robocop/project/context.py
+++ b/src/robocop/project/context.py
@@ -376,6 +376,7 @@ def build_project_context(config_manager: ConfigManager, silent: bool = False) -
             ignored_libraries=config.ignored_libraries,
             cache=cache,
             project_root=config_manager.root,
+            workers=config.library_workers,
         )
     global_scope = VariableScope()
     global_scope.add_variable_files(config.variable_files, search_paths)
@@ -403,4 +404,28 @@ def build_project_context(config_manager: ConfigManager, silent: bool = False) -
         for keyword in project_file.keywords:
             context.keywords.add(keyword)
 
+    if context.library_loader is not None:
+        context.library_loader.schedule_preload(_project_library_requests(context))
+
     return context
+
+
+def _project_library_requests(context: ProjectContext) -> Iterator[LibraryRequest]:
+    """
+    Collect every library imported in the project.
+
+    Yields:
+        LibraryRequest for the BuiltIn library and for every resolved library import.
+
+    """
+    yield BUILTIN_LIBRARY
+    for project_file in context.files.values():
+        for imported in project_file.library_imports():
+            if imported.status not in (ImportStatus.RESOLVED, ImportStatus.EXTERNAL) or not imported.args_resolved:
+                continue
+            yield LibraryRequest(
+                name=imported.resolved_name,
+                args=imported.args,
+                source=imported.path,
+                alias=imported.alias,
+            )

--- a/src/robocop/project/libraries.py
+++ b/src/robocop/project/libraries.py
@@ -2,8 +2,13 @@
 Importing Robot Framework libraries to find out what keywords they provide.
 
 Unlike the rest of the project analysis, which is based purely on the abstract syntax tree, loading a library
-**executes the library code**. That is why it only happens when project level rules are enabled, always in a
-separate process with a timeout, and can be disabled with the ``--no-analyze-libraries`` option.
+**executes the library code**. That is why it only happens when project level rules are enabled and can be disabled
+with the ``--no-analyze-libraries`` option.
+
+By default libraries are imported synchronously, in the Robocop process itself. With the ``--library-workers``
+option every library is instead imported in a separate process, several of them at the same time. Separate
+processes are slower to start, but they can be killed on timeout and they keep the imported code out of the
+Robocop process.
 
 Libraries that fail to import are not reported as an internal error. Such library simply provides no keywords, so
 rules using this information stay silent instead of reporting false positives.
@@ -11,11 +16,14 @@ rules using this information stay silent instead of reporting false positives.
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stdout
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from functools import cache
@@ -34,6 +42,8 @@ if TYPE_CHECKING:
 
 WORKER_MODULE = "robocop.project._libdoc_worker"
 DEFAULT_TIMEOUT = 10
+DEFAULT_LIBRARY_WORKERS = False
+MAX_WORKERS = 8
 
 
 def worker_environment() -> dict[str, str]:
@@ -139,10 +149,14 @@ def _keyword_definition(data: dict[str, Any], library_name: str, fallback_source
 @dataclass
 class LibraryLoader:
     """
-    Imports libraries in a separate process and caches the results.
+    Imports libraries and caches the results.
 
     Every library is imported only once, even if it is used in several files. Libraries imported with different
     arguments are treated as different libraries, since the arguments may change the provided keywords.
+
+    By default libraries are imported synchronously, in the Robocop process. With ``workers`` enabled every library
+    is imported in a separate process instead and libraries are imported in parallel. Only such imports can be
+    stopped with the timeout, since a library imported in the Robocop process cannot be safely interrupted.
 
     Successful imports are also stored in the persistent Robocop cache, so that the library does not have to be
     imported again in the next run. Cached results are only used for libraries installed outside of the analyzed
@@ -155,7 +169,9 @@ class LibraryLoader:
     ignored_libraries: list[str] = field(default_factory=list)
     cache: RobocopCache | None = None
     project_root: Path | None = None
+    workers: bool = DEFAULT_LIBRARY_WORKERS
     _cache: dict[tuple[str, tuple[str, ...]], LibrarySpec] = field(default_factory=dict, init=False)
+    _scheduled: list[LibraryRequest] = field(default_factory=list, init=False)
 
     def load(self, request: LibraryRequest) -> LibrarySpec:
         """
@@ -166,11 +182,42 @@ class LibraryLoader:
 
         """
         cached = self._cache.get(request.cache_key)
+        if cached is None:
+            self._preload_scheduled()
+            cached = self._cache.get(request.cache_key)
         if cached is not None:
             return self._with_name(cached, request.displayed_name)
         spec = self._load(request)
         self._cache[request.cache_key] = spec
         return self._with_name(spec, request.displayed_name)
+
+    def schedule_preload(self, requests: Iterable[LibraryRequest]) -> None:
+        """
+        Remember libraries used in the project, so that they can be imported in parallel.
+
+        Nothing is imported here. The libraries are imported together, in parallel, when the first library is
+        needed. With the default, synchronous loading this method does nothing and every library is imported
+        separately when it is used for the first time.
+        """
+        if not self.workers:
+            return
+        self._scheduled.extend(requests)
+
+    def _preload_scheduled(self) -> None:
+        """Import all scheduled libraries at once, using a pool of worker processes."""
+        if not self._scheduled:
+            return
+        pending: dict[tuple[str, tuple[str, ...]], LibraryRequest] = {}
+        for request in self._scheduled:
+            if request.cache_key not in self._cache and request.cache_key not in pending:
+                pending[request.cache_key] = request
+        self._scheduled = []
+        if len(pending) < 2:  # a single library does not benefit from the worker pool
+            return
+        with ThreadPoolExecutor(max_workers=min(MAX_WORKERS, len(pending))) as executor:
+            specs = executor.map(self._load, pending.values())
+            for cache_key, spec in zip(pending, specs, strict=False):
+                self._cache.setdefault(cache_key, spec)
 
     def load_import(self, resolved: ResolvedImport) -> LibrarySpec | None:
         """
@@ -219,7 +266,7 @@ class LibraryLoader:
 
     def _load(self, request: LibraryRequest) -> LibrarySpec:
         """
-        Import the library in a separate process.
+        Import the library and read its keywords.
 
         Returns:
             LibrarySpec with the library keywords, or with the error if it could not be imported.
@@ -249,7 +296,7 @@ class LibraryLoader:
             cached = self.cache.get_library_entry(cache_key, environment_hash())
             if cached is not None:
                 return cached
-        response = self._run_worker(request)
+        response = self._run_worker(request) if self.workers else self._import_in_process(request)
         if self.cache is not None and response.get("status") == "ok":
             source = response.get("source")
             if source and self._can_be_cached(Path(source)):
@@ -273,6 +320,66 @@ class LibraryLoader:
             return True
         return self.project_root.resolve() not in source.resolve().parents
 
+    def _worker_request(self, request: LibraryRequest) -> dict[str, Any]:
+        """
+        Build the request describing the library import.
+
+        Returns:
+            Request understood by the library import worker.
+
+        """
+        return {
+            "name": str(request.source) if request.source else request.name,
+            "args": list(request.args),
+            "search_paths": [str(path) for path in self.search_paths],
+        }
+
+    def _import_in_process(self, request: LibraryRequest) -> dict[str, Any]:
+        """
+        Import the library in the Robocop process.
+
+        This is the default way of importing libraries, since starting a process for every library is slow.
+        Anything the library prints during the import is discarded, so that it does not corrupt the Robocop
+        output. The import cannot be stopped, so the timeout does not apply here.
+
+        Returns:
+            Response describing the library keywords or the failure.
+
+        """
+        from robocop.project._libdoc_worker import load_library  # noqa: PLC0415
+
+        already_imported = set(sys.modules)
+        try:
+            with redirect_stdout(io.StringIO()):
+                return load_library(self._worker_request(request))
+        finally:
+            self._forget_local_modules(already_imported, request)
+
+    def _forget_local_modules(self, already_imported: set[str], request: LibraryRequest) -> None:
+        """
+        Remove modules imported from the project and the search paths from ``sys.modules``.
+
+        Libraries installed in the environment are left imported, since they do not change while Robocop runs.
+        Libraries coming from the analyzed project may be modified between the runs, which matters when Robocop
+        is used from a long living process such as the MCP server, and different libraries may even share the
+        module name. Such modules are removed, so that they are read from the disk again next time.
+        """
+        local_paths = [
+            path.resolve()
+            for path in (*self.search_paths, self.project_root, request.source.parent if request.source else None)
+            if path is not None
+        ]
+        if not local_paths:
+            return
+        for name in set(sys.modules) - already_imported:
+            module = sys.modules.get(name)
+            source = getattr(module, "__file__", None)
+            if not source:
+                continue
+            parents = Path(source).resolve().parents
+            if any(local_path in parents for local_path in local_paths):
+                sys.modules.pop(name, None)
+
     def _run_worker(self, request: LibraryRequest) -> dict[str, Any]:
         """
         Run the worker process importing the library.
@@ -281,17 +388,9 @@ class LibraryLoader:
             Response from the worker, or an error description if the worker failed or timed out.
 
         """
-        name = str(request.source) if request.source else request.name
         with tempfile.TemporaryDirectory(prefix="robocop_libdoc_") as directory:
             output = Path(directory) / "response.json"
-            payload = json.dumps(
-                {
-                    "name": name,
-                    "args": list(request.args),
-                    "search_paths": [str(path) for path in self.search_paths],
-                    "output": str(output),
-                }
-            )
+            payload = json.dumps({**self._worker_request(request), "output": str(output)})
             try:
                 subprocess.run(  # noqa: S603
                     [sys.executable, "-m", WORKER_MODULE],
@@ -368,6 +467,7 @@ def build_library_loader(
     ignored_libraries: Iterable[str] | None = None,
     cache: RobocopCache | None = None,
     project_root: Path | None = None,
+    workers: bool = DEFAULT_LIBRARY_WORKERS,
 ) -> LibraryLoader:
     """
     Create the loader used to import libraries during the project analysis.
@@ -382,4 +482,5 @@ def build_library_loader(
         ignored_libraries=list(ignored_libraries or []),
         cache=cache,
         project_root=project_root,
+        workers=workers,
     )

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -203,7 +203,16 @@ load_library_timeout_option = Annotated[
         "--load-library-timeout",
         show_default="10",
         metavar="SECONDS",
-        help="Maximum time for importing a single library.",
+        help="Maximum time for importing a single library. Only used together with --library-workers.",
+        rich_help_panel="Project analysis",
+    ),
+]
+library_workers_option = Annotated[
+    bool | None,
+    typer.Option(
+        "--library-workers/--no-library-workers",
+        show_default="--no-library-workers",
+        help="Import libraries in parallel, in separate processes with a timeout, instead of in Robocop itself.",
         rich_help_panel="Project analysis",
     ),
 ]
@@ -445,6 +454,7 @@ def check_files(
     project: project_option = None,
     analyze_libraries: analyze_libraries_option = None,
     load_library_timeout: load_library_timeout_option = None,
+    library_workers: library_workers_option = None,
     ignored_library: ignored_libraries_option = None,
     verbose: verbose_option = None,
     silent: silent_option = None,
@@ -497,6 +507,7 @@ def check_files(
         project=project,
         analyze_libraries=analyze_libraries,
         load_library_timeout=load_library_timeout,
+        library_workers=library_workers,
         ignored_libraries=ignored_library,
         silent=silent,
         verbose=verbose,

--- a/tests/project/test_libraries.py
+++ b/tests/project/test_libraries.py
@@ -87,10 +87,48 @@ class TestLibraryLoader:
         assert spec.keywords == ()
 
     def test_import_timeout(self, library_dir):
-        loader = LibraryLoader(timeout=2)
+        loader = LibraryLoader(timeout=2, workers=True)
         spec = loader.load(LibraryRequest(name="SlowLibrary", source=library_dir / "SlowLibrary.py"))
         assert not spec.loaded
         assert "timed out" in spec.error
+
+    def test_libraries_are_imported_in_process_by_default(self, library_dir, monkeypatch):
+        loader = build_library_loader(search_paths=[library_dir])
+        monkeypatch.setattr(
+            LibraryLoader,
+            "_run_worker",
+            lambda *args, **kwargs: pytest.fail("Library should be imported without a separate process"),  # noqa: ARG005
+        )
+        assert keyword_names(loader.load(LibraryRequest(name="MyLibrary"))) == ["Custom Keyword"]
+
+    def test_workers_import_library_in_separate_process(self, library_dir, monkeypatch):
+        loader = build_library_loader(search_paths=[library_dir], workers=True)
+        monkeypatch.setattr(
+            LibraryLoader,
+            "_import_in_process",
+            lambda *args, **kwargs: pytest.fail("Library should be imported in a separate process"),  # noqa: ARG005
+        )
+        assert keyword_names(loader.load(LibraryRequest(name="MyLibrary"))) == ["Custom Keyword"]
+
+    def test_library_printing_on_import_does_not_write_to_output(self, library_dir, capsys):
+        (library_dir / "NoisyLibrary.py").write_text("print('noise')\n\n\ndef noisy_keyword():\n    pass\n")
+        loader = build_library_loader(search_paths=[library_dir])
+        assert loader.load(LibraryRequest(name="NoisyLibrary")).loaded
+        assert "noise" not in capsys.readouterr().out
+
+    def test_scheduled_libraries_are_imported_in_parallel(self, library_dir):
+        loader = build_library_loader(search_paths=[library_dir], workers=True)
+        requests = [LibraryRequest(name="MyLibrary"), LibraryRequest(name="ArgLibrary"), LibraryRequest(name="BuiltIn")]
+        loader.schedule_preload(requests)
+        assert keyword_names(loader.load(requests[0])) == ["Custom Keyword"]
+        assert all(request.cache_key in loader._cache for request in requests)  # noqa: SLF001
+
+    def test_scheduled_libraries_are_not_imported_without_workers(self, library_dir):
+        loader = build_library_loader(search_paths=[library_dir])
+        requests = [LibraryRequest(name="MyLibrary"), LibraryRequest(name="ArgLibrary")]
+        loader.schedule_preload(requests)
+        assert keyword_names(loader.load(requests[0])) == ["Custom Keyword"]
+        assert requests[1].cache_key not in loader._cache  # noqa: SLF001
 
     def test_ignored_library(self, library_dir):
         loader = build_library_loader(search_paths=[library_dir], ignored_libraries=["My*"])
@@ -172,6 +210,17 @@ class TestLibrariesInProjectContext:
         context = build_context(project)
         assert context.visible_keywords(project / "test.robot").find("Own Keyword")
 
+    def test_libraries_are_not_loaded_with_workers_by_default(self, project):
+        context = build_context(project)
+        assert not context.library_loader.workers
+
+    def test_library_keywords_are_visible_with_workers(self, project):
+        context = build_context(project, library_workers=True)
+        assert context.library_loader.workers
+        assert context.visible_keywords(project / "test.robot").find("Custom Keyword")
+        assert context.visible_keywords(project / "test.robot").find("Append To List")
+        assert context.visible_keywords(project / "test.robot").find("Log")
+
 
 class TestPersistentLibraryCache:
     def test_library_is_read_from_cache_in_next_run(self, library_dir, tmp_path, monkeypatch):
@@ -182,11 +231,12 @@ class TestPersistentLibraryCache:
 
         next_cache = RobocopCache(cache_dir=tmp_path / "cache", enabled=True, verbose=False)
         next_loader = build_library_loader(search_paths=[library_dir], cache=next_cache)
-        monkeypatch.setattr(
-            LibraryLoader,
-            "_run_worker",
-            lambda *args, **kwargs: pytest.fail("Library should be read from the cache"),  # noqa: ARG005
-        )
+        for method in ("_run_worker", "_import_in_process"):
+            monkeypatch.setattr(
+                LibraryLoader,
+                method,
+                lambda *args, **kwargs: pytest.fail("Library should be read from the cache"),  # noqa: ARG005
+            )
         assert keyword_names(next_loader.load(LibraryRequest(name="MyLibrary"))) == ["Custom Keyword"]
 
     def test_modified_library_is_imported_again(self, library_dir, tmp_path):


### PR DESCRIPTION
## Why

Library analysis imported every library in its own subprocess. Starting a fresh interpreter per library dominates the run time, even for small projects: in our own test suite the library tests dropped from ~31s to ~5s once the subprocess was removed. Most users do not have libraries that hang on import, so paying that cost by default is not worth it.

## What changed

Libraries are now imported synchronously, in the Robocop process, by default. The old behaviour is opt in via a new `--library-workers` / `--no-library-workers` flag (TOML: `library-workers`), and it now also imports libraries **in parallel** instead of one after another.

- `LibraryLoader` gained a `workers` flag and dispatches to either `_import_in_process` (default) or the existing `_run_worker` subprocess path.
- With workers enabled, `build_project_context` schedules all resolved library imports on the loader. They are imported as one parallel batch (max 8 threads) the first time any library is actually needed, so nothing is imported when no rule asks for library keywords.
- `--load-library-timeout` now only applies with `--library-workers`, since an in process import cannot be interrupted. Documented and reflected in the CLI help.

## Non-obvious bits worth a look

Two hazards come with importing in the Robocop process, both handled:

- **Library output.** Anything a library prints on import is swallowed via `redirect_stdout`, so it cannot corrupt Robocop's own output (reports, JSON, etc.).
- **Stale modules.** Python caches imported modules in `sys.modules`. After an in process import, modules whose source lives under the project root, the search paths, or the imported library's directory are removed again. Libraries installed in the environment stay cached, since they do not change while Robocop runs. Without this, a long living process (MCP server) would keep serving keywords from a library that has since been edited, and two libraries sharing a module name could collide.

## Testing

- Full suite passes (2157 passed, 77 skipped), ruff and mypy clean.
- New tests cover: default path does not spawn a process, `--library-workers` does not import in process, library prints do not reach stdout, scheduled libraries are preloaded only with workers, and the project context wiring for both modes. The timeout test now runs with workers, since that is the only mode with a timeout.
- Verified manually that `robocop check --select PROJECT` produces identical output with and without `--library-workers`.