### PR TITLE
fix: handle comments between keywords in SmartSortKeywords

### DIFF
--- a/src/robocop/formatter/formatters/SmartSortKeywords.py
+++ b/src/robocop/formatter/formatters/SmartSortKeywords.py
@@ -95,7 +95,16 @@ class SmartSortKeywords(Formatter):
         while node.body and not isinstance(node.body[0], Keyword):
             before.append(node.body.pop(0))
         while node.body and not isinstance(node.body[-1], Keyword):
-            after.append(node.body.pop(-1))
+            after.insert(0, node.body.pop(-1))
+        # Non keyword nodes, such as comments, can be also placed between the keywords, for example after
+        # merging duplicated sections. Attach them to the preceding keyword so they are moved together with it.
+        keywords: list = []  # type: ignore[type-arg]
+        for child in node.body:
+            if isinstance(child, Keyword):
+                keywords.append(child)
+            else:
+                keywords[-1].body.append(child)
+        node.body = keywords
         return before, after
 
     def sort_function(self, kw: Keyword) -> str:

--- a/tests/formatter/formatters/SmartSortKeywords/expected/comment_between_keywords.robot
+++ b/tests/formatter/formatters/SmartSortKeywords/expected/comment_between_keywords.robot
@@ -1,0 +1,7 @@
+*** Keywords ***
+A Keyword
+    Log    2
+B Keyword
+    Log    1
+
+# standalone comment

--- a/tests/formatter/formatters/SmartSortKeywords/source/comment_between_keywords.robot
+++ b/tests/formatter/formatters/SmartSortKeywords/source/comment_between_keywords.robot
@@ -1,0 +1,8 @@
+*** Keywords ***
+B Keyword
+    Log    1
+
+*** Keywords ***
+# standalone comment
+A Keyword
+    Log    2

--- a/tests/formatter/formatters/SmartSortKeywords/test_formatter.py
+++ b/tests/formatter/formatters/SmartSortKeywords/test_formatter.py
@@ -79,5 +79,9 @@ class TestSmartSortKeywords(FormatterAcceptanceTest):
     def test_multiple_sections(self):
         self.compare(source="multiple_sections.robot")
 
+    def test_comment_between_keywords(self):
+        """Merged sections can leave a comment between the keywords (#1718)."""
+        self.compare(source="comment_between_keywords.robot", select=["MergeAndOrderSections"])
+
     def test_disablers(self):
         self.compare(source="disablers.robot", not_modified=True)


### PR DESCRIPTION
Closes #1718

## Problem

`SmartSortKeywords` crashed with:

```
AttributeError: 'Comment' object has no attribute 'body'
```

`leave_only_keywords()` only stripped non-`Keyword` nodes from the **start** and the **end** of the `*** Keywords ***` section body. Everything left in between was assumed to be a `Keyword`.

That assumption breaks when `MergeAndOrderSections` (which runs before `SmartSortKeywords`) merges duplicated keyword sections: the leading comment of the second section ends up in the *middle* of the merged body. `pop_empty_lines()` then accessed `kw.body` on a `Comment` and blew up.

Minimal reproduction with `--select SmartSortKeywords --select MergeAndOrderSections`:

```robotframework
*** Keywords ***
B Keyword
    Log    1

*** Keywords ***
# standalone comment
A Keyword
    Log    2
```

## Fix

- Non-`Keyword` nodes left between the keywords are now attached to the body of the preceding keyword, so they are preserved and moved together with that keyword while sorting.
- Fixed a latent bug in the same method: nodes following the last keyword were collected with `after.append(node.body.pop(-1))`, which **reversed** their order. Now they keep the original order.

Result for the reproduction above:

```robotframework
*** Keywords ***
A Keyword
    Log    2
B Keyword
    Log    1

# standalone comment
```

## Tests

Added `test_comment_between_keywords` together with new `source/` and `expected/` data files.

`uv run pytest tests/formatter` → 579 passed, 6 skipped. `ruff` and `mypy` clean.
