### PR TITLE
feat(linter): exclude project rules from ALL selection

### DIFF
--- a/docs/configuration/configuration_reference.md
+++ b/docs/configuration/configuration_reference.md
@@ -622,7 +622,8 @@ To only select and run rules with ``doc`` in their name:
     ]
     ```
 
-Use ``ALL`` keyword to select all rules (including rules disabled by default). You can combine it with ``--ignore``
+Use ``ALL`` keyword to select all rules (including rules disabled by default, but excluding
+[project level rules](../linter/linter.md#project-checks)). You can combine it with ``--ignore``
 option to select all rules except those you want to ignore:
 
 === ":octicons-command-palette-24: cli"
@@ -641,12 +642,14 @@ option to select all rules except those you want to ignore:
     ```
 
 Use ``PROJECT`` keyword to select all [project level rules](../linter/linter.md#project-checks). It works with
-``--select``, ``--extend-select`` and ``--ignore``:
+``--select``, ``--extend-select`` and ``--ignore``. Project level rules are not selected by ``ALL``, so use
+``PROJECT`` to run them together with every other rule:
 
 === ":octicons-command-palette-24: cli"
 
     ```bash
     robocop check --extend-select PROJECT
+    robocop check --select ALL --extend-select PROJECT
     ```
 
 === ":material-file-cog-outline: toml"

--- a/docs/linter/linter.md
+++ b/docs/linter/linter.md
@@ -152,10 +152,11 @@ All of them can be enabled at once with the special ``PROJECT`` value, which can
 ```bash
 robocop check --select PROJECT  # run only the project level rules
 robocop check --extend-select PROJECT  # run the default rules and all project level rules
-robocop check --select ALL --ignore PROJECT  # run every rule except the project level ones
+robocop check --select ALL --extend-select PROJECT  # run every rule, including the project level ones
 ```
 
-``--select ALL`` enables the project rules as well, since it selects every rule.
+``--select ALL`` does not enable the project rules. Since they are slower and require the whole project to be
+parsed, they have to be selected explicitly - either by name, or with the ``PROJECT`` value.
 
 Import paths often contain variables. Provide them with the ``--variable`` or ``--variablefile`` option so that the
 imports can be resolved:

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -41,7 +41,7 @@ class RulePattern(NamedTuple):
 
 
 ALL_RULES = "ALL"
-"""Special value of ``--select`` that matches every rule."""
+"""Special value of ``--select`` that matches every rule except the project level ones."""
 
 PROJECT_RULES = "PROJECT"
 """Special value of the rule filters that matches every project level rule."""
@@ -128,7 +128,8 @@ class RuleMatcher:
         if self._is_rule_disabled(rule):
             return False
 
-        if self.select_filter.has_all():
+        # ALL does not select project level rules - they need to be selected explicitly or with PROJECT
+        if self.select_filter.has_all() and not rule.project_rule:
             self.select_filter.matched.add(ALL_RULES)
             return True
 

--- a/tests/linter/test_rule_matcher.py
+++ b/tests/linter/test_rule_matcher.py
@@ -268,7 +268,7 @@ class TestRuleMatcher:
 
     def test_project_token_ignores_project_rules(self):
         rule_matcher = RuleMatcher(
-            select=["ALL"],
+            select=["ALL", "PROJECT"],
             extend_select=[],
             ignore=["PROJECT"],
             target_version=ROBOT_VERSION,
@@ -279,6 +279,44 @@ class TestRuleMatcher:
 
         assert rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
         assert not rule_matcher.is_rule_enabled(get_project_rule("0201"))
+
+    def test_all_does_not_select_project_rules(self):
+        rule_matcher = RuleMatcher(
+            select=["ALL"],
+            extend_select=[],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
+        assert rule_matcher.is_rule_enabled(get_disabled_rule("0102"))
+        assert not rule_matcher.is_rule_enabled(get_project_rule("0201"))
+
+    @pytest.mark.parametrize(
+        ("select", "extend_select"),
+        [
+            (["ALL", "PROJECT"], []),
+            (["ALL"], ["PROJECT"]),
+            (["ALL"], ["some-message-0201"]),
+            (["ALL", "0201"], []),
+        ],
+    )
+    def test_all_with_project_rules_selected(self, select, extend_select):
+        rule_matcher = RuleMatcher(
+            select=select,
+            extend_select=extend_select,
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+
+        assert rule_matcher.is_rule_enabled(get_enabled_rule("0101"))
+        assert rule_matcher.is_rule_enabled(get_project_rule("0201"))
 
     def test_project_token_is_matched(self, capsys):
         rule_matcher = RuleMatcher(

--- a/tests/project/test_project_run.py
+++ b/tests/project/test_project_run.py
@@ -49,6 +49,12 @@ class TestProjectRulesInCheck:
     def test_no_project_skips_project_rules(self, project):
         assert run(project, ["unused-keyword"], project=False) == []
 
+    def test_all_does_not_select_project_rules(self, project):
+        assert "unused-keyword" not in rule_names(run(project, ["ALL"]))
+
+    def test_all_with_project_selects_project_rules(self, project):
+        assert "unused-keyword" in rule_names(run(project, ["ALL", "PROJECT"]))
+
     def test_no_project_keeps_file_rules(self, project):
         diagnostics = run(project, ["unused-keyword", "missing-doc-test-case"], project=False)
         assert rule_names(diagnostics) == ["missing-doc-test-case"]


### PR DESCRIPTION
## Why

`--select ALL` also enabled the project level rules. That silently changes behavior for users who already had `select = ["ALL"]` in their configuration (project rules are much slower and require parsing the whole project), and it made "everything except project rules" awkward to express.

## What changed

`ALL` no longer matches rules with `project_rule = True`. Project rules now always have to be opted into explicitly, either by name/id or with the already existing `PROJECT` token:

```bash
robocop check --select ALL                        # every rule except project level ones
robocop check --select ALL --extend-select PROJECT  # every rule, including project level ones
robocop check --select PROJECT                    # only project level rules
```

The change is a single condition in `RuleMatcher.is_rule_enabled` - project rules fall through to the normal exact/pattern/`PROJECT` matching instead of being short-circuited by `ALL`. `--ignore PROJECT`, `--extend-select PROJECT` and `robocop list rules --filter PROJECT` are unchanged.

## Notes

- Breaking change for anyone relying on `--select ALL` to run project rules; documented in `docs/linter/linter.md` and `docs/configuration/configuration_reference.md`.
- Wildcard patterns (for example `--select "*"`) are intentionally left alone; only the `ALL` token was scoped down.
- Covered by new unit tests in `tests/linter/test_rule_matcher.py` and end-to-end tests in `tests/project/test_project_run.py`. Full suite and ruff pass.