### PR TITLE
perf: cache resolved paths in project analysis

### DIFF
--- a/src/robocop/files.py
+++ b/src/robocop/files.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import cache
+from functools import cache, lru_cache
 from pathlib import Path
 
 
@@ -22,6 +22,23 @@ def _path_relative_to(path: Path, cwd: Path) -> Path:
 def path_relative_to_cwd(path: Path) -> Path:
     """Return path in relation to cwd path. Results are cached per working directory."""
     return _path_relative_to(path, Path.cwd())
+
+
+@lru_cache(maxsize=100_000)
+def resolve_path(path: Path) -> Path:
+    """
+    Return the resolved (absolute, symlink free) path.
+
+    ``Path.resolve`` is a filesystem call and it is used all over the project analysis to normalize paths before
+    comparing them or using them as dictionary keys. A project contains a limited number of paths, but they are
+    resolved hundreds of thousands of times, so the results are cached. The cache is bounded, so that it does not
+    grow without a limit in long living processes such as the MCP server.
+
+    Returns:
+        Resolved path.
+
+    """
+    return path.resolve()
 
 
 def get_common_parent_dirs(sources: list[Path]) -> list[Path]:

--- a/src/robocop/linter/checkers/imports.py
+++ b/src/robocop/linter/checkers/imports.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import re
 from collections import deque
 from typing import TYPE_CHECKING
 
-from robocop.files import path_relative_to_cwd
+from robocop.files import path_relative_to_cwd, resolve_path
 from robocop.linter.rules import ProjectChecker, imports
 from robocop.project.context import KeywordIndex
 from robocop.project.definitions import ImportStatus, ImportType
@@ -144,12 +145,13 @@ class UnusedImportsChecker(ProjectChecker):
         if any(consumer.has_dynamic_keyword_calls for consumer in consumers):
             return
         used_keywords, used_variables = _collect_usage(consumers)
-        own_path = project_file.path.resolve()
+        own_path = project_file.resolved_path
         for imported in project_file.resource_imports():
-            if imported.status != ImportStatus.RESOLVED or imported.path is None:
+            imported_path = imported.resolved_path
+            if imported.status != ImportStatus.RESOLVED or imported_path is None:
                 continue
-            resource = context.files.get(imported.path.resolve())
-            if resource is None or resource.path.resolve() == own_path:
+            resource = context.files.get(imported_path)
+            if resource is None or resource.resolved_path == own_path:
                 continue
             if _is_used(resource, context, used_keywords, used_variables):
                 continue
@@ -207,13 +209,14 @@ class UnusedImportsChecker(ProjectChecker):
 
         """
         if project_file.collected.is_init_file:
-            directory = project_file.path.parent.resolve()
-            return [other for other in context.iter_files() if directory in other.path.resolve().parents]
+            # comparing string prefixes is much faster than Path.is_relative_to, which walks all parents
+            directory = f"{resolve_path(project_file.path.parent)}{os.sep}"
+            return [other for other in context.iter_files() if str(other.resolved_path).startswith(directory)]
         if project_file.is_suite:
             return [project_file]
         if self._importers is None:
             self._importers = _build_importers(context)
-        return self._importers.get(project_file.path.resolve(), [project_file])
+        return self._importers.get(project_file.resolved_path, [project_file])
 
 
 class CircularImports(ProjectChecker):
@@ -229,11 +232,11 @@ class CircularImports(ProjectChecker):
     ) -> list[Diagnostic]:
         self.issues = []
         for project_file in context.iter_files():
-            own_path = project_file.path.resolve()
+            own_path = project_file.resolved_path
             for imported in project_file.resource_imports():
                 if imported.status != ImportStatus.RESOLVED or imported.path is None:
                     continue
-                imported_path = imported.path.resolve()
+                imported_path = imported.resolved_path
                 if imported_path not in context.files:
                     continue
                 cycle = _path_back_to(context, imported_path, own_path)
@@ -271,10 +274,10 @@ def _path_back_to(context: ProjectContext, start: Path, target: Path) -> list[Pa
         for imported in project_file.resource_imports():
             if imported.status != ImportStatus.RESOLVED or imported.path is None:
                 continue
-            next_path = imported.path.resolve()
+            next_path = imported.resolved_path
             if next_path == target:
                 return [*chain, next_path]
-            if next_path in seen or next_path not in context.files:
+            if next_path is None or next_path in seen or next_path not in context.files:
                 continue
             seen.add(next_path)
             queue.append((next_path, [*chain, next_path]))
@@ -292,7 +295,7 @@ def _build_importers(context: ProjectContext) -> dict[Path, list[ProjectFile]]:
     importers: dict[Path, list[ProjectFile]] = {}
     for project_file in context.iter_files():
         for visible in context.imported_files(project_file.path):
-            importers.setdefault(visible.path.resolve(), []).append(project_file)
+            importers.setdefault(visible.resolved_path, []).append(project_file)
     return importers
 
 

--- a/src/robocop/linter/checkers/usage.py
+++ b/src/robocop/linter/checkers/usage.py
@@ -119,7 +119,7 @@ class KeywordNotFound(ProjectChecker):
             True if every import of the file and of its resources was resolved and loaded.
 
         """
