### PR TITLE
feat: add plugin functionality

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -98,3 +98,10 @@ extends = ["../relative/path.toml", "C:/absolute/path.toml"]
 ``extends`` accept both relative and absolute paths. Configuration is loaded in the order they are specified.
 List-like options (``select``, ``ignore`` etc.) are merged. String and boolean options are overwritten by the most recent
 value.
+
+``extends`` can also point to a configuration file shipped with an installed [plugin](../plugins.md):
+
+```toml
+[tool.robocop]
+extends = ["example.config.strict"]
+```

--- a/docs/formatter/custom_formatters.md
+++ b/docs/formatter/custom_formatters.md
@@ -25,6 +25,23 @@ Each formatter must be a class that inherits from `robocop.formatter.formatters.
     ]
     ```
 
+Formatters distributed as a [plugin](../plugins.md) are referenced with the plugin namespace instead of a path:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop format --extend-select example.formatters.ExampleFormatter
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.format]
+    extend-select = [
+        "example.formatters.ExampleFormatter"
+    ]
+    ```
+
 ## How to write custom formatters
 
 Custom formatter should inherit from `robocop.formatter.formatters.Formatter` class. This class is Robocop's

--- a/docs/linter/custom_rules.md
+++ b/docs/linter/custom_rules.md
@@ -21,6 +21,23 @@ It accepts a list of paths to files, directories or name of the Python module. E
     ]
     ```
 
+Rules distributed as a [plugin](../plugins.md) are referenced with the plugin namespace instead of a path:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```
+    robocop check --custom-rules example.rules
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    custom_rules = [
+        "example.rules"
+    ]
+    ```
+
 ## How to write custom rules
 
 Writing your own rules requires implementing the following:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,225 @@
