### PR TITLE
fix: align only first column of documentation in AlignSettingsSection

### DIFF
--- a/src/robocop/formatter/formatters/AlignSettingsSection.py
+++ b/src/robocop/formatter/formatters/AlignSettingsSection.py
@@ -93,11 +93,14 @@ class AlignSettingsSection(Formatter):
     @skip_section_if_disabled
     def visit_SettingSection(self, node: SettingSection) -> SettingSection:  # noqa: N802
         statements = []
+        # we're removing original separator, instead of modyfing it
         for child in node.body:
             if self.disablers.is_node_disabled("AlignSettingsSection", child) or self.is_node_skip(child):
                 statements.append(child)
             elif child.type in (Token.EOL, Token.COMMENT):
                 statements.append(misc.left_align(child))
+            elif child.type == Token.DOCUMENTATION:
+                statements.append([list(line) for line in child.lines])
             else:
                 statements.append(list(misc.tokens_by_lines(child)))
         nodes_to_be_aligned = [st for st in statements if isinstance(st, list)]
@@ -117,11 +120,18 @@ class AlignSettingsSection(Formatter):
             return is_library, True
         return is_library, statement_type in self.TOKENS_WITH_ARGUMENTS
 
+    @staticmethod
+    def is_documentation(statement: list[list[Token]]) -> bool:
+        return bool(statement[0][0].type == Token.DOCUMENTATION)
+
     def align_rows(self, statements: list[Statement | list[list[Token]]], look_up: dict[int, int]) -> list[Statement]:
         aligned_statements = []
         for st in statements:
             if not isinstance(st, list):
                 aligned_statements.append(st)
+                continue
+            if self.is_documentation(st):
+                aligned_statements.append(self.align_documentation(st, look_up))
                 continue
             is_library, indent_args = self.should_indent_arguments(st)
             aligned_statement: list[Token] = []
@@ -136,7 +146,9 @@ class AlignSettingsSection(Formatter):
                 up_to = self.up_to_column if self.up_to_column != -1 else len(line) - 2
                 for index, token in enumerate(line[:-2]):
                     aligned_statement.append(token)
-                    separator = self.calc_separator(index, up_to, indent_arg, token, look_up)
+                    separator = self.calc_separator(
+                        index, up_to, indent_arg, token, look_up, self.formatting_config.separator
+                    )
                     aligned_statement.append(Token(Token.SEPARATOR, separator))
                 last_token = line[-2]
                 # remove leading whitespace before token
@@ -146,7 +158,29 @@ class AlignSettingsSection(Formatter):
             aligned_statements.append(Statement.from_tokens(aligned_statement))
         return aligned_statements
 
-    def calc_separator(self, index: int, up_to: int, indent_arg: bool, token: Token, look_up: dict[int, int]) -> str:
+    def align_documentation(self, documentation: list[list[Token]], look_up: dict[int, int]) -> Statement:
+        prev_token = None
+        aligned = []
+        for line in documentation:
+            if len(line) == 1 and line[0].type == Token.EOL:  # remove empty lines in between
+                continue
+            for index, token in enumerate(line):
+                if index == 0:
+                    prev_token = token
+                    continue
+                if token.type != Token.SEPARATOR:
+                    break
+                token.value = self.calc_separator(
+                    index - 1, up_to=1, indent_arg=False, token=prev_token, look_up=look_up, default_value=token.value
+                )
+            # blank multiline adds spaces to EOL
+            line[-1].value = line[-1].value.lstrip(" \t")
+            aligned.extend(line)
+        return Statement.from_tokens(aligned)
+
+    def calc_separator(
+        self, index: int, up_to: int, indent_arg: bool, token: Token, look_up: dict[int, int], default_value: str
+    ) -> str:
         if index < up_to:
             if self.fixed_width:
                 return max(self.fixed_width - len(token.value), self.formatting_config.space_count) * " "
@@ -160,7 +194,7 @@ class AlignSettingsSection(Formatter):
                     * " "
                 )
             return (look_up[index] - len(token.value) + arg_indent + self.formatting_config.space_count) * " "
-        return self.formatting_config.space_count * " "
+        return default_value
 
     def create_look_up(self, statements: list[list[list[Token]]]) -> dict[int, int]:
         look_up: dict[int, int] = defaultdict(int)

--- a/tests/formatter/formatters/AlignSettingsSection/expected/all_columns.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/all_columns.robot
@@ -10,9 +10,13 @@ Test Timeout     1 min
 Library          CustomLibrary                        WITH NAME                                                                     name
 Library          ArgsedLibrary                        ${1}                                                                          ${2}             ${3}
 
