### PR TITLE
fix: silence library import output during project analysis

### DIFF
--- a/src/robocop/project/_libdoc_worker.py
+++ b/src/robocop/project/_libdoc_worker.py
@@ -13,12 +13,55 @@ The module does not import Robocop, so that it can be started even if the inspec
 
 from __future__ import annotations
 
+import io
 import json
 import sys
 import traceback
-from typing import Any
+import warnings
+from contextlib import contextmanager, redirect_stderr, redirect_stdout, suppress
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 ARGUMENT_SEPARATOR = "::"
+
+
+@contextmanager
+def _silenced_robot_logger() -> Iterator[None]:
+    """Stop Robot Framework from printing library import errors and warnings to the console."""
+    try:
+        from robot.output import LOGGER  # noqa: PLC0415
+    except ImportError:  # pragma: no cover - defensive, Robot Framework is a required dependency
+        yield
+        return
+    # Messages are not cached either, since cached messages are printed when a new logger is registered.
+    with suppress(AttributeError):
+        LOGGER.disable_message_cache()
+    with LOGGER.cache_only:
+        yield
+
+
+@contextmanager
+def silenced() -> Iterator[None]:
+    """Hide everything the imported library and Robot Framework print while the library is imported."""
+    discarded = io.StringIO()
+    # Robot Framework writes the output captured during the library import directly to the original streams.
+    original_stdout, original_stderr = sys.__stdout__, sys.__stderr__
+    sys.__stdout__ = discarded  # type: ignore[assignment, misc]
+    sys.__stderr__ = discarded  # type: ignore[assignment, misc]
+    try:
+        with (
+            warnings.catch_warnings(),
+            redirect_stdout(discarded),
+            redirect_stderr(discarded),
+            _silenced_robot_logger(),
+        ):
+            warnings.simplefilter("ignore")
+            yield
+    finally:
+        sys.__stdout__ = original_stdout  # type: ignore[misc]
+        sys.__stderr__ = original_stderr  # type: ignore[misc]
 
 
 def _argument_spec(spec: Any) -> dict[str, Any]:
@@ -78,12 +121,14 @@ def load_library(request: dict[str, Any]) -> dict[str, Any]:
     try:
         from robot.libdocpkg import LibraryDocumentation  # noqa: PLC0415
 
-        library = LibraryDocumentation(name)
+        with silenced():
+            library = LibraryDocumentation(name)
+            keywords = _keywords(library)
         return {
             "status": "ok",
             "name": library.name,
             "source": str(library.source) if library.source else None,
-            "keywords": _keywords(library),
+            "keywords": keywords,
         }
     except BaseException as error:  # noqa: BLE001 - importing a library executes arbitrary code
         message = f"{type(error).__name__}: {error}".strip()

--- a/src/robocop/project/libraries.py
+++ b/src/robocop/project/libraries.py
@@ -16,14 +16,12 @@ rules using this information stay silent instead of reporting false positives.
 
 from __future__ import annotations
 
-import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import redirect_stdout
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from functools import cache
@@ -339,8 +337,8 @@ class LibraryLoader:
         Import the library in the Robocop process.
 
         This is the default way of importing libraries, since starting a process for every library is slow.
-        Anything the library prints during the import is discarded, so that it does not corrupt the Robocop
-        output. The import cannot be stopped, so the timeout does not apply here.
+        Anything the library or Robot Framework prints during the import is discarded, so that it does not
+        corrupt the Robocop output. The import cannot be stopped, so the timeout does not apply here.
 
         Returns:
             Response describing the library keywords or the failure.
@@ -350,8 +348,7 @@ class LibraryLoader:
 
         already_imported = set(sys.modules)
         try:
-            with redirect_stdout(io.StringIO()):
-                return load_library(self._worker_request(request))
+            return load_library(self._worker_request(request))
         finally:
             self._forget_local_modules(already_imported, request)
 

--- a/tests/project/test_libraries.py
+++ b/tests/project/test_libraries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import time
 
 import pytest
