### PR TITLE
feat: improve config init output for severity, target version and project

### DIFF
--- a/src/robocop/config/generator.py
+++ b/src/robocop/config/generator.py
@@ -192,12 +192,12 @@ def _rule_select_lines(rules: list[Rule], target_version: Version) -> list[str]:
     """
     Build the ``select`` array listing every rule with a short inline comment.
 
-    Rules enabled by default are listed as active entries; rules disabled by default (community and
+    Rules enabled by default are listed as active entries; rules disabled by default (non-default and
     project rules) are listed commented out so they can be enabled by uncommenting them.
     """
     lines = [
         "# Rules to run. Each active entry enables a rule; remove or comment out an entry to disable it.",
-        "# Rules disabled by default (community and project rules) are listed commented out - uncomment",
+        "# Rules disabled by default (non-default and project rules) are listed commented out - uncomment",
         "# an entry to enable the rule. As-is, this list reproduces the default rule selection.",
         "select = [",
     ]

--- a/src/robocop/config/generator.py
+++ b/src/robocop/config/generator.py
@@ -52,7 +52,7 @@ def _wrap_comment(text: str, indent: str) -> list[str]:
 def _iter_rule_params(rule: Rule) -> Iterable[tuple[str, str, str, Any]]:
     """Yield ``(name, type, description, default)`` for every configurable rule parameter."""
     for param in rule.config.values():
-        if param.name == "enabled":
+        if param.name in ("enabled", "severity"):
             continue
         if isinstance(param, RuleParam):
             yield param.name, param.param_type, param.desc, param.default
@@ -114,8 +114,17 @@ def _global_options(target_version: Version) -> list[str]:
         ("default_exclude", list(defaults.DEFAULT_EXCLUDE), "Override the default excluded paths."),
         ("force_exclude", defaults.FORCE_EXCLUDE, "Enforce exclusions even for paths passed directly."),
         ("language", [], "Additional languages used to parse Robot Framework files."),
-        ("target_version", str(target_version), "Robot Framework version rules are evaluated against."),
-        ("project", False, "Run project level rules (they are otherwise enabled only when selected)."),
+        (
+            "target_version",
+            str(target_version.release[0]),
+            "Robot Framework major version rules are evaluated against.",
+        ),
+        (
+            "project",
+            True,
+            "Run project level rules. By default they run when a project rule is selected; "
+            "set to false (or use --no-project) to always skip them.",
+        ),
         ("analyze_libraries", defaults.ANALYZE_LIBRARIES, "Import libraries to analyze their keywords."),
         ("load_library_timeout", defaults.LOAD_LIBRARY_TIMEOUT, "Timeout (seconds) for importing a library."),
         ("library_workers", defaults.LIBRARY_WORKERS, "Use worker processes to import libraries."),
@@ -184,6 +193,10 @@ def _rule_lines(rules: list[Rule], target_version: Version) -> list[str]:
     lines = [
         "# Configure rule parameters and severities. Each entry uses the `rule-name.param=value` syntax.",
         "# Uncomment an entry to override the default value shown next to it.",
+        "#",
+        "# Every rule accepts a `severity` parameter (E = Error, W = Warning, I = Info) to change how its",
+        "# issues are reported, for example:",
+        '#     "line-too-long.severity=E",',
         "configure = [",
     ]
     grouped: dict[str, list[Rule]] = {}