-        resolved = project_file.path.resolve()
+        resolved = project_file.resolved_path
         cached = cache.get(resolved)
         if cached is not None:
             return cached
@@ -160,7 +160,7 @@ class KeywordNotFound(ProjectChecker):
         if imported.status not in (ImportStatus.RESOLVED, ImportStatus.EXTERNAL):
             return False
         if imported.import_type == ImportType.RESOURCE:
-            return imported.path is not None and imported.path.resolve() in context.files
+            return imported.resolved_path is not None and imported.resolved_path in context.files
         if not imported.args_resolved or context.library_loader is None:
             return False
         spec = context.library_loader.load_import(imported)
@@ -364,7 +364,7 @@ class UnusedKeywords(ProjectChecker):
         self.issues = []
         project_usages, file_usages = self._collect_usages(context)
         for project_file in context.iter_files():
-            private_usages = file_usages.get(project_file.path.resolve())
+            private_usages = file_usages.get(project_file.resolved_path)
             for keyword in project_file.keywords:
                 usages = private_usages if keyword.is_private else project_usages
                 if usages is not None and usages.uses(keyword):
@@ -399,9 +399,10 @@ class UnusedKeywords(ProjectChecker):
         """
         project_usages = UsedKeywordNames()
         file_usages: dict[Path, UsedKeywordNames] = {}
-        for project_file, keyword_usage in context.iter_usages():
-            per_file = file_usages.setdefault(project_file.path.resolve(), UsedKeywordNames())
-            for name in keyword_usage.names_to_check():
-                project_usages.add(name, keyword_usage.name_contains_variable)
-                per_file.add(name, keyword_usage.name_contains_variable)
+        for project_file in context.iter_files():
+            per_file = file_usages.setdefault(project_file.resolved_path, UsedKeywordNames())
+            for keyword_usage in project_file.usages:
+                for name in keyword_usage.names_to_check():
+                    project_usages.add(name, keyword_usage.name_contains_variable)
+                    per_file.add(name, keyword_usage.name_contains_variable)
         return project_usages, file_usages

--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -10,6 +10,7 @@ from robot.errors import DataError
 
 from robocop import exceptions
 from robocop.cache import restore_diagnostics
+from robocop.files import resolve_path
 from robocop.linter import reports
 from robocop.linter.diagnostics import Diagnostics, RunStatistic
 from robocop.linter.fix import FixApplier
@@ -111,7 +112,7 @@ class RobocopLinter:
         for source_file in self.config_manager.paths:
             if source_file.config.verbose:
                 print(f"Scanning file: {source_file.path}")
-            checked_paths.add(source_file.path.resolve())
+            checked_paths.add(source_file.resolved_path)
             diagnostics = self.get_cached_diagnostics(source_file.config, source_file.path)
             if diagnostics is not None:
                 no_fixables = all(not diag.rule.fixable for diag in diagnostics)
@@ -296,17 +297,17 @@ class RobocopLinter:
         for diagnostic in diagnostics:
             if not diagnostic.rule.fixable:
                 continue
-            if checked_paths is not None and diagnostic.source.path.resolve() not in checked_paths:
+            if checked_paths is not None and diagnostic.source.resolved_path not in checked_paths:
                 continue
             diag_by_source[diagnostic.source.path].append(diagnostic)
         if not diag_by_source:
             return False
-        modified_files = {source_file.path.resolve(): source_file for source_file in fix_applier.modified_files}
-        project_files = {source_file.path.resolve(): source_file for source_file in self.config_manager.project_paths}
+        modified_files = {source_file.resolved_path: source_file for source_file in fix_applier.modified_files}
+        project_files = {source_file.resolved_path: source_file for source_file in self.config_manager.project_paths}
         fixed = False
         for path, source_diagnostics in diag_by_source.items():
             # reuse source file already parsed for the project context, so that the next scan sees fixed model
-            resolved_path = path.resolve()
+            resolved_path = resolve_path(path)
             source_file = modified_files.get(resolved_path) or project_files.get(resolved_path)
             if source_file is None:
                 source_file = source_diagnostics[0].source

--- a/src/robocop/project/context.py
+++ b/src/robocop/project/context.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from robot.errors import DataError
 
+from robocop.files import resolve_path
 from robocop.linter.utils.misc import normalize_robot_name
 from robocop.project.collector import ProjectFileCollector
 from robocop.project.definitions import ImportStatus, ImportType, KeywordDefinition
@@ -50,6 +51,11 @@ class ProjectFile:
     @property
     def path(self) -> Path:
         return self.source_file.path
+
+    @property
+    def resolved_path(self) -> Path:
+        """Resolved path of the file, computed once per source file."""
+        return self.source_file.resolved_path
 
     @property
     def is_suite(self) -> bool:
@@ -171,7 +177,7 @@ class ProjectContext:
             ProjectFile or None if the path is not part of the project.
 
         """
