### PR TITLE
fix: replace deprecated GitWildMatchPattern with GitIgnoreSpec

### DIFF
--- a/src/robocop/config/manager.py
+++ b/src/robocop/config/manager.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pathspec
-from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from robocop import exceptions, files
 from robocop.cache import RobocopCache
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
 CONFIG_NAMES = ("robocop.toml", "robot.toml", "pyproject.toml")
-GitIgnorePathSpec = pathspec.PathSpec
+GitIgnorePathSpec = pathspec.GitIgnoreSpec
 
 
 class GitIgnoreResolver:
@@ -44,7 +43,7 @@ class GitIgnoreResolver:
         """Return a PathSpec loaded from the file."""
         with path.open(encoding="utf-8") as gf:
             lines = gf.readlines()
-        return pathspec.PathSpec.from_lines(GitWildMatchPattern, lines)
+        return pathspec.GitIgnoreSpec.from_lines(lines)
 
     def resolve_path_ignores(self, path: Path) -> list[tuple[Path, GitIgnorePathSpec]]:
         """


### PR DESCRIPTION
## Summary

Running the test suite with warnings enabled produced **34,454 warnings**, all from a single source:

```
pathspec/pattern.py:125: DeprecationWarning: GitWildMatchPattern ('gitwildmatch') is deprecated.
Use 'gitignore' for GitIgnoreBasicPattern or GitIgnoreSpecPattern instead.
```

`GitIgnoreResolver.read_gitignore` built its spec with `pathspec.PathSpec.from_lines(GitWildMatchPattern, lines)`, which emits one `DeprecationWarning` per pattern line of every parsed `.gitignore`.

## Change

Use `pathspec.GitIgnoreSpec.from_lines(lines)` instead:

- it is the API `pathspec` points to as the replacement,
- it fully replicates git behaviour, including negation edge-cases where `PathSpec` + `GitWildMatchPattern` differs from real git,
- it is available since `pathspec` 0.10, so the existing `pathspec>=0.12` requirement is unchanged.

The existing workaround in `path_excluded` (appending a trailing separator for directories) is still required and was kept - verified that `GitIgnoreSpec` also needs the trailing slash to match a `dir/` pattern.

## Verification

- `uv run pytest tests -W always` -> **0 warnings** (was 34,454), 2190 passed, 77 skipped.
- Behaviour checked against both `pathspec` 0.12.1 and 1.1.1.
- `ruff check`, `ruff format` and `mypy` clean.

> [!NOTE]
> `tests/test_cli.py::test_version` fails locally for an unrelated reason (stale editable-install metadata reporting `5.9.0` vs `9.0.0b1`) and was deselected during the runs above.