-Documentation    Example using the space separated format.
-...              and this documentation is multiline
-...              where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags     default tag 1                        default tag 2                                                                 default tag 3    default tag 4    default tag 5
 Test Setup       Open Application                     App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/all_columns_fixed.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/all_columns_fixed.robot
@@ -10,9 +10,13 @@ Test Timeout        1 min
 Library             CustomLibrary       WITH NAME           name
 Library             ArgsedLibrary       ${1}                ${2}                ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation       Here is some regular text that should be formatted
+...
+...                 | This pre-formatted text should stay intact
+...                 |    1.2 <----> 1.2    .--> 1.2
+...                 |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                 |    1.4    `-> 1.4    /    1.4
+...                 |    1.5        1.5 <-´     1.5
 
 Default Tags        default tag 1       default tag 2       default tag 3       default tag 4       default tag 5
 Test Setup          Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/selected_part.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/selected_part.robot
@@ -10,9 +10,13 @@ Test Timeout  1 min
 Library          CustomLibrary    WITH NAME    name
 Library          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation    Example using the space separated format.
-...              and this documentation is multiline
-...              where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup       Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/selected_whole.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/selected_whole.robot
@@ -10,9 +10,13 @@ Test Timeout     1 min
 Library          CustomLibrary    WITH NAME    name
 Library          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation    Example using the space separated format.
-...              and this documentation is multiline
-...              where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags     default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup       Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test.robot
@@ -10,9 +10,13 @@ Test Timeout     1 min
 Library          CustomLibrary    WITH NAME    name
 Library          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation    Example using the space separated format.
-...              and this documentation is multiline
-...              where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags     default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup       Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_fixed.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_fixed.robot
@@ -10,9 +10,13 @@ Test Timeout                       1 min
 Library                            CustomLibrary    WITH NAME    name
 Library                            ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation                      Example using the space separated format.
-...                                and this documentation is multiline
-...                                where this line should go I wonder?
+Documentation                      Here is some regular text that should be formatted
+...
+...                                | This pre-formatted text should stay intact
+...                                |    1.2 <----> 1.2    .--> 1.2
+...                                |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                                |    1.4    `-> 1.4    /    1.4
+...                                |    1.5        1.5 <-´     1.5
 
 Default Tags                       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup                         Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width.robot
@@ -10,9 +10,13 @@ Test Timeout        1 min
 Library             CustomLibrary    WITH NAME    name
 Library             ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation       Example using the space separated format.
-...                 and this documentation is multiline
-...                 where this line should go I wonder?
+Documentation       Here is some regular text that should be formatted
+...
+...                 | This pre-formatted text should stay intact
+...                 |    1.2 <----> 1.2    .--> 1.2
+...                 |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                 |    1.4    `-> 1.4    /    1.4
+...                 |    1.5        1.5 <-´     1.5
 
 Default Tags        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup          Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_49_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_49_width.robot
@@ -10,9 +10,13 @@ Test Timeout                                     1 min
 Library                                          CustomLibrary    WITH NAME    name
 Library                                          ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation                                    Example using the space separated format.
-...                                              and this documentation is multiline
-...                                              where this line should go I wonder?
+Documentation                                    Here is some regular text that should be formatted
+...
+...                                              | This pre-formatted text should stay intact
+...                                              |    1.2 <----> 1.2    .--> 1.2
+...                                              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                                              |    1.4    `-> 1.4    /    1.4
+...                                              |    1.5        1.5 <-´     1.5
 
 Default Tags                                     default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup                                       Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_50_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_50_width.robot
@@ -10,9 +10,13 @@ Test Timeout                                      1 min
 Library                                           CustomLibrary    WITH NAME    name
 Library                                           ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation                                     Example using the space separated format.
-...                                               and this documentation is multiline
-...                                               where this line should go I wonder?
+Documentation                                     Here is some regular text that should be formatted
+...
+...                                               | This pre-formatted text should stay intact
+...                                               |    1.2 <----> 1.2    .--> 1.2
+...                                               |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                                               |    1.4    `-> 1.4    /    1.4
+...                                               |    1.5        1.5 <-´     1.5
 
 Default Tags                                      default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup                                        Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_51_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_51_width.robot
@@ -10,9 +10,13 @@ Test Timeout                                       1 min
 Library                                            CustomLibrary    WITH NAME    name
 Library                                            ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation                                      Example using the space separated format.
-...                                                and this documentation is multiline
-...                                                where this line should go I wonder?
+Documentation                                      Here is some regular text that should be formatted
+...
+...                                                | This pre-formatted text should stay intact
+...                                                |    1.2 <----> 1.2    .--> 1.2
+...                                                |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                                                |    1.4    `-> 1.4    /    1.4
+...                                                |    1.5        1.5 <-´     1.5
 
 Default Tags                                       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup                                         Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_52_width.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_min_width_52_width.robot
