### PR TITLE
fix: resolve run keywords called with a BDD prefix

### DIFF
--- a/src/robocop/parsing/run_keywords.py
+++ b/src/robocop/parsing/run_keywords.py
@@ -82,6 +82,44 @@ RUN_KEYWORDS = RunKeywords(
 )
 
 
+BDD_PREFIXES = frozenset({"Given", "When", "Then", "And", "But"})
+"""Prefixes Robot Framework removes from the keyword name if the keyword is not found with the full name."""
+
+
+def remove_bdd_prefix(name: str, bdd_prefixes: frozenset[str] = BDD_PREFIXES) -> str:
+    """
+    Remove the BDD prefix from the keyword name.
+
+    Returns:
+        Name without the prefix, or the original name if it does not start with one.
+
+    """
+    first_word, separator, rest = name.partition(" ")
+    if not separator or first_word.title() not in bdd_prefixes:
+        return name
+    return rest.lstrip()
+
+
+def get_run_keyword(name: str) -> RunKeywordVariant | None:
+    """
+    Find the run keyword variant matching the name, ignoring the BDD prefix if there is one.
+
+    Robot Framework resolves the full name first and only then retries without the BDD prefix,
+    which is why ``Then Wait Until Keyword Succeeds`` runs the keyword passed in its arguments.
+
+    Returns:
+        Matching RunKeywordVariant or None if the name does not refer to a run keyword.
+
+    """
+    run_keyword = RUN_KEYWORDS.get(name)
+    if run_keyword is not None:
+        return run_keyword
+    without_prefix = remove_bdd_prefix(name)
+    if without_prefix == name:
+        return None
+    return RUN_KEYWORDS.get(without_prefix)
+
+
 def skip_leading_tokens(tokens: list[Token], break_token: str) -> list[Token]:
     for index, token in enumerate(tokens):
         if token.type == break_token:
@@ -148,7 +186,7 @@ def parse_run_keyword_calls(tokens: list[Token]) -> Generator[KeywordCallTokens,
     if not tokens:
         return
     yield KeywordCallTokens(name=tokens[0], arguments=list(tokens[1:]))
-    run_keyword = RUN_KEYWORDS[tokens[0].value]
+    run_keyword = get_run_keyword(tokens[0].value)
     if not run_keyword:
         return
     tokens = tokens[run_keyword.resolve :]
@@ -192,7 +230,7 @@ def parse_run_keyword(tokens: list[Token]) -> Generator[Token, None, None]:
     if not tokens:
         return
     yield tokens[0]
-    run_keyword = RUN_KEYWORDS[tokens[0].value]
+    run_keyword = get_run_keyword(tokens[0].value)
     if not run_keyword:
         return
     tokens = tokens[run_keyword.resolve :]
@@ -223,5 +261,4 @@ def split_on_and(tokens: list[Token]) -> Generator[Token, None, None]:
 
 
 def is_run_keyword(token_name: str) -> bool:
-    run_keyword = RUN_KEYWORDS[token_name]
-    return run_keyword is not None
+    return get_run_keyword(token_name) is not None

--- a/src/robocop/project/collector.py
+++ b/src/robocop/project/collector.py
@@ -12,7 +12,7 @@ from robot.parsing.model.statements import Arguments, Statement, Tags
 from robot.variables.search import search_variable
 
 from robocop.linter.utils.misc import normalize_robot_name
-from robocop.parsing.run_keywords import iterate_keyword_calls
+from robocop.parsing.run_keywords import BDD_PREFIXES, iterate_keyword_calls
 from robocop.parsing.variables import VariableMatches  # type: ignore[attr-defined]
 from robocop.project.definitions import (
     ArgumentsSpec,
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     )
 
 
-DEFAULT_BDD_PREFIXES = frozenset({"Given", "When", "Then", "And", "But"})
+DEFAULT_BDD_PREFIXES = BDD_PREFIXES
 VARIABLE_VALUE_TOKENS = (Token.ARGUMENT, Token.NAME, Token.KEYWORD, Token.OPTION)
 
 

--- a/tests/linter/rules/keywords/unused_keyword/suite.robot
+++ b/tests/linter/rules/keywords/unused_keyword/suite.robot
@@ -46,6 +46,18 @@ Used In Timeout
 Used In Run Keyword
     No Operation
 
+Used In Wait Until Keyword
+    No Operation
+
+Used With BDD
+    No Operation
+
+Used With BDD In Run Keyword
+    No Operation
+
+Embedded ${bdd} With Run Keyword
+    No Operation
+
 
 *** Test Cases ***
 Test cases are last for testing purposes
@@ -60,3 +72,10 @@ Test with run keywords
     Run Keywords    Used Keyword
     ...    AND
     ...    Used In Run Keyword
+
+Test with bdd and run keywords
+    Given Used With BDD
+    Then Wait Until Keyword Succeeds    10x    500ms    Used In Wait Until Keyword
+    When Run Keywords    Used With BDD In Run Keyword
+    ...    AND
+    ...    Embedded bdd With Run Keyword


### PR DESCRIPTION
Keywords passed as arguments to a run keyword were not counted as used when the run keyword itself was called with a BDD prefix. For example, in `Then Wait Until Keyword Succeeds    10x    500ms    Used In Wait Until Keyword`, the `Used In Wait Until Keyword` keyword was reported by `unused-keyword` as never called.

## Cause

`parse_run_keyword` / `parse_run_keyword_calls` looked up `RUN_KEYWORDS` using the raw name token. With a BDD prefix the name is `Then Wait Until Keyword Succeeds`, which is not in the map, so parsing stopped at the outer call and the nested keyword names were never collected as usages. A plain `Given Used With BDD` worked because `KeywordUsage.names_to_check()` already handles the prefix - only the run keyword lookup did not.

## Fix

Added `remove_bdd_prefix()` and `get_run_keyword()` in `robocop/parsing/run_keywords.py`. The lookup now tries the full name first and falls back to the name without the BDD prefix, which mirrors how Robot Framework resolves keyword names (full name first, then retry without the prefix). Both parse functions and `is_run_keyword()` go through the new helper, so `wrong-case-in-keyword-call`, `missing-argument-name` and the spacing rules that detect run keywords get the same behaviour. `project/collector.py` now reuses the shared `BDD_PREFIXES` set instead of keeping its own copy.

## Tests

Extended `tests/linter/rules/keywords/unused_keyword/suite.robot` with the reported case plus a `When Run Keywords` variant and a nested embedded keyword. All three were reported as unused before the change and none are after; `expected_output.txt` is unchanged, which is the point. Full test suite, ruff and mypy pass.