+# Plugins
+
+Robocop plugins allow you to package and distribute custom rules, formatters and configuration files as a regular
+Python package. Once the plugin package is installed, its resources can be referenced in the Robocop configuration
+using a short, namespaced syntax instead of file paths.
+
+## Using a plugin
+
+Install the plugin package the same way as any other Python package:
+
+```bash
+pip install example-plugin
+```
+
+Robocop discovers installed plugins automatically. You can list them with:
+
+```bash
+robocop list plugins
+```
+
+Installing a plugin does **not** enable anything on its own. It only registers the plugin namespace, so its
+resources can be referenced in the configuration.
+
+### Rules
+
+Point ``custom-rules`` to a module inside the plugin:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```
+    robocop check --custom-rules example.rules --select plugin-rule
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    custom_rules = [
+        "example.rules"
+    ]
+    select = [
+        "plugin-rule"
+    ]
+    ```
+
+All submodules of the referenced module are imported, so the plugin does not have to import them in its
+``__init__.py``.
+
+### Formatters
+
+Select a single formatter class or a whole module with formatters:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```
+    robocop format --select example.formatters.ExampleFormatter
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.format]
+    select = [
+        "example.formatters.ExampleFormatter",
+    ]
+    ```
+
+Formatters are configured by their class name, without the plugin namespace:
+
+```toml
+[tool.robocop.format]
+configure = [
+    "ExampleFormatter.test_name=Configured Name"
+]
+```
+
+### Configuration files
+
+Configuration files shipped with a plugin are used with the [extends](configuration/index.md#inherit-configuration-file)
+option:
+
+```toml
+[tool.robocop]
+extends = ["example.config.strict"]
+```
+
+The reference points to the ``config/strict.toml`` file inside the plugin. Such a configuration file can itself
+reference other plugin resources:
+
+```toml title="config/strict.toml"
+[tool.robocop.lint]
+custom_rules = [
+    "example.rules"
+]
+select = [
+    "plugin-rule"
+]
+
+[tool.robocop.format]
+select = [
+    "example.formatters.ExampleFormatter"
+]
+```
+
+## Creating a plugin
+
+A plugin is a Python package that registers itself using the ``robocop.plugins``
+[entry point group](https://packaging.python.org/en/latest/specifications/entry-points/):
+
+```toml title="pyproject.toml"
+[project]
+name = "example-plugin"
+version = "1.0.0"
+
+[project.entry-points."robocop.plugins"]
+example = "example_plugin"
+```
+
+The entry point name (``example``) is the plugin namespace used in the Robocop configuration. The value is an
+importable path to the Python package with the plugin resources. It does not have to be the top level package:
+
+```toml
+[project.entry-points."robocop.plugins"]
+example = "example_plugin.path.to.dir"
+```
+
+### Reference syntax
+
+Every plugin resource is referenced with the ``<plugin_name>.<path.inside.the.plugin>`` syntax. The first part is
+always the plugin name, and the rest is a dot separated path relative to the package the entry point points to.
+Robocop does not enforce any particular directory layout, but the following one is a good starting point:
+
+```
+example_plugin/
+    __init__.py
+    rules/
+        __init__.py
+        naming.py
+    formatters/
+        __init__.py
+        ExampleFormatter.py
+    config/
+        strict.toml
+```
+
+With such a layout, the plugin provides:
+
+| Reference | Resolved to |
+| --- | --- |
+| ``example.rules`` | ``example_plugin/rules`` package with the rules and checkers |
+| ``example.formatters`` | all formatters from the ``example_plugin/formatters`` package |
+| ``example.formatters.ExampleFormatter`` | single ``ExampleFormatter`` formatter |
+| ``example.config.strict`` | ``example_plugin/config/strict.toml`` configuration file |
+
+!!! note
+
+    Plugin names take precedence over file paths and module names. If a plugin called ``example`` is installed,
+    ``example.rules`` is always resolved as a plugin reference.
+
+### Rules
+
+Rules and checkers inside a plugin are written exactly the same way as any other
+[custom rule](linter/custom_rules.md):
+
+```python title="example_plugin/rules/naming.py"
+from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker
+
+
+class PluginRule(Rule):
+    """Rule shipped with the example plugin."""
+
+    name = "plugin-rule"
+    rule_id = "EXPL01"
+    message = "Test case name '{name}' comes from the plugin rule"
+    severity = RuleSeverity.INFO
+    added_in_version = "1.0.0"
+
+
+class PluginChecker(VisitorChecker):
+    plugin_rule: PluginRule
+
+    def visit_TestCaseName(self, node):  # noqa: N802
+        self.report(self.plugin_rule, name=node.name, node=node)
+```
+
+### Formatters
+
+Formatters follow the [custom formatter](formatter/formatter.md) rules - the file name must match the formatter
+class name:
+
+```python title="example_plugin/formatters/ExampleFormatter.py"
+from robot.api.parsing import Token
+
+from robocop.formatter.formatters import Formatter
+
+
+class ExampleFormatter(Formatter):
+    """Formatter shipped with the example plugin."""
+
+    ENABLED = False
+
+    def __init__(self, test_name: str = "Plugin Test"):
+        super().__init__()
+        self.test_name = test_name
+
+    def visit_TestCaseName(self, node):  # noqa: N802
+        name_token = node.get_token(Token.TESTCASE_NAME)
+        if name_token is not None:
+            name_token.value = self.test_name
+        return node
+```
+
+Use the ``FORMATTERS`` list in the ``__init__.py`` of the formatters package to define the order in which the
+formatters are run when the whole module is selected:
+
+```python title="example_plugin/formatters/__init__.py"
+from example_plugin.formatters.ExampleFormatter import ExampleFormatter
+
+FORMATTERS = ["ExampleFormatter"]
+```
+
+### Configuration files
+
+Configuration files shipped with the plugin use the same syntax as any other Robocop configuration file and
+require the ``[tool.robocop]`` section.

--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -302,6 +302,42 @@ linter: add fixes for malformed separators (#1862) (4a40f9f)
 linter: check automatic variable availability (#1867) (b2ffe06)
 linter: detect variables in documentation (#1866) (05a73ed)
 
+### Plugins (#1538)
+
+Custom rules, formatters and configuration files can now be packaged and distributed as a Robocop plugin.
+A plugin is a regular Python package that registers itself using the ``robocop.plugins`` entry point group:
+
+```toml title="pyproject.toml"
+[project]
+name = "example-plugin"
+
+[project.entry-points."robocop.plugins"]
+example = "example_plugin.path.to.dir"
+```
+
+Robocop discovers installed plugins automatically. Use ``robocop list plugins`` to see them.
+The entry point name becomes the plugin namespace, and its resources are referenced with the
+``<plugin_name>.<path.inside.the.plugin>`` syntax:
+
+```toml
+[tool.robocop]
+extends = ["example.config.strict"]
+
+[tool.robocop.lint]
+custom_rules = ["example.rules"]
+
+[tool.robocop.format]
+select = ["example.formatters.FormatterA"]
+```
+
+Installing a plugin does not enable anything on its own - it only registers the namespace, so plugin resources
+can be referenced in the configuration.
+
+Note that ``extends`` values that do not end with ``.toml`` were previously silently ignored. They are now
+resolved as plugin references, and Robocop reports an error if the plugin or its configuration file is missing.
+
+See the [plugins documentation](../plugins.md) for more details.
+
 ### Other features
 
 TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - configuration/index.md
     - Reference: configuration/configuration_reference.md
     - Disablers: configuration/disablers.md
+  - Plugins: plugins.md
   - Integrations:
       - Pre-commit: integrations/precommit.md
       - SonarQube: integrations/sonarqube.md

--- a/src/robocop/config/parser.py
+++ b/src/robocop/config/parser.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     Languages = None
 
-from robocop import exceptions
+from robocop import exceptions, plugins
 from robocop.linter.rules import RuleSeverity
 from robocop.version_handling import ROBOT_VERSION, Version
 
@@ -214,12 +214,18 @@ def extend_configs(config: dict[str, Any], config_path: Path, seen: set[Path]) -
                 f"{base_config} is not a string."
             )
         if not base_config.endswith(".toml"):
-            continue
-        base_config = Path(base_config)
-        if base_config.is_absolute():
-            extended_path = base_config
+            extended_path = plugins.resolve_path_reference(base_config)
+            if not extended_path.is_file():
+                raise exceptions.ConfigurationError(
+                    f"Configuration '{base_config}' referenced in the 'extends' parameter in the configuration "
+                    f"file: '{config_path}' does not exist. Expected plugin file: '{extended_path}'."
+                )
         else:
-            extended_path = (config_path.parent / base_config).resolve()
+            base_config_path = Path(base_config)
+            if base_config_path.is_absolute():
+                extended_path = base_config_path
+            else:
+                extended_path = (config_path.parent / base_config_path).resolve()
         if extended_path in seen:
             raise exceptions.CircularExtendsReferenceError(str(config_path)) from None
         normalized_config = read_robocop_toml_config(extended_path)

--- a/src/robocop/formatter/formatters/__init__.py
+++ b/src/robocop/formatter/formatters/__init__.py
@@ -21,6 +21,7 @@ from robot.api.parsing import ModelTransformer
 from robot.errors import DataError
 from robot.utils.importer import Importer
 
+from robocop import plugins
 from robocop.config.defaults import SKIP_OPTIONS
 from robocop.exceptions import ImportFormatterError, InvalidParameterError
 from robocop.formatter.skip import Skip
@@ -204,7 +205,8 @@ def import_custom_formatter(
 ) -> Generator[FormatterContainer, None, None]:
     try:
         short_name = get_formatter_short_name(name)
-        abs_path = get_absolute_path_to_formatter(name)
+        import_name = plugins.resolve_module_reference(name) or name
+        abs_path = get_absolute_path_to_formatter(import_name)
         imported = IMPORTER.import_class_or_module(abs_path)
         if inspect.isclass(imported):
             yield create_formatter_instance(imported, short_name, formatter_args.get(short_name, {}), skip_config)

--- a/src/robocop/plugins.py
+++ b/src/robocop/plugins.py
@@ -1,0 +1,202 @@
+"""
+Robocop plugins.
+
+Plugins allow to package and distribute custom rules, formatters and configuration files as a Python package.
+A plugin is registered using the ``robocop.plugins`` entry point group::
+
+    [project.entry-points."robocop.plugins"]
+    example = "example_plugin.path.to.dir"
+
+The entry point name (``example``) becomes the plugin namespace and the value points to an importable Python
+package that contains the plugin resources. Resources are referenced in the configuration using the
+``<plugin_name>.<path.inside.the.plugin>`` syntax, for example ``example.rules`` or ``example.config.strict``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import import_module
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+
+from robocop import exceptions
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+ENTRY_POINT_GROUP = "robocop.plugins"
+"""Name of the entry point group used to register Robocop plugins."""
+
+
+class UnknownPluginError(exceptions.FatalError):
+    def __init__(self, plugin_name: str, reference: str, plugins: list[str]) -> None:
+        from robocop.linter.utils.misc import RecommendationFinder  # noqa: PLC0415
+
+        if plugins:
+            similar = RecommendationFinder().find_similar(plugin_name, plugins)
+            known = similar or f" Installed plugins: {', '.join(sorted(plugins))}."
+        else:
+            known = " There are no Robocop plugins installed."
+        super().__init__(f"Plugin '{plugin_name}' used in '{reference}' is not installed.{known}")
+
+
+class InvalidPluginError(exceptions.FatalError):
+    def __init__(self, plugin_name: str, module_path: str, error: str) -> None:
+        super().__init__(f"Failed to load plugin '{plugin_name}' from '{module_path}': {error}")
+
+
+@dataclass(frozen=True)
+class Plugin:
+    """Robocop plugin registered with the ``robocop.plugins`` entry point."""
+
+    name: str
+    module_path: str
+
+    @property
+    def path(self) -> Path:
+        """Filesystem location of the plugin package."""
+        module = self.load()
+        if module_paths := list(getattr(module, "__path__", [])):
+            return Path(module_paths[0])
+        module_file = getattr(module, "__file__", None)
+        if module_file is None:
+            raise InvalidPluginError(self.name, self.module_path, "cannot determine the location of the plugin")
+        return Path(module_file).parent
+
+    def load(self) -> ModuleType:
+        try:
+            return import_module(self.module_path)
+        except ImportError as err:
+            raise InvalidPluginError(self.name, self.module_path, str(err)) from None
+
+
+class PluginRegistry:
+    """Container with all Robocop plugins discovered in the current environment."""
+
+    def __init__(self, plugins: dict[str, Plugin]) -> None:
+        self.plugins = plugins
+
+    @classmethod
+    def discover(cls) -> PluginRegistry:
+        plugins: dict[str, Plugin] = {}
+        for entry_point in entry_points(group=ENTRY_POINT_GROUP):
+            if entry_point.name in plugins:
+                typer.echo(
+                    f"Robocop plugin '{entry_point.name}' is registered more than once. "
+                    f"Using '{plugins[entry_point.name].module_path}' and ignoring '{entry_point.value}'.",
+                    err=True,
+                )
+                continue
+            plugins[entry_point.name] = Plugin(name=entry_point.name, module_path=entry_point.value)
+        return cls(plugins)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.plugins
+
+    def __iter__(self) -> Iterator[Plugin]:
+        return iter(sorted(self.plugins.values(), key=lambda plugin: plugin.name))
+
+    def __len__(self) -> int:
+        return len(self.plugins)
+
+    def get(self, reference: str) -> tuple[Plugin, str] | None:
+        """
+        Split the reference into the plugin and the path inside the plugin.
+
+        Returns:
+            Tuple with the plugin and the remaining, dot separated path, or None if the reference does not start
+            with a name of the installed plugin.
+
+        """
+        plugin_name, _, rest = reference.partition(".")
+        plugin = self.plugins.get(plugin_name)
+        if plugin is None:
+            return None
+        return plugin, rest
+
+    def resolve_module(self, reference: str) -> str | None:
+        """
+        Resolve the plugin reference to an importable module path.
+
+        ``example.rules`` is resolved to ``example_plugin.path.to.dir.rules``.
+
+        Returns:
+            Importable module path, or None if the reference does not point to an installed plugin.
+
+        """
+        resolved = self.get(reference)
+        if resolved is None:
+            return None
+        plugin, rest = resolved
+        return f"{plugin.module_path}.{rest}" if rest else plugin.module_path
+
+    def resolve_path(self, reference: str, suffix: str) -> Path | None:
+        """
+        Resolve the plugin reference to a path to the file inside the plugin.
+
+        ``example.config.strict`` is resolved to ``<plugin directory>/config/strict.toml``.
+
+        Returns:
+            Path to the file inside the plugin, or None if the reference does not point to an installed plugin.
+
+        """
+        resolved = self.get(reference)
+        if resolved is None:
+            return None
+        plugin, rest = resolved
+        if not rest:
+            raise exceptions.ConfigurationError(
+                f"Invalid plugin reference: '{reference}'. "
+                f"Expected '{plugin.name}.<path.to.file>' pointing to a file inside the plugin."
+            )
+        *parents, name = rest.split(".")
+        return plugin.path.joinpath(*parents, f"{name}{suffix}")
+
+
+@lru_cache(maxsize=1)
+def get_plugins() -> PluginRegistry:
+    """
+    Return the registry with all installed Robocop plugins.
+
+    Plugins are discovered only once and the result is cached. Use ``get_plugins.cache_clear()`` to force
+    rediscovery (for example in the tests).
+
+    Returns:
+        Registry with the installed plugins.
+
+    """
+    return PluginRegistry.discover()
+
+
+def resolve_module_reference(reference: str) -> str | None:
+    """
+    Resolve the plugin reference to an importable module path.
+
+    Returns:
+        Importable module path, or None if the reference does not point to an installed plugin.
+
+    """
+    return get_plugins().resolve_module(reference)
+
+
+def resolve_path_reference(reference: str, suffix: str = ".toml") -> Path:
+    """
+    Resolve the plugin reference to a path to the file inside the plugin.
+
+    Raises ``UnknownPluginError`` if the plugin is not installed.
+
+    Returns:
+        Path to the file inside the plugin.
+
+    """
+    plugins = get_plugins()
+    path = plugins.resolve_path(reference, suffix)
+    if path is None:
+        plugin_name = reference.partition(".")[0]
+        raise UnknownPluginError(plugin_name, reference, list(plugins.plugins))
+    return path

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 import typer
 from rich.console import Console
 
-from robocop import __version__
+from robocop import __version__, plugins
 from robocop.config import defaults, manager, parser, schema
 from robocop.formatter.runner import RobocopFormatter
 from robocop.linter import rules_list
@@ -36,7 +36,7 @@ app = typer.Typer(
     rich_markup_mode="rich",
     cls=CliWithVersion,
 )
-list_app = typer.Typer(help="List available rules, reports or formatters.")
+list_app = typer.Typer(help="List available rules, reports, formatters or plugins.")
 app.add_typer(list_app, name="list")
 
 
@@ -925,6 +925,39 @@ def list_formatters(
             "Non-default formatters needs to be selected explicitly with [bold cyan]--select[/] or "
             "configured with param `enabled=True`.\n"
         )
+
+
+@list_app.command(name="plugins")
+def list_plugins(
+    silent: silent_option = None,
+) -> None:
+    """
+    List installed Robocop plugins.
+
+    Plugins are Python packages that register themselves using the `robocop.plugins` entry point group.
+    Rules, formatters and configuration files shipped with a plugin are referenced using the
+    `plugin_name.path.inside.the.plugin` syntax.
+    """
+    from rich.box import MINIMAL  # noqa: PLC0415
+    from rich.table import Table  # noqa: PLC0415
+
+    if silent:
+        return
+    console = Console(soft_wrap=True)
+    installed_plugins = plugins.get_plugins()
+    if not len(installed_plugins):
+        console.print(
+            "There are no Robocop plugins installed.\n"
+            "Visit https://robocop.dev/stable/plugins/ to learn how to create and install a plugin."
+        )
+        return
+    table = Table(title="Plugins", header_style="bold", box=MINIMAL)
+    table.add_column("Name", justify="left", no_wrap=True)
+    table.add_column("Module")
+    table.add_column("Location")
+    for plugin in installed_plugins:
+        table.add_row(plugin.name, plugin.module_path, str(plugin.path))
+    console.print(table)
 
 
 @app.command("docs")

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     Languages = None
 
-from robocop import exceptions
+from robocop import exceptions, plugins
 from robocop.config.parser import compile_rule_pattern
 from robocop.formatter.formatters import FORMATTERS, import_formatter
 from robocop.linter.rules import AfterRunChecker, BaseChecker, ProjectChecker, Rule, RuleSeverity, VisitorChecker
@@ -315,6 +315,9 @@ class LinterImporter:
 
     def modules_from_paths(self, paths: list[str | Path]) -> Generator[types.ModuleType, None, None]:
         for path in paths:
+            if isinstance(path, str) and (plugin_module := plugins.resolve_module_reference(path)) is not None:
+                yield from self._modules_from_plugin(plugin_module)
+                continue
             path_object = Path(path)
             if path_object.exists():
                 if path_object.is_dir():
@@ -332,6 +335,27 @@ class LinterImporter:
                     yield mod
                 except ImportError:
                     raise exceptions.InvalidExternalCheckerError(str(path)) from None
+
+    def _modules_from_plugin(self, module_path: str) -> Generator[types.ModuleType, None, None]:
+        """
+        Import the module from the plugin together with all its submodules.
+
+        Unlike the modules imported from a physical path, plugin modules are installed packages and can be
+        imported by their name. Submodules are imported explicitly so that the plugin does not have to import
+        them in its ``__init__.py``.
+        """
+        try:
+            module = import_module(module_path)
+        except ImportError:
+            raise exceptions.InvalidExternalCheckerError(module_path) from None
+        yield module
+        for _, submodule_name, _ in pkgutil.walk_packages(
+            getattr(module, "__path__", []), prefix=f"{module.__name__}."
+        ):
+            try:
+                yield import_module(submodule_name)
+            except ImportError:
+                continue
 
     def _import_module_from_file(self, file_path: Path) -> types.ModuleType:
         """

--- a/tests/config/test_extend_config.py
+++ b/tests/config/test_extend_config.py
@@ -180,14 +180,14 @@ class TestExtendConfig:
         assert raw_config.config_source == str(final_config)
         assert raw_config.linter.select == ["DOC01", "DOC01"]
 
-    def test_not_toml_are_ignored(self):
+    def test_not_toml_is_resolved_as_plugin(self):
         # Arrange
         config_path = DATA_DIR / "extends" / "extends_with_name.toml"
         # Act
-        raw_config = RawConfig.from_dict(config_dict=read_toml_config(config_path), config_path=config_path)
+        with pytest.raises(typer.Exit) as exc_info:
+            RawConfig.from_dict(config_dict=read_toml_config(config_path), config_path=config_path)
         # Assert
-        assert raw_config.config_source == str(config_path)
-        assert raw_config.linter is None
+        assert exc_info.value.exit_code == 2
 
     def test_extend_does_not_exist(self, tmp_path):
         # Arrange

--- a/tests/documentation/conftest.py
+++ b/tests/documentation/conftest.py
@@ -1,4 +1,12 @@
+import os
+import sys
+from pathlib import Path
+
 import pytest
+
+from robocop import plugins
+
+PLUGIN_SITE_DIR = Path(__file__).parent.parent / "plugins" / "test_data" / "example_plugin"
 
 
 def pytest_collection_modifyitems(config, items):
@@ -7,3 +15,28 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "docs" in item.keywords:
                 item.add_marker(skip_docs)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def example_plugin_installed():
+    """
+    Register the example plugin used in the plugin documentation.
+
+    Documentation examples reference the ``example`` plugin. Putting the directory with the plugin package and
+    its metadata on ``sys.path`` (and ``PYTHONPATH``, for the examples executed in a subprocess) is enough for
+    ``importlib.metadata`` to discover it.
+    """
+    plugin_dir = str(PLUGIN_SITE_DIR)
+    previous_python_path = os.environ.get("PYTHONPATH")
+    sys.path.insert(0, plugin_dir)
+    os.environ["PYTHONPATH"] = os.pathsep.join(filter(None, [plugin_dir, previous_python_path]))
+    plugins.get_plugins.cache_clear()
+    try:
+        yield
+    finally:
+        sys.path.remove(plugin_dir)
+        if previous_python_path is None:
+            del os.environ["PYTHONPATH"]
+        else:
+            os.environ["PYTHONPATH"] = previous_python_path
+        plugins.get_plugins.cache_clear()

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from robocop import plugins
+from robocop.linter.rules import RuleSeverity
+from robocop.runtime.resolver import RuleMatcher, RulesLoader
+from robocop.version_handling import ROBOT_VERSION
+
+TEST_DATA_DIR = Path(__file__).parent / "test_data"
+PLUGIN_SITE_DIR = TEST_DATA_DIR / "example_plugin"
+
+
+def _purge_plugin_modules() -> None:
+    for module in list(sys.modules):
+        if module == "example_plugin" or module.startswith("example_plugin."):
+            del sys.modules[module]
+
+
+@pytest.fixture
+def example_plugin():
+    """
+    Register the example plugin without installing it.
+
+    ``importlib.metadata`` discovers entry points by scanning ``sys.path`` for ``*.dist-info`` directories,
+    so putting the directory with the plugin package and its metadata on ``sys.path`` is enough.
+    """
+    sys.path.insert(0, str(PLUGIN_SITE_DIR))
+    plugins.get_plugins.cache_clear()
+    try:
+        yield plugins.get_plugins()
+    finally:
+        sys.path.remove(str(PLUGIN_SITE_DIR))
+        plugins.get_plugins.cache_clear()
+        _purge_plugin_modules()
+
+
+@pytest.fixture
+def no_plugins():
+    """Make sure no Robocop plugin is discovered."""
+    plugins.get_plugins.cache_clear()
+    try:
+        yield
+    finally:
+        plugins.get_plugins.cache_clear()
+
+
+@pytest.fixture
+def loader() -> RulesLoader:
+    rule_matcher = RuleMatcher(
+        select=[],
+        extend_select=[],
+        ignore=[],
+        target_version=ROBOT_VERSION,
+        threshold=RuleSeverity.INFO,
+        fixable=[],
+        unfixable=[],
+    )
+    return RulesLoader(rule_matcher=rule_matcher, custom_rules=[], configure=[], silent=True, config_source="mock")

--- a/tests/plugins/test_data/example_plugin/example_plugin-1.0.0.dist-info/METADATA
+++ b/tests/plugins/test_data/example_plugin/example_plugin-1.0.0.dist-info/METADATA
@@ -1,0 +1,4 @@
+Metadata-Version: 2.1
+Name: example-plugin
+Version: 1.0.0
+Summary: Example Robocop plugin used in tests.

--- a/tests/plugins/test_data/example_plugin/example_plugin-1.0.0.dist-info/entry_points.txt
+++ b/tests/plugins/test_data/example_plugin/example_plugin-1.0.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[robocop.plugins]
+example = example_plugin

--- a/tests/plugins/test_data/example_plugin/example_plugin/__init__.py
+++ b/tests/plugins/test_data/example_plugin/example_plugin/__init__.py
@@ -1,0 +1,1 @@
+"""Example Robocop plugin used in tests."""

--- a/tests/plugins/test_data/example_plugin/example_plugin/config/strict.toml
+++ b/tests/plugins/test_data/example_plugin/example_plugin/config/strict.toml
@@ -1,0 +1,15 @@
+[tool.robocop.lint]
+custom_rules = [
+    "example.rules"
+]
+select = [
+    "plugin-rule"
+]
+configure = [
+    "line-too-long.line_length=140"
+]
+
+[tool.robocop.format]
+select = [
+    "example.formatters.ExampleFormatter"
+]

--- a/tests/plugins/test_data/example_plugin/example_plugin/formatters/ExampleFormatter.py
+++ b/tests/plugins/test_data/example_plugin/example_plugin/formatters/ExampleFormatter.py
@@ -1,0 +1,19 @@
+from robot.api.parsing import Token
+
+from robocop.formatter.formatters import Formatter
+
+
+class ExampleFormatter(Formatter):
+    """Formatter shipped with the example plugin. It replaces test case names with a configurable name."""
+
+    ENABLED = False
+
+    def __init__(self, test_name: str = "Plugin Test"):
+        super().__init__()
+        self.test_name = test_name
+
+    def visit_TestCaseName(self, node):  # noqa: N802
+        name_token = node.get_token(Token.TESTCASE_NAME)
+        if name_token is not None:
+            name_token.value = self.test_name
+        return node

--- a/tests/plugins/test_data/example_plugin/example_plugin/formatters/__init__.py
+++ b/tests/plugins/test_data/example_plugin/example_plugin/formatters/__init__.py
@@ -1,0 +1,7 @@
+"""Formatters shipped with the example plugin."""
+
+from example_plugin.formatters.ExampleFormatter import ExampleFormatter
+
+FORMATTERS = ["ExampleFormatter"]
+
+__all__ = ["ExampleFormatter"]

--- a/tests/plugins/test_data/example_plugin/example_plugin/rules/__init__.py
+++ b/tests/plugins/test_data/example_plugin/example_plugin/rules/__init__.py
@@ -1,0 +1,1 @@
+"""Rules shipped with the example plugin."""

--- a/tests/plugins/test_data/example_plugin/example_plugin/rules/naming.py
+++ b/tests/plugins/test_data/example_plugin/example_plugin/rules/naming.py
@@ -1,0 +1,20 @@
+from robocop.linter.rules import Rule, RuleSeverity, VisitorChecker
+
+
+class PluginRule(Rule):
+    """Rule shipped with the example plugin."""
+
+    name = "plugin-rule"
+    rule_id = "EXPL01"
+    message = "Test case name '{name}' comes from the plugin rule"
+    severity = RuleSeverity.INFO
+    added_in_version = "9.0.0"
+
+
+class PluginChecker(VisitorChecker):
+    """Checker shipped with the example plugin."""
+
+    plugin_rule: PluginRule
+
+    def visit_TestCaseName(self, node) -> None:  # noqa: N802
+        self.report(self.plugin_rule, name=node.name, node=node)

--- a/tests/plugins/test_data/test.robot
+++ b/tests/plugins/test_data/test.robot
@@ -1,0 +1,9 @@
+*** Test Cases ***
+Test
+    [Documentation]    doc
+    [Tags]    tag
+    Keyword
+
+*** Keywords ***
+Keyword
+    No Operation

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from robocop import plugins
+from robocop.config.parser import read_toml_config
+from robocop.config.schema import RawConfig
+from robocop.exceptions import FatalError
+from robocop.run import app
+from tests import working_directory
+
+TEST_DATA_DIR = Path(__file__).parent / "test_data"
+PLUGIN_SITE_DIR = TEST_DATA_DIR / "example_plugin"
+PLUGIN_DIR = PLUGIN_SITE_DIR / "example_plugin"
+
+
+def generate_config(config_path: Path, config_content: str) -> Path:
+    config_path.write_text(textwrap.dedent(config_content))
+    return config_path
+
+
+class TestPluginDiscovery:
+    def test_plugin_is_discovered(self, example_plugin):
+        assert "example" in example_plugin
+        assert len(example_plugin) == 1
+        plugin = example_plugin.plugins["example"]
+        assert plugin.name == "example"
+        assert plugin.module_path == "example_plugin"
+        assert plugin.path == PLUGIN_DIR
+
+    def test_no_plugins_installed(self, no_plugins):  # noqa: ARG002
+        assert len(plugins.get_plugins()) == 0
+
+    @pytest.mark.parametrize(
+        ("reference", "expected"),
+        [
+            ("example", "example_plugin"),
+            ("example.rules", "example_plugin.rules"),
+            ("example.formatters.ExampleFormatter", "example_plugin.formatters.ExampleFormatter"),
+            ("other.rules", None),
+            ("rules", None),
+            ("path/to/rules.py", None),
+        ],
+    )
+    def test_resolve_module_reference(self, example_plugin, reference, expected):  # noqa: ARG002
+        assert plugins.resolve_module_reference(reference) == expected
+
+    def test_resolve_path_reference(self, example_plugin):  # noqa: ARG002
+        assert plugins.resolve_path_reference("example.config.strict") == PLUGIN_DIR / "config" / "strict.toml"
+
+    def test_resolve_path_reference_unknown_plugin(self, example_plugin):  # noqa: ARG002
+        with pytest.raises(FatalError):
+            plugins.resolve_path_reference("unknown.config.strict")
+
+    def test_resolve_path_reference_without_path(self, example_plugin):  # noqa: ARG002
+        with pytest.raises(FatalError):
+            plugins.resolve_path_reference("example")
+
+
+class TestPluginRules:
+    def test_load_rules_from_plugin(self, example_plugin, loader):  # noqa: ARG002
+        loader.custom_rules = ["example.rules"]
+        loader.load_rules()
+        assert "EXPL01" in loader.rules
+        assert "plugin-rule" in loader.rules
+
+    def test_load_rules_from_plugin_root(self, example_plugin, loader):  # noqa: ARG002
+        loader.custom_rules = ["example"]
+        loader.load_rules()
+        assert "EXPL01" in loader.rules
+
+    def test_unknown_plugin_is_not_treated_as_plugin(self, example_plugin, loader):  # noqa: ARG002
+        loader.custom_rules = ["idontexist.rules"]
+        with pytest.raises(FatalError):
+            loader.load_rules()
+
+    def test_check_with_plugin_rule(self, example_plugin):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "check",
+                "--no-cache",
+                "--custom-rules",
+                "example.rules",
+                "--select",
+                "plugin-rule",
+                str(TEST_DATA_DIR / "test.robot"),
+            ],
+        )
+        assert "EXPL01 Test case name 'Test' comes from the plugin rule" in result.output
+
+
+class TestPluginFormatters:
+    @pytest.fixture
+    def source(self, tmp_path) -> Path:
+        source = tmp_path / "test.robot"
+        shutil.copy(TEST_DATA_DIR / "test.robot", source)
+        return source
+
+    @pytest.mark.parametrize("select", ["example.formatters.ExampleFormatter", "example.formatters"])
+    def test_format_with_plugin_formatter(self, example_plugin, source, select):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(app, ["format", "--select", select, str(source)])
+        assert result.exit_code == 0
+        assert "Plugin Test" in source.read_text()
+
+    def test_configure_plugin_formatter(self, example_plugin, source):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "format",
+                "--select",
+                "example.formatters.ExampleFormatter",
+                "--configure",
+                "ExampleFormatter.test_name=Configured Name",
+                str(source),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Configured Name" in source.read_text()
+
+
+class TestPluginConfigs:
+    def test_extends_plugin_config(self, example_plugin, tmp_path):  # noqa: ARG002
+        config_path = generate_config(
+            tmp_path / "robocop.toml",
+            """
+            [tool.robocop]
+            extends = ["example.config.strict"]
+
+            [tool.robocop.lint]
+            select = ["line-too-long"]
+            """,
+        )
+        raw_config = RawConfig.from_dict(config_dict=read_toml_config(config_path), config_path=config_path)
+        assert raw_config.linter.custom_rules == ["example.rules"]
+        assert raw_config.linter.select == ["plugin-rule", "line-too-long"]
+        assert raw_config.linter.configure == ["line-too-long.line_length=140"]
+        assert raw_config.formatter.select == ["example.formatters.ExampleFormatter"]
+
+    def test_extends_plugin_config_end_to_end(self, example_plugin, tmp_path):  # noqa: ARG002
+        shutil.copy(TEST_DATA_DIR / "test.robot", tmp_path / "test.robot")
+        generate_config(
+            tmp_path / "robocop.toml",
+            """
+            [tool.robocop]
+            extends = ["example.config.strict"]
+            """,
+        )
+        runner = CliRunner()
+        with working_directory(tmp_path):
+            result = runner.invoke(app, ["check", "--no-cache"])
+        assert "EXPL01 Test case name 'Test' comes from the plugin rule" in result.output
+
+    def test_extends_unknown_plugin(self, example_plugin, tmp_path):  # noqa: ARG002
+        config_path = generate_config(
+            tmp_path / "robocop.toml",
+            """
+            [tool.robocop]
+            extends = ["unknown.config.strict"]
+            """,
+        )
+        with pytest.raises(FatalError):
+            RawConfig.from_dict(config_dict=read_toml_config(config_path), config_path=config_path)
+
+    def test_extends_missing_plugin_config(self, example_plugin, tmp_path):  # noqa: ARG002
+        config_path = generate_config(
+            tmp_path / "robocop.toml",
+            """
+            [tool.robocop]
+            extends = ["example.config.idontexist"]
+            """,
+        )
+        with pytest.raises(FatalError):
+            RawConfig.from_dict(config_dict=read_toml_config(config_path), config_path=config_path)
+
+
+class TestListPlugins:
+    def test_list_plugins(self, example_plugin):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(app, ["list", "plugins"])
+        assert result.exit_code == 0
+        assert "example" in result.output
+        assert "example_plugin" in result.output
+
+    def test_list_plugins_no_plugins(self, no_plugins):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(app, ["list", "plugins"])
+        assert result.exit_code == 0
+        assert "There are no Robocop plugins installed." in result.output


### PR DESCRIPTION
Closes #1538

Adds plugin capability so custom rules, formatters and configuration files can be packaged and shipped as a regular Python package.

## How it works

A plugin registers itself with the `robocop.plugins` entry point group:

```toml
[project]
name = "example-plugin"

[project.entry-points."robocop.plugins"]
example = "example_plugin.path.to.dir"
```

The entry point name becomes the plugin namespace and the value points to an importable package. Resources are referenced with the `<plugin_name>.<path.inside.the.plugin>` syntax - the first segment is the plugin name, the rest is a dot separated path relative to the plugin package. No directory layout is enforced.

```toml
[tool.robocop]
extends = ["example.config.strict"]

[tool.robocop.lint]
custom-rules = ["example.rules"]

[tool.robocop.format]
select = ["example.formatters.FormatterA"]
```

Installing a plugin does **not** enable anything on its own - it only registers the namespace, so nothing changes for users who do not reference plugin resources explicitly.

## Changes

- new `robocop/plugins.py` with entry point discovery (cached), `Plugin`, `PluginRegistry` and the `resolve_module_reference()` / `resolve_path_reference()` helpers
- `custom-rules`: plugin references are resolved in `LinterImporter.modules_from_paths`. The referenced package is imported together with all its submodules, so a plugin does not have to import them in its `__init__.py`
- formatters: plugin references are resolved in `import_custom_formatter`, both for a single class (`example.formatters.FormatterA`) and for a whole module (`example.formatters`). Formatters are still configured by their class name
- `extends`: plugin config references are resolved in `extend_configs`
- new `robocop list plugins` command
- docs: new `docs/plugins.md` page plus cross-links from custom rules, custom formatters and configuration docs

Reports are not included - the issue marks them as future work and there is currently no way to load a custom report at all.

## Breaking change

`extends` values that do not end with `.toml` were previously silently ignored. They are now resolved as plugin references and Robocop reports an error if the plugin or its configuration file does not exist.

## Tests

`tests/plugins/` contains a real example plugin package registered through a generated `.dist-info/entry_points.txt` placed on `sys.path`, so entry point discovery is exercised for real without a `pip install`. It covers discovery, reference resolution, custom rules, formatters (including `--configure`), `extends` (unit and end to end), `robocop list plugins` and the error paths.

The documentation examples on the new page are executed by the `-m docs` suite - `tests/documentation/conftest.py` registers the same example plugin.
