### PR TITLE
feat: add ignore_docs parameter to line-too-long

### DIFF
--- a/src/robocop/linter/checkers/raw_file.py
+++ b/src/robocop/linter/checkers/raw_file.py
@@ -36,9 +36,12 @@ class RawFileRulesChecker(RawFileChecker):
             self.bom_encoding_in_file.check(is_bom)
             self.ignored_data.check(self.lines, is_bom)
         if self.trailing_whitespace.enabled or self.line_too_long.enabled:
+            doc_lines: frozenset[int] = frozenset()
+            if self.line_too_long.enabled and self.line_too_long.ignore_docs:
+                doc_lines = self.line_too_long.get_documentation_lines(self.source_file.model)
             for lineno, line in enumerate(self.lines, start=1):
                 self.trailing_whitespace.check(line, lineno)
-                self.line_too_long.check(line, lineno)
+                self.line_too_long.check(line, lineno, doc_lines)
         self.too_many_trailing_blank_lines.check(self.lines)
         self.missing_trailing_blank_line.check(self.lines)
 

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,6 +44,8 @@ from robocop.linter.utils.misc import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from robot.parsing import File
     from robot.parsing.model.blocks import Section
     from robot.parsing.model.statements import Node, Statement
@@ -387,6 +390,11 @@ class LineTooLongRule(Rule):
 
         robocop check --configure line-too-long.ignore_pattern=pattern
 
+    Lines that are part of a documentation (the ``Documentation`` setting or the ``[Documentation]`` setting of a
+    test case or keyword, together with their ``...`` continuation lines) can be ignored using the following option:
+
+        robocop check --configure line-too-long.ignore_docs=True
+
     This rule is not fixed by ``robocop check --fix``. Use the ``SplitTooLongLine`` formatter
     (``robocop format``) to fix it.
 
@@ -405,6 +413,13 @@ class LineTooLongRule(Rule):
             show_type="regex",
             desc="ignore lines that contain configured pattern",
         ),
+        RuleParam(
+            name="ignore_docs",
+            default=False,
+            converter=str2bool,
+            show_type="bool",
+            desc="ignore lines that are part of a documentation",
+        ),
     ]
     severity_threshold = SeverityThreshold("line_length", substitute_value="allowed_length")
     added_in_version = "1.0.0"
@@ -415,8 +430,10 @@ class LineTooLongRule(Rule):
     deprecated_names = ("0508",)
     fix_suggestion = "Break long lines using the '...' continuation syntax."
 
-    def check(self, line: str, lineno: int) -> None:
+    def check(self, line: str, lineno: int, doc_lines: frozenset[int] = frozenset()) -> None:
         if not self.enabled:
+            return
+        if lineno in doc_lines:
             return
         line = line.rstrip().expandtabs(4)
         if len(line) <= self.line_length:
@@ -452,6 +469,14 @@ class LineTooLongRule(Rule):
 
     def line_is_ignored(self, line: str) -> bool:
         return bool(self.ignore_pattern and self.ignore_pattern.search(line))
+
+    @staticmethod
+    def get_documentation_lines(model: File) -> frozenset[int]:
+        """Collect line numbers covered by documentation settings (including continuation lines)."""
+        doc_lines: set[int] = set()
+        for doc in _iter_documentation(model):
+            doc_lines.update(range(doc.lineno, doc.end_lineno + 1))
+        return frozenset(doc_lines)
 
 
 class EmptySectionRule(FixableRule):
@@ -1173,6 +1198,13 @@ def get_documentation_length(node: Node) -> int:
         if isinstance(child, Documentation):
             doc_len += child.end_lineno - child.lineno + 1
     return doc_len
+
+
+def _iter_documentation(model: File) -> Iterator[Documentation]:
+    """Yield every ``Documentation`` statement in the model (suite, test case and keyword documentation)."""
+    for node in ast.walk(model):
+        if isinstance(node, Documentation):
+            yield node
 
 
 KEYWORD_CALL_ALIKE = tuple(

--- a/tests/linter/cli/test_rule.py
+++ b/tests/linter/cli/test_rule.py
@@ -60,6 +60,11 @@ class TestDescribeRule:
 
             robocop check --configure line-too-long.ignore_pattern=pattern
 
+        Lines that are part of a documentation (the ``Documentation`` setting or the ``[Documentation]`` setting of a
+        test case or keyword, together with their ``...`` continuation lines) can be ignored using the following option:
+
+            robocop check --configure line-too-long.ignore_docs=True
+
         This rule is not fixed by ``robocop check --fix``. Use the ``SplitTooLongLine`` formatter
         (``robocop format``) to fix it.
 
@@ -73,6 +78,9 @@ class TestDescribeRule:
             ignore_pattern = None
                 type: pattern_type
                 info: ignore lines that contain configured pattern
+            ignore_docs = False
+                type: str2bool
+                info: ignore lines that are part of a documentation
 
         """).lstrip()
         assert expected == out
@@ -105,6 +113,11 @@ class TestDescribeRule:
 
             robocop check --configure line-too-long.ignore_pattern=pattern
 
+        Lines that are part of a documentation (the ``Documentation`` setting or the ``[Documentation]`` setting of a
+        test case or keyword, together with their ``...`` continuation lines) can be ignored using the following option:
+
+            robocop check --configure line-too-long.ignore_docs=True
+
         This rule is not fixed by ``robocop check --fix``. Use the ``SplitTooLongLine`` formatter
         (``robocop format``) to fix it.
 
@@ -118,6 +131,9 @@ class TestDescribeRule:
             ignore_pattern = None
                 type: pattern_type
                 info: ignore lines that contain configured pattern
+            ignore_docs = False
+                type: str2bool
+                info: ignore lines that are part of a documentation
 
         """).lstrip()
         assert expected == out

