### PR TITLE
fix: report empty and unterminated GROUP parse errors

### DIFF
--- a/src/robocop/linter/checkers/errors.py
+++ b/src/robocop/linter/checkers/errors.py
@@ -97,6 +97,12 @@ class ParsingErrorChecker(VisitorChecker):
 
     visit_For = visit_While = visit_Try = visit_If  # noqa: N815
 
+    def visit_Group(self, node: NestedBlock) -> None:  # noqa: N802
+        # Report block level errors such as ``GROUP cannot be empty.`` or ``GROUP must have closing END.``.
+        # Unlike IF/FOR/WHILE/TRY, we must not set ``self.in_block`` (it is only used for the ``invalid-if`` rule).
+        self.parse_errors(node)
+        self.generic_visit(node)
+
     def visit_KeywordCall(self, node: KeywordCall) -> None:  # noqa: N802
         if node.keyword and node.keyword.startswith("..."):
             col = node.data_tokens[0].col_offset + 1

--- a/tests/linter/rules/errors/parsing_error_group/expected_output.txt
+++ b/tests/linter/rules/errors/parsing_error_group/expected_output.txt
@@ -1,0 +1,5 @@
+groups.robot:3:5 [E] ERR01 Robot Framework syntax error: GROUP cannot be empty.
+groups.robot:7:5 [E] ERR01 Robot Framework syntax error: GROUP must have closing END.
+groups.robot:11:5 [E] ERR01 Robot Framework syntax error: GROUP accepts only one argument as name, got 3 arguments 'Too', 'many' and 'values'.
+
+Found 3 issues.

--- a/tests/linter/rules/errors/parsing_error_group/groups.robot
+++ b/tests/linter/rules/errors/parsing_error_group/groups.robot
@@ -1,0 +1,23 @@
+*** Test Cases ***
+Empty group
+    GROUP    Empty group
+    END
+
+Group without end
+    GROUP    No end
+        Log    message
+
+Group with too many values
+    GROUP    Too    many    values
+        Log    message
+    END
+
+Valid group
+    GROUP    Valid
+        Log    message
+    END
+
+Valid group without name
+    GROUP
+        Log    message
+    END

--- a/tests/linter/rules/errors/parsing_error_group/test_rule.py
+++ b/tests/linter/rules/errors/parsing_error_group/test_rule.py
@@ -1,0 +1,13 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    rule_name = "parsing-error"
+
+    def test_rule(self):
+        self.check_rule(
+            select=["parsing-error"],
+            src_files=["groups.robot"],
+            expected_file="expected_output.txt",
+            test_on_version=">=7.2",
+        )


### PR DESCRIPTION
## Summary

The `ParsingErrorChecker` had `visit_For = visit_While = visit_Try = visit_If` aliases but no `visit_Group`, so block-level `DataError`s on `GROUP` nodes were never surfaced. As a result two Robot Framework syntax errors were silently dropped:

- `GROUP cannot be empty.`
- `GROUP must have closing END.`

This PR adds `visit_Group` to the checker so both are now reported through the existing `parsing-error` (ERR01) rule, matching how empty `FOR`/`IF` blocks are handled.

## Changes

- `src/robocop/linter/checkers/errors.py`: add `visit_Group` to `ParsingErrorChecker`.
- Add acceptance test `tests/linter/rules/errors/parsing_error_group/` (gated to RF >= 7.2).

Part of the GROUP syntax work (#1159, #1158).