-        return self.files.get(path.resolve())
+        return self.files.get(resolve_path(path))
 
     def imported_files(self, path: Path) -> list[ProjectFile]:
         """
@@ -188,15 +194,15 @@ class ProjectContext:
         if start is None:
             return []
         visible = [start]
-        seen = {start.path.resolve()}
+        seen = {start.resolved_path}
         queue = [start]
         while queue:
             current = queue.pop()
             for imported in current.resource_imports():
                 if imported.status != ImportStatus.RESOLVED or imported.path is None:
                     continue
-                resolved_path = imported.path.resolve()
-                if resolved_path in seen:
+                resolved_path = imported.resolved_path
+                if resolved_path is None or resolved_path in seen:
                     continue
                 imported_file = self.files.get(resolved_path)
                 if imported_file is None:
@@ -218,13 +224,13 @@ class ProjectContext:
             KeywordIndex with keywords visible from the file.
 
         """
-        resolved = path.resolve()
+        resolved = resolve_path(path)
         cached = self._visible_keywords.get(resolved)
         if cached is not None:
             return cached
         index = KeywordIndex()
         for project_file in self.imported_files(path):
-            is_own_file = project_file.path.resolve() == resolved
+            is_own_file = project_file.resolved_path == resolved
             for keyword in project_file.keywords:
                 if keyword.is_private and not is_own_file:
                     continue