@@ -25,6 +26,30 @@ def slow_keyword():
 
 BROKEN_LIBRARY = """
 raise RuntimeError("boom")
+"""
+
+STDERR_LIBRARY = """
+import sys
+
+sys.stderr.write("noise\\n")
+
+
+def stderr_keyword():
+    pass
+"""
+
+LIBRARY_WITH_DUPLICATED_KEYWORDS = """
+from robot.api.deco import keyword
+
+
+@keyword("Defined twice")
+def first():
+    pass
+
+
+@keyword("Defined twice")
+def second():
+    pass
 """
 
 LIBRARY_WITH_ARGUMENTS = """
@@ -115,6 +140,29 @@ class TestLibraryLoader:
         loader = build_library_loader(search_paths=[library_dir])
         assert loader.load(LibraryRequest(name="NoisyLibrary")).loaded
         assert "noise" not in capsys.readouterr().out
+
+    def test_library_writing_to_stderr_on_import_does_not_write_to_output(self, library_dir, capfd):
+        (library_dir / "StderrLibrary.py").write_text(STDERR_LIBRARY)
+        loader = build_library_loader(search_paths=[library_dir])
+        assert loader.load(LibraryRequest(name="StderrLibrary")).loaded
+        captured = capfd.readouterr()
+        assert "noise" not in captured.err
+        assert "noise" not in captured.out
+
+    def test_robot_framework_errors_are_not_printed(self, library_dir, capfd):
+        (library_dir / "DupeLibrary.py").write_text(LIBRARY_WITH_DUPLICATED_KEYWORDS)
+        loader = build_library_loader(search_paths=[library_dir])
+        assert loader.load(LibraryRequest(name="DupeLibrary")).loaded
+        captured = capfd.readouterr()
+        assert "Defined twice" not in captured.err
+        assert "Defined twice" not in captured.out
+
+    def test_output_streams_are_restored_after_import(self, library_dir):
+        original_stdout, original_stderr = sys.__stdout__, sys.__stderr__
+        loader = build_library_loader(search_paths=[library_dir])
+        assert loader.load(LibraryRequest(name="MyLibrary")).loaded
+        assert sys.__stdout__ is original_stdout
+        assert sys.__stderr__ is original_stderr
 
     def test_scheduled_libraries_are_imported_in_parallel(self, library_dir):
         loader = build_library_loader(search_paths=[library_dir], workers=True)


### PR DESCRIPTION
Running `robocop check` with project rules enabled polluted the console with dozens of Robot Framework messages coming from the libraries being imported, for example:

```
[ ERROR ] Error in library 'DupeKeywords': Adding keyword 'Defined twice' failed: Keyword with same name defined multiple times.
[ WARN ] Warning via stdout in import
Info via stderr in import
_libdoc_worker.py:90: RuntimeWarning: coroutine 'AsyncDynamicLibrary.get_keyword_names' was never awaited
```

None of that is a Robocop diagnostic. Libraries that fail to import are already reported as "no keywords", so the noise is confusing and makes the real output hard to read.

## Why it leaked

The in-process import only redirected `stdout`, which was not enough:

- Robot Framework's global `LOGGER` writes `[ ERROR ]` / `[ WARN ]` library import messages to the console itself.
- RF's `OutputCapturer` re-emits the stderr captured during a library import straight to `sys.__stderr__`, so it bypasses `contextlib.redirect_stderr`.
- Python warnings triggered by the imported code also go to stderr.

## Approach

Added a `silenced()` context manager in `robocop/project/_libdoc_worker.py` that wraps the `LibraryDocumentation` import and:

- redirects `stdout` and `stderr`, plus `sys.__stdout__` / `sys.__stderr__`, to a throwaway buffer and restores them afterwards,
- ignores warnings raised while the library is imported,
- puts RF's `LOGGER` into `cache_only` mode and disables its message cache, so nothing is printed now and nothing is replayed later when another logger is registered.

Because the silencing lives in `load_library`, it covers both the default in-process import and the `--library-workers` subprocess path. The now redundant partial `redirect_stdout` in `libraries.py` was removed.

## Notes for reviewers

- `LOGGER.disable_message_cache()` is global and permanent for the process. Robocop never registers an RF console or output logger for its own reporting, so nothing else depends on that cache.
- The `sys.__stderr__` patching looks unusual, but it is required: RF deliberately writes there so that library stderr is visible even when streams are captured.
- Tests cover library stderr noise, RF duplicate-keyword errors, and that the original streams are restored after the import.