### PR TITLE
feat: support custom reports

### DIFF
--- a/docs/linter/reports/reports.md
+++ b/docs/linter/reports/reports.md
@@ -92,6 +92,83 @@ You can filter the list using ``--enabled`` / ``--disabled`` flags:
 robocop list reports --disabled
 ```
 
+## Custom reports
+
+Robocop can load and run reports defined outside Robocop. Custom reports are enabled with the same
+``--reports`` option - instead of the report name, provide the source with the reports:
+
+- a path to the Python file or a directory with the reports,
+- an importable module (for example ``my_package.reports``),
+- a [plugin](../../plugins.md) reference (for example ``example.reports``).
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports path/to/custom_report.py
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "path/to/custom_report.py"
+    ]
+    ```
+
+All reports found in the source are loaded and enabled. Paths in the configuration file are resolved relative to
+the configuration file. Custom reports can be mixed with the built-in reports and the order is preserved:
+
+```toml
+[tool.robocop.lint]
+reports = [
+    "all",
+    "path/to/custom_report.py"
+]
+```
+
+A custom report is a class that inherits from the ``robocop.linter.reports.Report`` class and defines the ``name``
+and the ``description`` attributes:
+
+```python title="custom_report.py"
+from robocop.linter.reports import Report
+
+
+class CustomReport(Report):
+    """
+    **Report name**: ``custom_report``
+
+    Report that prints the number of the found issues.
+    """
+
+    def __init__(self, config):
+        self.name = "custom_report"
+        self.description = "Prints number of found issues"
+        self.prefix = "Custom report"
+        super().__init__(config)
+
+    def configure(self, name, value):
+        """Optional - allows to configure the report with --configure custom_report.prefix=value."""
+        if name == "prefix":
+            self.prefix = value
+        else:
+            super().configure(name, value)
+
+    def generate_report(self, diagnostics, **kwargs):
+        print(f"{self.prefix}: found {len(diagnostics.diagnostics)} issues")
+```
+
+Custom reports are configured, listed and documented the same way as the built-in ones:
+
+```bash
+robocop check --reports custom_report.py --configure custom_report.prefix=Issues
+robocop list reports --reports custom_report.py
+robocop docs custom_report
+```
+
+Reports inheriting from ``robocop.linter.reports.FileReport``, ``JsonFileReport`` or ``ComparableReport`` are also
+supported. A custom report cannot reuse the name of the built-in report.
+
 ## Comparing results
 
 Several reports allow comparing the current run with the previous run. ``--persistent`` and ``--compare`` options can

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -74,6 +74,36 @@ configure = [
 ]
 ```
 
+### Reports
+
+Enable reports shipped with a plugin by pointing ``reports`` to a module with the reports:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```
+    robocop check --reports example.reports
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "example.reports"
+    ]
+    ```
+
+All reports from the referenced module are loaded and enabled. Use the full reference
+(``example.reports.issues_count``) to only enable reports from the selected module. Reports are configured by their
+name, without the plugin namespace:
+
+```toml
+[tool.robocop.lint]
+configure = [
+    "issues_count.prefix=Issues"
+]
+```
+
 ### Configuration files
 
 Configuration files shipped with a plugin are used with the [extends](configuration/index.md#inherit-configuration-file)
@@ -139,6 +169,9 @@ example_plugin/
     formatters/
         __init__.py
         ExampleFormatter.py
+    reports/
+        __init__.py
+        issues_count.py
     config/
         strict.toml
 ```
@@ -150,6 +183,7 @@ With such a layout, the plugin provides:
 | ``example.rules`` | ``example_plugin/rules`` package with the rules and checkers |
 | ``example.formatters`` | all formatters from the ``example_plugin/formatters`` package |
 | ``example.formatters.ExampleFormatter`` | single ``ExampleFormatter`` formatter |
+| ``example.reports`` | all reports from the ``example_plugin/reports`` package |
 | ``example.config.strict`` | ``example_plugin/config/strict.toml`` configuration file |
 
 !!! note