@@ -10,9 +10,13 @@ Test Timeout                                        1 min
 Library                                             CustomLibrary    WITH NAME    name
 Library                                             ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation                                       Example using the space separated format.
-...                                                 and this documentation is multiline
-...                                                 where this line should go I wonder?
+Documentation                                       Here is some regular text that should be formatted
+...
+...                                                 | This pre-formatted text should stay intact
+...                                                 |    1.2 <----> 1.2    .--> 1.2
+...                                                 |    1.3 <-.    1.3 <-´ ,-> 1.3
+...                                                 |    1.4    `-> 1.4    /    1.4
+...                                                 |    1.5        1.5 <-´     1.5
 
 Default Tags                                        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup                                          Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/test_skip_documentation.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/test_skip_documentation.robot
@@ -10,9 +10,13 @@ Test Timeout        1 min
 Library             CustomLibrary    WITH NAME    name
 Library             ArgsedLibrary    ${1}    ${2}    ${3}
 
-Documentation     Example using the space separated format.
-...  and this documentation is multiline
-...  where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup          Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/expected/three_columns.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/expected/three_columns.robot
@@ -10,9 +10,13 @@ Test Timeout     1 min
 Library          CustomLibrary                        WITH NAME    name
 Library          ArgsedLibrary                        ${1}    ${2}    ${3}
 
-Documentation    Example using the space separated format.
-...              and this documentation is multiline
-...              where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags     default tag 1                        default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup       Open Application                     App A

--- a/tests/formatter/formatters/AlignSettingsSection/source/test.robot
+++ b/tests/formatter/formatters/AlignSettingsSection/source/test.robot
@@ -10,9 +10,13 @@ Test Timeout  1 min
 Library    CustomLibrary   WITH NAME  name
 Library    ArgsedLibrary   ${1}  ${2}  ${3}
 
-Documentation     Example using the space separated format.
-...  and this documentation is multiline
-...  where this line should go I wonder?
+Documentation    Here is some regular text that should be formatted
+...
+...              | This pre-formatted text should stay intact
+...              |    1.2 <----> 1.2    .--> 1.2
+...              |    1.3 <-.    1.3 <-´ ,-> 1.3
+...              |    1.4    `-> 1.4    /    1.4
+...              |    1.5        1.5 <-´     1.5
 
 Default Tags       default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
 Test Setup       Open Application    App A

--- a/tests/formatter/formatters/AlignSettingsSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignSettingsSection/test_formatter.py
@@ -20,7 +20,7 @@ class TestAlignSettingsSection(FormatterAcceptanceTest):
         )
 
     def test_align_selected_whole(self):
-        self.compare(source="test.robot", expected="selected_whole.robot", start_line=1, end_line=25)
+        self.compare(source="test.robot", expected="selected_whole.robot", start_line=1, end_line=29)
 
     def test_align_selected_part(self):
         self.compare(source="test.robot", expected="selected_part.robot", start_line=9, end_line=14)


### PR DESCRIPTION
## Summary

Fixes #1773. `AlignSettingsSection` was the only default-enabled formatter that reformatted the `Documentation` value in the `*** Settings ***` section beyond the first column. It split documentation continuation lines on 2+‑space separators and re-aligned them, corrupting [pre-formatted blocks](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#preformatted-text).

### Root cause

Documentation was aligned like any other setting: every column of every continuation line was re-separated to match the section alignment grid. This destroyed the intentional inner spacing of pre-formatted documentation (tables, ASCII art, indented blocks).

### Change

- `AlignSettingsSection` now aligns **only the first column** of `Documentation` - i.e. the separator between the `Documentation` setting name and its first value - so the setting name still lines up with the rest of the settings.
- The original separators inside documentation continuation lines are **preserved as-is**, keeping pre-formatted blocks intact.
- Empty in-between lines are normalized and trailing whitespace on blank continuation lines is stripped, but the meaningful inner content/spacing is left untouched.

This keeps documentation visually consistent with the aligned settings block while never rewriting the author formatting of the documentation body.

### Tests

- Updated the `test.robot` source (and affected expected files) to use a pre-formatted multiline `Documentation` example, verifying the body is left intact while the first column is aligned.
- `expected/test_skip_documentation.robot` regenerated to reflect the new first-column-only alignment.
- Adjusted line ranges in `test_align_selected_whole` for the larger documentation block.

## Verification

- Pre-formatted documentation blocks are no longer corrupted; only the `Documentation` setting name is aligned.
- Full `AlignSettingsSection` formatter suite passes (24); `ruff check`, `ruff format`, and `mypy` clean.
