### PR TITLE
docs: document branch, commit and PR naming conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,6 +105,27 @@ Docs are mkdocs (material theme) under `docs/`, partly generated from rule docst
 the relevant doc: formatters at `docs/formatter/formatters/<name>.md`, custom-rule docs at
 `docs/linter/custom_rules.md`, rule docs via the docstring.
 
+### Branch, commit and PR naming
+Everything is keyed off a Conventional Commits type. Allowed types (enforced by
+`.github/workflows/pr-title.yml`): `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`,
+`chore`, `revert`.
+
+Pick the type that matches the change, then use it consistently:
+
+| Artifact | Format | Example |
+| --- | --- | --- |
+| Branch | `<type>/short-description` (kebab-case after the slash) | `feat/add-ignored-sections-param` |
+| Commit | `<type>: description` | `feat: add ignored sections parameter` |
+| PR title | `<type>: description` | `feat: add ignored sections parameter` |
+
+Rules:
+- Description is lowercase, imperative mood, no trailing period.
+- Branch name uses `/` after the type and `-` between words; do not use `_` or spaces. The words after the slash
+  should mirror the commit/PR description, so `feat: add ignored sections param` → `feat/add-ignored-sections-param`.
+- Scopes are optional (`feat(linter): ...`); never required.
+- Breaking changes use `<type>!: description` or a `BREAKING CHANGE:` footer.
+- Keep branch, commits and PR title on the same type so the generated changelog matches the branch.
+
 ### Releases
 Versioning/changelog is automated via release-please (`release-please-config.json`, `.release-please-manifest.json`).
 Follow Conventional Commits — PR titles are validated by `.github/workflows/pr-title.yml`. Version lives in


### PR DESCRIPTION
Branch names in this repo have drifted into three different styles (`fix-var13-shadowing`, `feat/fixable_rules`, `deprecated_robocop`), which makes it hard for both contributors and AI agents to guess the right name. The `pr-title.yml` workflow already enforces Conventional Commits on PR titles, but nothing documented how that type should carry through to the branch and the commits.

This adds a "Branch, commit and PR naming" section to `.github/copilot-instructions.md` that pins all three artifacts to the same Conventional Commits type:

- Lists the 11 allowed types, sourced directly from `.github/workflows/pr-title.yml` so the doc and the CI check cannot disagree.
- A table mapping the type to each artifact: branch `feat/add-ignored-sections-param`, commit `feat: add ignored sections parameter`, PR title `feat: add ignored sections parameter`.
- Rules for casing, imperative mood, optional scopes, and breaking changes.

Branches use kebab-case rather than snake_case so the words after the slash mirror the commit and PR title exactly, which makes the branch derivable from the PR title and matches what GitHub tooling generates by default.

Docs only, no code or behavior changes.