--- a/src/robocop/config/generator.py
+++ b/src/robocop/config/generator.py
@@ -140,13 +140,6 @@ def _global_options(target_version: Version) -> list[str]:
 def _lint_options() -> list[str]:
     """Commented linter (``[tool.robocop.lint]``) options with their defaults."""
     options: list[tuple[str, Any, str]] = [
-        ("select", [], "Select which rules to run. Empty value runs all rules enabled by default."),
-        (
-            "extend_select",
-            [],
-            "Enable extra rules on top of the default ones. Use it to enable community "
-            "(default-disabled) rules without losing the default selection.",
-        ),
         ("ignore", [], "Disable selected rules."),
         ("fixable", [], "Only apply automatic fixes for the selected rules."),
         ("unfixable", [], "Never apply automatic fixes for the selected rules."),
@@ -188,31 +181,64 @@ def _format_options() -> list[str]:
     return _render_options("[tool.robocop.format]", options)
 
 
-def _rule_lines(rules: list[Rule], target_version: Version) -> list[str]:
-    """Build the commented ``configure`` array documenting every rule and its parameters."""
-    lines = [
-        "# Configure rule parameters and severities. Each entry uses the `rule-name.param=value` syntax.",
-        "# Uncomment an entry to override the default value shown next to it.",
-        "#",
-        "# Every rule accepts a `severity` parameter (E = Error, W = Warning, I = Info) to change how its",
-        "# issues are reported, for example:",
-        '#     "line-too-long.severity=E",',
-        "configure = [",
-    ]
+def _grouped_by_category(rules: list[Rule]) -> dict[str, list[Rule]]:
     grouped: dict[str, list[Rule]] = {}
     for rule in rules:
         grouped.setdefault(_rule_category(rule), []).append(rule)
+    return grouped
+
+
+def _rule_select_lines(rules: list[Rule], target_version: Version) -> list[str]:
+    """
+    Build the ``select`` array listing every rule with a short inline comment.
+
+    Rules enabled by default are listed as active entries; rules disabled by default (community and
+    project rules) are listed commented out so they can be enabled by uncommenting them.
+    """
+    lines = [
+        "# Rules to run. Each active entry enables a rule; remove or comment out an entry to disable it.",
+        "# Rules disabled by default (community and project rules) are listed commented out - uncomment",
+        "# an entry to enable the rule. As-is, this list reproduces the default rule selection.",
+        "select = [",
+    ]
+    grouped = _grouped_by_category(rules)
     for category in sorted(grouped):
         lines.append("")
-        lines.append(f"{INDENT}# {'-' * 60}")
         lines.append(f"{INDENT}# {category} rules")
-        lines.append(f"{INDENT}# {'-' * 60}")
         for rule in sorted(grouped[category], key=lambda rule: rule.rule_id):
             enabled = rule.enabled and not rule.is_disabled(target_version)
-            state = "enabled by default" if enabled else "disabled by default (enable it with `extend_select`)"
+            comment = f"  # {rule.message}" if rule.message else ""
+            if enabled:
+                lines.append(f'{INDENT}"{rule.name}",{comment}')
+            else:
+                note = "project rule" if rule.project_rule else "disabled by default"
+                lines.append(f'{INDENT}# "{rule.name}",{comment} ({note})')
+    lines.append("]")
+    return lines
+
+
+def _rule_configure_lines(rules: list[Rule]) -> list[str]:
+    """Build the commented ``configure`` array documenting every configurable rule parameter."""
+    lines = [
+        "# Configure rule parameters. Each entry uses the `rule-name.param=value` syntax.",
+        "# Uncomment an entry to override the default value shown next to it.",
+        "#",
+        "# Every rule also accepts a `severity` parameter (E = Error, W = Warning, I = Info) to change how",
+        '# its issues are reported, for example: "line-too-long.severity=E".',
+        "configure = [",
+    ]
+    grouped = _grouped_by_category(rules)
+    for category in sorted(grouped):
+        rules_with_params = [
+            rule for rule in sorted(grouped[category], key=lambda rule: rule.rule_id) if list(_iter_rule_params(rule))
+        ]
+        if not rules_with_params:
+            continue
+        lines.append("")
+        lines.append(f"{INDENT}# {category} rules")
+        for rule in rules_with_params:
             lines.append("")
-            lines.append(f"{INDENT}# {rule.rule_id} {rule.name} ({state})")
-            lines.extend(_wrap_comment(rule.message, INDENT))
+            lines.append(f"{INDENT}# {rule.name}")
             for name, param_type, desc, default in _iter_rule_params(rule):
                 if desc:
                     lines.extend(_wrap_comment(f"{name} ({param_type}): {desc}", INDENT))
@@ -255,7 +281,9 @@ def generate_config(rules: list[Rule], formatters: list[Formatter], target_versi
     lines.extend(_generate_header())
     lines.extend(_global_options(target_version))
     lines.extend(_lint_options())
-    lines.extend(_rule_lines(rules, target_version))
+    lines.extend(_rule_select_lines(rules, target_version))
+    lines.append("")
+    lines.extend(_rule_configure_lines(rules))
     lines.append("")
     lines.extend(_format_options())
     lines.extend(_formatter_lines(formatters))

--- a/tests/config/test_config_init.py
+++ b/tests/config/test_config_init.py
@@ -54,6 +54,36 @@ class TestConfigInit:
         assert "NormalizeSeparators" in content
         assert "Translate" in content
 
+    def test_severity_documented_once(self, tmp_path):
+        """The severity parameter is documented once, not repeated for every rule."""
+        runner = CliRunner()
+        with working_directory(tmp_path):
+            runner.invoke(app, ["config", "init"])
+        content = (tmp_path / "robocop.toml").read_text(encoding="utf-8")
+        assert "Every rule accepts a `severity` parameter" in content
+        # `.severity=` should only appear in the single documentation example, not per rule
+        # (`.severity_threshold=` is a different parameter and is excluded).
+        severity_entries = [
+            line for line in content.splitlines() if ".severity=" in line and ".severity_threshold=" not in line
+        ]
+        assert len(severity_entries) == 1
+        assert "line-too-long.severity=E" in severity_entries[0]
+
+    def test_target_version_is_major_only(self, tmp_path):
+        runner = CliRunner()
+        with working_directory(tmp_path):
+            runner.invoke(app, ["config", "init"])
+        data = tomllib.loads((tmp_path / "robocop.toml").read_text(encoding="utf-8"))
+        # target_version line is commented, so assert the rendered value in raw text
+        content = (tmp_path / "robocop.toml").read_text(encoding="utf-8")
+        assert "# target_version = " in content
+        for line in content.splitlines():
+            if line.startswith("# target_version = "):
+                value = line.split("=", 1)[1].strip().strip('"')
+                assert value.isdigit(), f"target_version should be a major version, got {value!r}"
+                break
+        assert "lint" in data["tool"]["robocop"]
+
     def test_generated_file_reproduces_default_behaviour(self, tmp_path):
         """Using the generated file as configuration should not change which rules are enabled."""
         runner = CliRunner()

--- a/tests/config/test_config_init.py
+++ b/tests/config/test_config_init.py
@@ -49,7 +49,7 @@ class TestConfigInit:
         assert '"todo-in-comment",  # Found a marker' in content
         # a default-enabled rule and its parameter in the configure section
         assert '# "todo-in-comment.markers=todo,fixme"' in content
-        # a community (default-disabled) rule is listed commented out in select
+        # a non-default (default-disabled) rule is listed commented out in select
         assert '# "unresolved-resource-import",' in content
         assert "(project rule)" in content
         # a default formatter and a disabled one
@@ -65,7 +65,7 @@ class TestConfigInit:
         select = data["tool"]["robocop"]["lint"]["select"]
         # only default-enabled rules are active entries
         assert "todo-in-comment" in select
-        # community and project rules are commented out, not active
+        # non-default and project rules are commented out, not active
         assert "unresolved-resource-import" not in select
 
     def test_severity_documented_once(self, tmp_path):

--- a/tests/config/test_config_init.py
+++ b/tests/config/test_config_init.py
@@ -45,14 +45,28 @@ class TestConfigInit:
         with working_directory(tmp_path):
             runner.invoke(app, ["config", "init"])
         content = (tmp_path / "robocop.toml").read_text(encoding="utf-8")
-        # a default-enabled rule and its parameter
-        assert "todo-in-comment" in content
+        # a default-enabled rule appears as an active select entry with an inline comment
+        assert '"todo-in-comment",  # Found a marker' in content
+        # a default-enabled rule and its parameter in the configure section
         assert '# "todo-in-comment.markers=todo,fixme"' in content
-        # a community (default-disabled) rule
-        assert "enable it with `extend_select`" in content
+        # a community (default-disabled) rule is listed commented out in select
+        assert '# "unresolved-resource-import",' in content
+        assert "(project rule)" in content
         # a default formatter and a disabled one
         assert "NormalizeSeparators" in content
         assert "Translate" in content
+
+    def test_rules_listed_in_select(self, tmp_path):
+        """Rules are represented as a select list, not as per-rule configure comment blocks."""
+        runner = CliRunner()
+        with working_directory(tmp_path):
+            runner.invoke(app, ["config", "init"])
+        data = tomllib.loads((tmp_path / "robocop.toml").read_text(encoding="utf-8"))
+        select = data["tool"]["robocop"]["lint"]["select"]
+        # only default-enabled rules are active entries
+        assert "todo-in-comment" in select
+        # community and project rules are commented out, not active
+        assert "unresolved-resource-import" not in select
 
     def test_severity_documented_once(self, tmp_path):
         """The severity parameter is documented once, not repeated for every rule."""
@@ -60,7 +74,7 @@ class TestConfigInit:
         with working_directory(tmp_path):
             runner.invoke(app, ["config", "init"])
         content = (tmp_path / "robocop.toml").read_text(encoding="utf-8")
-        assert "Every rule accepts a `severity` parameter" in content
+        assert "Every rule also accepts a `severity` parameter" in content
         # `.severity=` should only appear in the single documentation example, not per rule
         # (`.severity_threshold=` is a different parameter and is excluded).
         severity_entries = [


### PR DESCRIPTION
## Description

Follow-up improvements to the `robocop config init` command (added in #1893).

### Changes

- **Severity documented once.** The per-rule `severity` parameter created a lot of noise since every rule accepts it. It is now documented a single time at the top of the `[tool.robocop.lint]` `configure` array, with an example (`"line-too-long.severity=E"`), instead of being repeated for every rule.
- **Correct target version.** `target_version` is now rendered as the major version only (e.g. `7`) to match the accepted values (`4`, `5`, `6`, `7`), instead of the full `7.4.2`.
- **Correct project default.** Project rules run by default when a project rule is selected. The generated file now shows `project = true` and the description clarifies that `--no-project` (`project = false`) disables them, instead of the misleading `project = false`.

### Tests

Added tests asserting severity is documented once (no per-rule severity entries), and that `target_version` is a major-only value. Existing tests (valid TOML, reproduces default behaviour, etc.) still pass.