@@ -247,7 +253,7 @@ class ProjectContext:
         """
         if self.library_loader is None:
             return []
-        resolved = project_file.path.resolve()
+        resolved = project_file.resolved_path
         cached = self._library_keywords.get(resolved)
         if cached is not None:
             return cached
@@ -390,7 +396,7 @@ def build_project_context(config_manager: ConfigManager, silent: bool = False) -
             if not silent:
                 print(f"Failed to parse {source_file.path} with an error: {error}. Skipping file")
             continue
-        context.files[source_file.path.resolve()] = ProjectFile(source_file=source_file, collected=collected)
+        context.files[source_file.resolved_path] = ProjectFile(source_file=source_file, collected=collected)
 
     for project_file in context.files.values():
         scope = global_scope.copy_for(project_file.path)

--- a/src/robocop/project/definitions.py
+++ b/src/robocop/project/definitions.py
@@ -11,6 +11,7 @@ from robot.errors import DataError
 from robot.running.arguments import EmbeddedArguments, UserKeywordArgumentParser
 from robot.variables.search import search_variable
 
+from robocop.files import resolve_path
 from robocop.linter.utils.misc import normalize_robot_name
 from robocop.version_handling import ROBOT_VERSION
 
@@ -415,6 +416,16 @@ class ResolvedImport:
     """Name the library was imported with (``AS`` / ``WITH NAME``)."""
     args_resolved: bool = True
     """Whether all variables used in the import arguments could be resolved."""
+    _resolved_path: Path | None = field(default=None, repr=False, compare=False)
+
+    @property
+    def resolved_path(self) -> Path | None:
+        """Resolved path the import points to, computed once per import."""
+        if self.path is None:
+            return None
+        if self._resolved_path is None:
+            self._resolved_path = resolve_path(self.path)
+        return self._resolved_path
 
     @property
     def is_resolved(self) -> bool:

--- a/src/robocop/source_file.py
+++ b/src/robocop/source_file.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     Languages = None
 
-from robocop.files import path_relative_to_cwd
+from robocop.files import path_relative_to_cwd, resolve_path
 from robocop.version_handling import LANG_SUPPORTED
 
 if TYPE_CHECKING:
@@ -45,6 +45,14 @@ class SourceFile:
     _model: File | None = None
     _source_lines: list[str] | None = None
     _original_source_lines: list[str] | None = None
+    _resolved_path: Path | None = None
+
+    @property
+    def resolved_path(self) -> Path:
+        """Resolved path of the file, computed once per source file."""
+        if self._resolved_path is None:
+            self._resolved_path = resolve_path(self.path)
+        return self._resolved_path
 
     @property
     def relative_path(self) -> Path:


### PR DESCRIPTION
## Summary

Project level checkers normalize paths with `Path.resolve()` before comparing them or using them as dictionary keys. `Path.resolve()` is a filesystem call, and profiling `robocop check --select PROJECT` over the [robotframework](https://github.com/robotframework/robotframework) repository (1366 files) showed it was called **569 624 times** for roughly 1400 unique paths — about a third of the whole run was spent in `nt._getfinalpathname`.

The worst offender was `ProjectContext.visible_keywords()`, which resolves the source path on every keyword usage lookup.

## Changes

- New cached `robocop.files.resolve_path()` helper. It follows the pattern already used by `_path_relative_to()` and by `RobocopCache._path_cache`, and is bounded so it does not grow without a limit in long living processes such as the MCP server.
- `SourceFile.resolved_path`, `ProjectFile.resolved_path` and `ResolvedImport.resolved_path` compute the resolved path once and reuse it.
- Hot loops in `project/context.py`, `linter/checkers/imports.py`, `linter/checkers/usage.py` and `linter/runner.py` use those properties instead of calling `Path.resolve()` repeatedly.
- `UnusedImportsChecker._consumers_of()` compares path prefixes for suite initialization files instead of using `Path.is_relative_to()`, which walks all parents and allocates a `Path` for each of them.
- `UnusedKeywords._collect_usages()` iterates files and then their usages, so the file path is resolved once per file instead of once per keyword call.

## Results

Measured on the robotframework repository, `robocop check --select PROJECT --no-cache`:

| | before | after |
| --- | --- | --- |
| CLI wall time | 38.6s | **17.8s** |
| project checkers only | 29.8s | **9.7s** |
| `Path.resolve()` syscalls | 569 624 | 17 264 |

Per checker (project checker phase only):

| checker | before | after |
| --- | --- | --- |
| `UnusedImportsChecker` | 12.34s | 8.23s (now dominated by library importing) |
| `KeywordNotFound` | 3.28s | 0.04s |
| `ProjectArgumentNamesChecker` | 3.01s | 0.27s |
| `UnusedKeywords` | 2.81s | 0.34s |
| `ProjectArgumentsChecker` | 2.46s | 0.13s |
| `AmbiguousKeywordNames` | 2.39s | 0.05s |
| `MissingKeywordPrefix` | 2.34s | 0.06s |

## Behaviour

No behaviour change. All 12390 reported diagnostics are identical before and after.

## Follow up

The remaining bottleneck is library importing (8.2s of the 17.8s), which is tracked separately.