@@ -217,6 +251,26 @@ formatters are run when the whole module is selected:
 from example_plugin.formatters.ExampleFormatter import ExampleFormatter
 
 FORMATTERS = ["ExampleFormatter"]
+```
+
+### Reports
+
+Reports inside a plugin follow the [custom report](linter/reports/reports.md#custom-reports) rules:
+
+```python title="example_plugin/reports/issues_count.py"
+from robocop.linter.reports import Report
+
+
+class IssuesCountReport(Report):
+    """Report shipped with the example plugin."""
+
+    def __init__(self, config):
+        self.name = "issues_count"
+        self.description = "Returns number of found issues"
+        super().__init__(config)
+
+    def generate_report(self, diagnostics, **kwargs):
+        print(f"Found {len(diagnostics.diagnostics)} issues")
 ```
 
 ### Configuration files

--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -325,6 +325,7 @@ extends = ["example.config.strict"]
 
 [tool.robocop.lint]
 custom_rules = ["example.rules"]
+reports = ["example.reports"]
 
 [tool.robocop.format]
 select = ["example.formatters.FormatterA"]
@@ -337,6 +338,36 @@ Note that ``extends`` values that do not end with ``.toml`` were previously sile
 resolved as plugin references, and Robocop reports an error if the plugin or its configuration file is missing.
 
 See the [plugins documentation](../plugins.md) for more details.
+
+### Custom reports (#1115)
+
+Reports can now be defined outside Robocop, in the same way as the custom rules and formatters. Custom reports are
+enabled with the existing ``--reports`` option by pointing it to the source with the reports: a path to the Python
+file or a directory, an importable module or a plugin reference:
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop check --reports path/to/custom_report.py
+    robocop check --reports example.reports
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.lint]
+    reports = [
+        "all",
+        "path/to/custom_report.py"
+    ]
+    ```
+
+All reports found in the source are loaded and enabled. Custom report is a class that inherits from the
+``robocop.linter.reports.Report`` class and defines the ``name`` and the ``description`` attributes. Such report
+can be configured (``--configure custom_report.param=value``), listed (``robocop list reports``) and documented
+(``robocop docs custom_report``) exactly like the built-in reports.
+
+See the [reports documentation](../linter/reports/reports.md#custom-reports) for more details.
 
 ### Other features
 

--- a/src/robocop/config/schema.py
+++ b/src/robocop/config/schema.py
@@ -30,6 +30,11 @@ def validate_config_fields(config_dict: dict[str, Any], known_fields: set[str], 
         raise typer.Exit(code=1)
 
 
+def _is_report_path(report: str) -> bool:
+    """Check if the report configuration value points to the file or directory with the custom reports."""
+    return "/" in report or "\\" in report or report.endswith(".py")
+
+
 @dataclass
 class RawWhitespaceConfig:
     space_count: int | None = None
@@ -89,6 +94,13 @@ class RawLinterConfig:
             config_dict["custom_rules"] = [
                 resolve_relative_path(path, config_path.parent, ensure_exists=True)
                 for path in config_dict["custom_rules"]
+            ]
+        if "reports" in config_dict:
+            config_dict["reports"] = [
+                resolve_relative_path(report, config_path.parent, ensure_exists=True)
+                if _is_report_path(report)
+                else report
+                for report in config_dict["reports"]
             ]
         return cls(**config_dict, silent=silent)
 

--- a/src/robocop/exceptions.py
+++ b/src/robocop/exceptions.py
@@ -53,6 +53,15 @@ class InvalidExternalCheckerError(FatalError):
         super().__init__(msg)
 
 
+class InvalidCustomReportSource(FatalError):
+    def __init__(self, source: str) -> None:
+        super().__init__(
+            f"Failed to load custom reports from '{source}'. "
+            f"Verify if it is a valid report name, path to the file or directory with the reports, "
+            f"an importable module or an installed plugin."
+        )
+
+
 class RuleParamNotFoundError(FatalError):  # TODO, not used
     def __init__(self, rule: Rule, param: str, checker: object) -> None:
         super().__init__(

--- a/src/robocop/linter/reports/__init__.py
+++ b/src/robocop/linter/reports/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import importlib.util
 import inspect
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from robocop import exceptions
+from robocop import exceptions, plugins
 from robocop.config import defaults
 from robocop.config.builder import ConfigBuilder
 from robocop.linter.utils.misc import get_robocop_cache_directory, str2bool
@@ -101,9 +102,9 @@ class ComparableReport(Report):
         raise NotImplementedError
 
 
-def load_reports(config: Config) -> dict[str, Report]:
+def _load_reports_from_paths(config: Config, paths: list[str | Path]) -> dict[str, Report]:
     """
-    Load all valid reports.
+    Load all valid reports from the given paths.
 
     Report is considered valid if it inherits from the ` Report ` class
     and contains both `name` and `description` attributes.
@@ -111,10 +112,12 @@ def load_reports(config: Config) -> dict[str, Report]:
     loaded_reports: dict[str, Report] = {}
     # TODO: Move report loading to resolver
     robocop_importer = LinterImporter()
-    for module in robocop_importer.modules_from_paths([Path(__file__).parent]):
+    for module in robocop_importer.modules_from_paths(paths):
         classes = inspect.getmembers(module, inspect.isclass)
         for report_class in classes:
             if not issubclass(report_class[1], Report):
+                continue
+            if report_class[1].__module__ == __name__:  # base classes imported by the module
                 continue
             report = report_class[1](config)
             if not hasattr(report, "name") or not hasattr(report, "description"):
@@ -123,20 +126,95 @@ def load_reports(config: Config) -> dict[str, Report]:
     return loaded_reports
 
 
+def load_reports(config: Config) -> dict[str, Report]:
+    """Load all valid, internal reports."""
+    return _load_reports_from_paths(config, [Path(__file__).parent])
+
+
+def is_custom_report_source(name: str) -> bool:
+    """
+    Check if the value configured with ``--reports`` points to the source with the custom reports.
+
+    Custom reports are loaded from the plugin reference (``example.reports``), importable module
+    (``package.reports``) or a path to the Python file or a directory with the reports.
+    """
+    if name in {"all", "None"}:
+        return False
+    if plugins.resolve_module_reference(name) is not None:
+        return True
+    if "." in name or "/" in name or "\\" in name:
+        return True
+    return Path(name).is_dir()
+
+
+def load_custom_reports(config: Config, sources: list[str]) -> dict[str, Report]:
+    """Load reports from the custom sources: plugins, importable modules or paths."""
+    if not sources:
+        return {}
+    for source in sources:
+        _validate_custom_report_source(source)
+    return _load_reports_from_paths(config, list(sources))
+
+
+def _validate_custom_report_source(source: str) -> None:
+    """Raise an error if the custom report source cannot be resolved to a plugin, path or a module."""
+    if plugins.resolve_module_reference(source) is not None or Path(source).exists():
+        return
+    try:
+        if importlib.util.find_spec(source) is not None:
+            return
+    except (ImportError, AttributeError, ValueError):
+        pass
+    raise exceptions.InvalidCustomReportSource(source)
+
+
+def load_all_reports(config: Config) -> dict[str, Report]:
+    """Load internal reports together with the custom reports configured with ``--reports``."""
+    reports = load_reports(config)
+    sources = [name for name in _iter_configured_reports(config) if is_custom_report_source(name)]
+    for name, report in load_custom_reports(config, sources).items():
+        if name not in reports:
+            reports[name] = report
+    return reports
+
+
+def _iter_configured_reports(config: Config) -> list[str]:
+    """Return reports configured with ``--reports``, with the comma separated values split."""
+    return [csv_report for report in config.linter.reports for csv_report in report.split(",")]
+
+
 def get_reports(config: Config) -> dict[str, Report]:
     """
     Return the dictionary with a list of valid, enabled reports (listed in `configured_reports` set of str).
 
     If `configured_reports` contains `all`, then all default reports are enabled.
+
+    Values that point to the custom reports source (plugin, module or path) load and enable all reports
+    defined in such source.
     """
-    configured_reports = config.linter.reports
-    configured_reports = [csv_report for report in configured_reports for csv_report in report.split(",")]
+    configured_reports = _iter_configured_reports(config)
     if "None" in configured_reports:
         configured_reports = []
+    custom_reports_by_source: dict[str, dict[str, Report]] = {
+        source: load_custom_reports(config, [source])
+        for source in dict.fromkeys(configured_reports)
+        if is_custom_report_source(source)
+    }
     reports = load_reports(config)
+    for source_reports in custom_reports_by_source.values():
+        for name, report_class in source_reports.items():
+            if name in reports:
+                raise exceptions.ConfigurationError(
+                    f"Custom report '{name}' has the same name as the existing Robocop report."
+                )
+            reports[name] = report_class
     enabled_reports = {name: report_class for name, report_class in reports.items() if report_class.ENABLED}
     for report in configured_reports:
-        if report == "all":
+        if report in custom_reports_by_source:  # custom reports are enabled by loading them
+            for name, report_class in custom_reports_by_source[report].items():
+                if name not in enabled_reports:
+                    enabled_reports[name] = report_class
+        elif report == "all":
             for name, report_class in reports.items():
                 if report_class.NO_ALL and name not in enabled_reports:
                     enabled_reports[name] = report_class
@@ -150,7 +228,7 @@ def get_reports(config: Config) -> dict[str, Report]:
     return enabled_reports
 
 
-def print_reports(reports: dict[str, Report], only_enabled: bool | None) -> str:
+def print_reports(reports: dict[str, Report], only_enabled: bool | None, config: Config | None = None) -> str:
     """
     Return description of reports.
 
@@ -160,10 +238,15 @@ def print_reports(reports: dict[str, Report], only_enabled: bool | None) -> str:
     Args:
         reports: Dictionary with loaded reports.
         only_enabled: if set to True/False, it will filter reports by enabled/disabled status
+        config: configuration used to load reports. Required to list custom reports.
 
     """
-    config = ConfigBuilder().from_raw(None, None)
-    all_public_reports = [report for report in load_reports(config).values() if not report.INTERNAL]
+    if config is None:
+        config = ConfigBuilder().from_raw(None, None)
+    all_reports = load_all_reports(config)
+    for name, report in reports.items():  # custom reports enabled in the runtime configuration
+        all_reports.setdefault(name, report)
+    all_public_reports = [report for report in all_reports.values() if not report.INTERNAL]
     all_public_reports = sorted(all_public_reports, key=lambda x: x.name)
     configured_reports = {x.name for x in reports.values()}
     available_reports = ""

--- a/src/robocop/run.py
+++ b/src/robocop/run.py
@@ -10,7 +10,7 @@ from robocop.config import defaults, manager, parser, schema
 from robocop.formatter.runner import RobocopFormatter
 from robocop.linter import rules_list
 from robocop.linter.diagnostics import Diagnostic
-from robocop.linter.reports import load_reports, print_reports
+from robocop.linter.reports import load_all_reports, print_reports
 from robocop.linter.rules import Rule, RuleSeverity
 from robocop.linter.runner import RobocopLinter
 from robocop.linter.utils.misc import ROBOCOP_RULES_URL, get_plural_form  # TODO: move higher up
@@ -347,7 +347,8 @@ reports_option = Annotated[
         "-r",
         show_default=False,
         help="Generate reports from reported issues. To list available reports use `list reports` command. "
-        "Use `all` to enable all reports.",
+        "Use `all` to enable all reports. Custom reports are enabled by providing a path, module or plugin "
+        "reference with the reports.",
         rich_help_panel="Reports",
     ),
 ]
@@ -866,7 +867,7 @@ def list_reports(
     config_manager = manager.ConfigManager(config=configuration_file, overwrite_config=overwrite_config)
     runner = RobocopLinter(config_manager)
     if not silent:
-        console.print(print_reports(runner.reports, enabled))  # TODO: color etc
+        console.print(print_reports(runner.reports, enabled, config_manager.default_config))  # TODO: color etc
 
 
 @list_app.command(name="formatters")
@@ -977,7 +978,7 @@ def print_resource_documentation(
         console.print(resolved_config.rules[name].description_with_configurables)
         return
 
-    reports = load_reports(config_manager.default_config)
+    reports = load_all_reports(config_manager.default_config)
     if name in reports:
         docs = textwrap.dedent(str(reports[name].__doc__))
         console.print(docs)

--- a/tests/linter/reports/test_custom_reports.py
+++ b/tests/linter/reports/test_custom_reports.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from robocop import exceptions
+from robocop.linter.reports import get_reports, is_custom_report_source, load_all_reports
+from robocop.run import app
+from tests import working_directory
+
+TEST_DATA_DIR = Path(__file__).parent / "test_data"
+CUSTOM_REPORTS_DIR = TEST_DATA_DIR / "custom_reports"
+CUSTOM_REPORT_FILE = CUSTOM_REPORTS_DIR / "custom_report.py"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("all", False),
+        ("None", False),
+        ("sarif", False),
+        ("print_issues", False),
+        ("custom_reports.custom_report", True),
+        ("path/to/reports", True),
+        ("path\\to\\reports", True),
+        ("reports.py", True),
+    ],
+)
+def test_is_custom_report_source(name, expected):
+    assert is_custom_report_source(name) == expected
+
+
+@pytest.mark.parametrize("source", [CUSTOM_REPORTS_DIR, CUSTOM_REPORT_FILE])
+def test_load_custom_report_from_path(source, empty_config):
+    empty_config.linter.reports = [str(source)]
+    reports = get_reports(empty_config)
+    assert "custom_report" in reports
+    assert "print_issues" in reports  # default reports are still loaded
+
+
+def test_custom_report_is_listed_in_all_reports(empty_config):
+    empty_config.linter.reports = [str(CUSTOM_REPORT_FILE)]
+    assert "custom_report" in load_all_reports(empty_config)
+
+
+def test_load_custom_report_with_other_reports(empty_config):
+    empty_config.linter.reports = [f"{CUSTOM_REPORT_FILE},timestamp"]
+    reports = get_reports(empty_config)
+    assert "custom_report" in reports
+    assert "timestamp" in reports
+
+
+def test_custom_reports_disabled_with_none(empty_config):
+    empty_config.linter.reports = [str(CUSTOM_REPORT_FILE), "None"]
+    reports = get_reports(empty_config)
+    assert "custom_report" not in reports
+
+
+def test_custom_report_order_is_preserved(empty_config):
+    empty_config.linter.reports = ["all", str(CUSTOM_REPORT_FILE)]
+    reports_list = list(get_reports(empty_config).keys())
+    assert reports_list.index("timestamp") < reports_list.index("custom_report")
+    empty_config.linter.reports = [str(CUSTOM_REPORT_FILE), "all"]
+    reports_list = list(get_reports(empty_config).keys())
+    assert reports_list.index("custom_report") < reports_list.index("timestamp")
+
+
+def test_custom_report_with_existing_name(empty_config, tmp_path):
+    report_source = tmp_path / "duplicated_report.py"
+    report_source.write_text(
+        "from robocop.linter.reports import Report\n\n\n"
+        "class DuplicatedReport(Report):\n"
+        "    def __init__(self, config):\n"
+        "        self.name = 'timestamp'\n"
+        "        self.description = 'Duplicated report'\n"
+        "        super().__init__(config)\n"
+    )
+    empty_config.linter.reports = [str(report_source)]
+    with pytest.raises(exceptions.ConfigurationError):
+        get_reports(empty_config)
+
+
+def test_custom_report_path_relative_to_config(tmp_path):
+    shutil.copy(CUSTOM_REPORT_FILE, tmp_path / "custom_report.py")
+    (tmp_path / "test.robot").write_text("*** Settings ***\n\n")
+    (tmp_path / "robocop.toml").write_text('[tool.robocop.lint]\nreports = ["custom_report.py"]\n')
+    runner = CliRunner()
+    with working_directory(tmp_path):
+        result = runner.invoke(app, ["check", "--no-cache"])
+    assert "Custom report: found 4 issues" in result.output
+
+
+def test_invalid_custom_report_source(empty_config, capsys):
+    empty_config.linter.reports = ["idontexist.reports"]
+    with pytest.raises(exceptions.InvalidCustomReportSource):
+        get_reports(empty_config)
+    _, err = capsys.readouterr()
+    assert "Failed to load custom reports from" in err
+    assert "'idontexist.reports'" in err
+
+
+def test_check_with_custom_report(tmp_path):
+    (tmp_path / "test.robot").write_text("*** Settings ***\n\n")
+    runner = CliRunner()
+    with working_directory(tmp_path):
+        result = runner.invoke(app, ["check", "--no-cache", "--reports", str(CUSTOM_REPORT_FILE)])
+    assert "Custom report: found 4 issues" in result.output
+
+
+def test_configure_custom_report(tmp_path):
+    (tmp_path / "test.robot").write_text("*** Settings ***\n\n")
+    runner = CliRunner()
+    with working_directory(tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "check",
+                "--no-cache",
+                "--reports",
+                str(CUSTOM_REPORT_FILE),
+                "--configure",
+                "custom_report.prefix=Configured",
+            ],
+        )
+    assert "Configured: found 4 issues" in result.output
+
+
+def test_list_custom_report(tmp_path):
+    runner = CliRunner()
+    with working_directory(tmp_path):
+        result = runner.invoke(app, ["list", "reports", "--reports", str(CUSTOM_REPORT_FILE)])
+    assert "custom_report" in result.output
+    assert "Example custom report" in result.output
+
+
+def test_docs_for_custom_report(tmp_path):
+    config_path = tmp_path / "robocop.toml"
+    config_path.write_text(f'[tool.robocop.lint]\nreports = ["{CUSTOM_REPORT_FILE.as_posix()}"]\n')
+    runner = CliRunner()
+    with working_directory(tmp_path):
+        result = runner.invoke(app, ["docs", "custom_report"])
+    assert "Example custom report" in result.output

--- a/tests/linter/reports/test_data/custom_reports/custom_report.py
+++ b/tests/linter/reports/test_data/custom_reports/custom_report.py
@@ -1,0 +1,26 @@
+"""Custom reports used in the tests."""
+
+from robocop.linter.reports import Report
+
+
+class CustomReport(Report):
+    """
+    **Report name**: ``custom_report``
+
+    Example custom report.
+    """
+
+    def __init__(self, config):
+        self.name = "custom_report"
+        self.description = "Example custom report"
+        self.prefix = "Custom report"
+        super().__init__(config)
+
+    def configure(self, name, value):
+        if name == "prefix":
+            self.prefix = value
+        else:
+            super().configure(name, value)
+
+    def generate_report(self, diagnostics, **kwargs):  # noqa: ARG002
+        print(f"{self.prefix}: found {len(diagnostics.diagnostics)} issues")

--- a/tests/plugins/test_data/example_plugin/example_plugin/reports/issues_count.py
+++ b/tests/plugins/test_data/example_plugin/example_plugin/reports/issues_count.py
@@ -1,0 +1,24 @@
+from robocop.linter.reports import Report
+
+
+class IssuesCountReport(Report):
+    """
+    **Report name**: ``issues_count``
+
+    Report shipped with the example plugin. Prints the number of the found issues.
+    """
+
+    def __init__(self, config):
+        self.name = "issues_count"
+        self.description = "Returns number of found issues"
+        self.prefix = "Plugin report"
+        super().__init__(config)
+
+    def configure(self, name, value):
+        if name == "prefix":
+            self.prefix = value
+        else:
+            super().configure(name, value)
+
+    def generate_report(self, diagnostics, **kwargs):  # noqa: ARG002
+        print(f"{self.prefix}: found {len(diagnostics.diagnostics)} issues")

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -127,6 +127,39 @@ class TestPluginFormatters:
         assert "Configured Name" in source.read_text()
 
 
+class TestPluginReports:
+    @pytest.mark.parametrize("reports", ["example.reports", "example.reports.issues_count"])
+    def test_check_with_plugin_report(self, example_plugin, reports):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["check", "--no-cache", "--reports", reports, str(TEST_DATA_DIR / "test.robot")],
+        )
+        assert "Plugin report: found" in result.output
+
+    def test_configure_plugin_report(self, example_plugin):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "check",
+                "--no-cache",
+                "--reports",
+                "example.reports",
+                "--configure",
+                "issues_count.prefix=Configured",
+                str(TEST_DATA_DIR / "test.robot"),
+            ],
+        )
+        assert "Configured: found" in result.output
+
+    def test_list_plugin_report(self, example_plugin):  # noqa: ARG002
+        runner = CliRunner()
+        result = runner.invoke(app, ["list", "reports", "--reports", "example.reports"])
+        assert result.exit_code == 0
+        assert "issues_count" in result.output
+
+
 class TestPluginConfigs:
     def test_extends_plugin_config(self, example_plugin, tmp_path):  # noqa: ARG002
         config_path = generate_config(


### PR DESCRIPTION
Closes #1115

Reports can now be defined outside Robocop, in the same way as custom rules and formatters.
No new option was added - custom reports are enabled with the existing `--reports` option by pointing it to
the source with the reports:

- a path to a Python file or a directory with reports,
- an importable module (`my_package.reports`),
- a plugin reference (`example.reports`), so the newly added plugin functionality supports reports too.

```bash
robocop check --reports path/to/custom_report.py
robocop check --reports example.reports
```

```toml
[tool.robocop.lint]
reports = [
    "all",
    "path/to/custom_report.py"
]
```

All reports found in the source are loaded and enabled, and the configured order is preserved
(`reports = ["custom_report.py", "all"]` runs the custom report first).

A custom report is a class inheriting from `robocop.linter.reports.Report` (or `FileReport` / `JsonFileReport` /
`ComparableReport`) with `name` and `description` attributes. Such reports can be configured, listed and documented
exactly like the built-in ones:

```bash
robocop check --reports custom_report.py --configure custom_report.prefix=Issues
robocop list reports --reports custom_report.py
robocop docs custom_report
```

### Implementation notes

- `linter/reports/__init__.py`: report loading split into `_load_reports_from_paths`, with new
  `is_custom_report_source`, `load_custom_reports` and `load_all_reports` helpers. `get_reports` resolves custom
  sources, keeps the order, validates duplicated report names and still honours `all` / `None`.
- `exceptions.py`: new `InvalidCustomReportSource` raised when the source cannot be resolved to a plugin, path
  or module.
- `config/schema.py`: report values that look like paths are resolved relative to the configuration file.
- `run.py`: `list reports` and `docs` are aware of custom reports, `--reports` help updated.

### Tests

- `tests/linter/reports/test_custom_reports.py` - loading from file/directory, order, `None`, duplicated name,
  invalid source, configuration, `list reports`, `docs` and paths relative to the configuration file.
- `TestPluginReports` in `tests/plugins/test_plugins.py` with a new `example_plugin/reports` package.

### Documentation

- New *Custom reports* section in `docs/linter/reports/reports.md`.
- Reports sections in `docs/plugins.md` (usage + creating a plugin).
- Release notes entry in `docs/releasenotes/9.0.0.md`.