--- a/tests/linter/rules/lengths/line_too_long/expected_output_ignore_docs.txt
+++ b/tests/linter/rules/lengths/line_too_long/expected_output_ignore_docs.txt
@@ -1,0 +1,4 @@
+ignore_docs.robot:10:120 [W] LEN08 Line is too long (139/120)
+ignore_docs.robot:17:120 [W] LEN08 Line is too long (139/120)
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/line_too_long/ignore_docs.robot
+++ b/tests/linter/rules/lengths/line_too_long/ignore_docs.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Documentation    This is a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long suite documentation line
+...              And a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long continuation line of documentation
+
+
+*** Test Cases ***
+Test
+    [Documentation]    This is a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long test documentation
+    ...                And a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long continuation line
+    Keyword With Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Name And  ${args}
+
+
+*** Keywords ***
+Keyword
+    [Documentation]    This is a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long keyword documentation
+    ...                And a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long continuation line
+    Keyword With Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Name And  ${args}

--- a/tests/linter/rules/lengths/line_too_long/test_rule.py
+++ b/tests/linter/rules/lengths/line_too_long/test_rule.py
@@ -7,6 +7,13 @@ class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
 
+    def test_ignore_docs(self):
+        self.check_rule(
+            configure=["line-too-long.ignore_docs=True"],
+            src_files=["ignore_docs.robot"],
+            expected_file="expected_output_ignore_docs.txt",
+        )
+
     def test_extended(self):
         self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
 
@@ -37,6 +44,9 @@ class TestRuleAcceptance(RuleAcceptance):
                 ignore_pattern = None
                     type: pattern_type
                     info: ignore lines that contain configured pattern
+                ignore_docs = False
+                    type: str2bool
+                    info: ignore lines that are part of a documentation
             """  # noqa: E501
         ).lstrip()
         output = self.check_rule(


### PR DESCRIPTION
## Summary

Adds an `ignore_docs` parameter to the `line-too-long` (LEN08) rule, resolving #1442. This makes the rule consistent with `too-long-keyword` and `too-long-test-case`, which already offer `ignore_docs`.

When enabled, lines belonging to a documentation setting (the `Documentation` suite setting or the `[Documentation]` setting of a test case/keyword), including their `...` continuation lines, are ignored.

```
robocop check --configure line-too-long.ignore_docs=True
```

Default is `False`, so existing behavior is unchanged.

## Approach

The rule stays a fast `RawFileChecker` (no visitor refactor). When `ignore_docs` is enabled, the checker reuses the already-parsed model (parsed anyway for visitor checkers/disablers) to collect the line numbers covered by `Documentation` statements and skips them in the raw line loop.

Benefits:
- **No extra parse** and **zero cost when the option is off** (the default path is unchanged).
- **Language-aware for free**: localized settings such as `[Dokumentacja]` are resolved by the RF parser into `Documentation` nodes, so they are ignored correctly. Pipe-separated format, tabs and continuations are handled by the parser too.

## Changes

- `line-too-long` gains the `ignore_docs` param + docstring documentation.
- `LineTooLongRule.get_documentation_lines()` / `_iter_documentation()` collect documentation line ranges from the model.
- `RawFileRulesChecker` computes those lines once (only when the option is enabled) and passes them to `check()`.
- Acceptance test `test_ignore_docs` with `ignore_docs.robot` + expected output; updated the param-listing assertion.

## Testing

- `uv run pytest tests/linter/rules/lengths/ tests/linter/test_disablers.py` — pass
- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy --strict` — clean
- Manually verified localized (`language: pl`, `[Dokumentacja]`) documentation is ignored.

## Out of scope

The secondary idea from the issue discussion (ignoring unsplittable long single values) is left for a separate change.
