### PR TITLE
feat: add fix for the deprecated-run-keyword-if rule

### DIFF
--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -363,6 +363,7 @@ to detect metadata without a name.
 
 TODO
 
+add fix for the deprecated-run-keyword-if rule (#TBD)
 add fix for the duplicated-variable rule (#1857) (b7a87ed)
 add fix for the else-not-upper-case rule (#1854) (837a979)
 add fix for the empty-return rule (#1846) (f376046)

--- a/src/robocop/formatter/formatters/ReplaceRunKeywordIf.py
+++ b/src/robocop/formatter/formatters/ReplaceRunKeywordIf.py
@@ -2,25 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from robot.api.parsing import ElseHeader, ElseIfHeader, End, If, IfHeader, KeywordCall, Token
-
 from robocop.formatter.disablers import skip_if_disabled, skip_section_if_disabled
 from robocop.formatter.formatters import Formatter
 from robocop.formatter.utils import misc
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
+    from robot.api.parsing import If, KeywordCall
     from robot.parsing.model.blocks import Section
-
-
-def insert_separators(indent: str, tokens: list[Token], separator: str) -> Generator[Token, None, None]:
-    yield Token(Token.SEPARATOR, indent)
-    for token in tokens[:-1]:
-        yield token
-        yield Token(Token.SEPARATOR, separator)
-    yield tokens[-1]
-    yield Token(Token.EOL)
 
 
 class ReplaceRunKeywordIf(Formatter):
@@ -97,102 +85,11 @@ class ReplaceRunKeywordIf(Formatter):
         return self.generic_visit(node)
 
     @skip_if_disabled
-    def visit_KeywordCall(self, node: KeywordCall) -> KeywordCall:  # noqa: N802
+    def visit_KeywordCall(self, node: KeywordCall) -> KeywordCall | If:  # noqa: N802
         if not node.keyword:
             return node
         if misc.after_last_dot(misc.normalize_name(node.keyword)) == "runkeywordif":
-            return self.create_branched(node)
-        return node
-
-    def create_branched(self, node: KeywordCall) -> KeywordCall | If:
-        separator = node.tokens[0]
-        assign = node.get_tokens(Token.ASSIGN)
-        raw_args = node.get_tokens(Token.ARGUMENT)
-        if len(raw_args) < 2:
-            return node
-        end = End([separator, Token(Token.END), Token(Token.EOL)])
-        prev_if: If | None = None
-        for branch in reversed(list(self.split_args_on_delimiters(raw_args, ("ELSE", "ELSE IF"), assign=assign))):
-            if branch[0].value == "ELSE":
-                if len(branch) < 2:
-                    return node
-                args = branch[1:]
-                if self.check_for_useless_set_variable(args, assign):
-                    continue
-                header = ElseHeader([separator, Token(Token.ELSE), Token(Token.EOL)])
-            elif branch[0].value == "ELSE IF":
-                if len(branch) < 3:
-                    return node
-                header = ElseIfHeader(
-                    [
-                        separator,
-                        Token(Token.ELSE_IF),
-                        Token(Token.SEPARATOR, self.formatting_config.separator),
-                        branch[1],
-                        Token(Token.EOL),
-                    ]
-                )
-                args = branch[2:]
-            else:
-                if len(branch) < 2:
-                    return node
-                header = IfHeader(
-                    [
-                        separator,
-                        Token(Token.IF),
-                        Token(Token.SEPARATOR, self.formatting_config.separator),
-                        branch[0],
-                        Token(Token.EOL),
-                    ]
-                )
-                args = branch[1:]
-            keywords = self.create_keywords(args, assign, separator.value + self.formatting_config.indent)
-            if_block = If(header=header, body=keywords, orelse=prev_if)
-            prev_if = if_block
-        prev_if.end = end  # type: ignore[union-attr]
-        return prev_if
-
-    def create_keywords(self, arg_tokens: list[Token], assign: list[Token], indent: str) -> list[KeywordCall]:
-        keyword_name = misc.normalize_name(arg_tokens[0].value)
-        if keyword_name == "runkeywords":
-            return [
-                self.args_to_keyword(keyword[1:], assign, indent)
-                for keyword in self.split_args_on_delimiters(arg_tokens, ("AND",))
-            ]
-        if misc.is_var(keyword_name):
-            keyword_token = Token(Token.KEYWORD_NAME, "Run Keyword")
-            arg_tokens = [keyword_token, *arg_tokens]
-        return [self.args_to_keyword(arg_tokens, assign, indent)]
-
-    def args_to_keyword(self, arg_tokens: list[Token], assign: list[Token], indent: str) -> KeywordCall:
-        separated_tokens = list(
-            insert_separators(
-                indent,
-                [*assign, Token(Token.KEYWORD, arg_tokens[0].value), *arg_tokens[1:]],
-                self.formatting_config.separator,
+            return misc.run_keyword_if_to_branched(
+                node, self.formatting_config.separator, self.formatting_config.indent
             )
-        )
-        return KeywordCall.from_tokens(separated_tokens)
-
-    @staticmethod
-    def split_args_on_delimiters(
-        args: list[Token], delimiters: tuple[str, ...], assign: list[Token] | None = None
-    ) -> Generator[list[Token], None, None]:
-        split_points = [index for index, arg in enumerate(args) if arg.value in delimiters]
-        prev_index = 0
-        for split_point in split_points:
-            yield args[prev_index:split_point]
-            prev_index = split_point
-        yield args[prev_index : len(args)]
-        if assign and "ELSE" in delimiters and not any(arg.value == "ELSE" for arg in args):
-            values = [Token(Token.ARGUMENT, "${None}")] * len(assign)
-            yield [Token(Token.ELSE), Token(Token.ARGUMENT, "Set Variable"), *values]
-
-    @staticmethod
-    def check_for_useless_set_variable(tokens: list[Token], assign: list[Token]) -> bool:
-        if not assign or misc.normalize_name(tokens[0].value) != "setvariable" or len(tokens[1:]) != len(assign):
-            return False
-        for var, var_assign in zip(tokens[1:], assign, strict=False):
-            if misc.normalize_name(var.value) != misc.normalize_name(var_assign.value):
-                return False
-        return True
+        return node

--- a/src/robocop/formatter/utils/misc.py
+++ b/src/robocop/formatter/utils/misc.py
@@ -7,7 +7,17 @@ from typing import TYPE_CHECKING
 
 import typer
 from rich.markup import escape
-from robot.api.parsing import Comment, End, If, IfHeader, ModelVisitor, Token
+from robot.api.parsing import (
+    Comment,
+    ElseHeader,
+    ElseIfHeader,
+    End,
+    If,
+    IfHeader,
+    KeywordCall,
+    ModelVisitor,
+    Token,
+)
 from robot.parsing.model import Statement
 from robot.utils.robotio import file_writer
 
@@ -208,6 +218,127 @@ def wrap_in_if_and_replace_statement(node: Statement, statement: type[Statement]
     )
     end = End.from_params(indent=node.tokens[0].value)
     return If(header=header, body=[body], orelse=None, end=end)
+
+
+def _run_keyword_if_insert_separators(indent: str, tokens: list[Token], separator: str) -> Generator[Token, None, None]:
+    yield Token(Token.SEPARATOR, indent)
+    for token in tokens[:-1]:
+        yield token
+        yield Token(Token.SEPARATOR, separator)
+    yield tokens[-1]
+    yield Token(Token.EOL)
+
+
+def _run_keyword_if_split_args(
+    args: list[Token], delimiters: tuple[str, ...], assign: list[Token] | None = None
+) -> Generator[list[Token], None, None]:
+    split_points = [index for index, arg in enumerate(args) if arg.value in delimiters]
+    prev_index = 0
+    for split_point in split_points:
+        yield args[prev_index:split_point]
+        prev_index = split_point
+    yield args[prev_index : len(args)]
+    if assign and "ELSE" in delimiters and not any(arg.value == "ELSE" for arg in args):
+        values = [Token(Token.ARGUMENT, "${None}")] * len(assign)
+        yield [Token(Token.ELSE), Token(Token.ARGUMENT, "Set Variable"), *values]
+
+
+def _run_keyword_if_useless_set_variable(tokens: list[Token], assign: list[Token]) -> bool:
+    if not assign or normalize_name(tokens[0].value) != "setvariable" or len(tokens[1:]) != len(assign):
+        return False
+    return all(
+        normalize_name(var.value) == normalize_name(var_assign.value)
+        for var, var_assign in zip(tokens[1:], assign, strict=False)
+    )
+
+
+def _run_keyword_if_args_to_keyword(
+    arg_tokens: list[Token], assign: list[Token], indent: str, separator: str
+) -> KeywordCall:
+    separated_tokens = list(
+        _run_keyword_if_insert_separators(
+            indent,
+            [*assign, Token(Token.KEYWORD, arg_tokens[0].value), *arg_tokens[1:]],
+            separator,
+        )
+    )
+    return KeywordCall.from_tokens(separated_tokens)
+
+
+def _run_keyword_if_create_keywords(
+    arg_tokens: list[Token], assign: list[Token], indent: str, separator: str
+) -> list[KeywordCall]:
+    keyword_name = normalize_name(arg_tokens[0].value)
+    if keyword_name == "runkeywords":
+        return [
+            _run_keyword_if_args_to_keyword(keyword[1:], assign, indent, separator)
+            for keyword in _run_keyword_if_split_args(arg_tokens, ("AND",))
+        ]
+    if is_var(keyword_name):
+        keyword_token = Token(Token.KEYWORD_NAME, "Run Keyword")
+        arg_tokens = [keyword_token, *arg_tokens]
+    return [_run_keyword_if_args_to_keyword(arg_tokens, assign, indent, separator)]
+
+
+def run_keyword_if_to_branched(
+    node: KeywordCall, separator: str, indent: str, negate: bool = False
+) -> If | KeywordCall:
+    """
+    Convert a ``Run Keyword If`` (or ``Run Keyword Unless``) keyword call to an ``IF`` block.
+
+    ``separator`` is the whitespace used between tokens, ``indent`` is the extra indentation added to the block body.
+    When ``negate`` is set (``Run Keyword Unless``) the ``IF`` condition is wrapped in ``not (...)``.
+    The original ``node`` is returned unchanged when it cannot be safely converted.
+    """
+    base_separator = node.tokens[0]
+    assign = node.get_tokens(Token.ASSIGN)
+    raw_args = node.get_tokens(Token.ARGUMENT)
+    if len(raw_args) < 2:
+        return node
+    end = End([base_separator, Token(Token.END), Token(Token.EOL)])
+    prev_if: If | None = None
+    for branch in reversed(list(_run_keyword_if_split_args(raw_args, ("ELSE", "ELSE IF"), assign=assign))):
+        if branch[0].value == "ELSE":
+            if len(branch) < 2:
+                return node
+            args = branch[1:]
+            if _run_keyword_if_useless_set_variable(args, assign):
+                continue
+            header = ElseHeader([base_separator, Token(Token.ELSE), Token(Token.EOL)])
+        elif branch[0].value == "ELSE IF":
+            if len(branch) < 3:
+                return node
+            header = ElseIfHeader(
+                [
+                    base_separator,
+                    Token(Token.ELSE_IF),
+                    Token(Token.SEPARATOR, separator),
+                    branch[1],
+                    Token(Token.EOL),
+                ]
+            )
+            args = branch[2:]
+        else:
+            if len(branch) < 2:
+                return node
+            condition = Token(Token.ARGUMENT, f"not ({branch[0].value})") if negate else branch[0]
+            header = IfHeader(
+                [
+                    base_separator,
+                    Token(Token.IF),
+                    Token(Token.SEPARATOR, separator),
+                    condition,
+                    Token(Token.EOL),
+                ]
+            )
+            args = branch[1:]
+        keywords = _run_keyword_if_create_keywords(args, assign, base_separator.value + indent, separator)
+        if_block = If(header=header, body=keywords, orelse=prev_if)
+        prev_if = if_block
+    if prev_if is None:
+        return node
+    prev_if.end = end
+    return prev_if
 
 
 def get_comments(tokens: list[Token]) -> list[Token]:

--- a/src/robocop/linter/rules/deprecated.py
+++ b/src/robocop/linter/rules/deprecated.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     ReturnStatement = None
 
+from robot.parsing.model.statements import KeywordCall as KeywordCallStatement
+
 from robocop.formatter.utils import misc as format_utils
 from robocop.linter import sonar_qube
 from robocop.linter.fix import Fix, FixApplicability, FixAvailability, TextEdit
@@ -373,7 +375,7 @@ class DeprecatedForceTagsRule(FixableRule):
         )
 
 
-class DeprecatedRunKeywordIfRule(Rule):
+class DeprecatedRunKeywordIfRule(FixableRule):
     """
     ``Run Keyword If`` and ``Run Keyword Unless`` keywords are deprecated.
 
@@ -403,6 +405,10 @@ class DeprecatedRunKeywordIfRule(Rule):
                     Keyword3
                 END
 
+    The fix replaces the keyword call with an ``IF`` block. ``Run Keyword Unless`` conditions are wrapped in
+    ``not (...)``. Only keyword calls in the body are fixed - ``Run Keyword If`` used as a setting value
+    (for example ``Suite Setup`` or ``[Template]``) or without arguments cannot be converted and is left as is.
+
     """
 
     name = "deprecated-run-keyword-if"
@@ -415,6 +421,7 @@ class DeprecatedRunKeywordIfRule(Rule):
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
     )
     run_keyword_if_names = {"runkeywordif", "runkeywordunless"}
+    fix_availability = FixAvailability.SOMETIMES
 
     def check(self, node: KeywordCall, keyword_name: str, normalized_keyword_name: str) -> bool:
         """Check and return True if issue not found, otherwise return False."""
@@ -430,6 +437,31 @@ class DeprecatedRunKeywordIfRule(Rule):
             )
             return False
         return True
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        """Replace ``Run Keyword If``/``Run Keyword Unless`` keyword call with an IF block."""
+        node = diag.node
+        # only keyword calls in the body can be converted, settings (Suite Setup, [Template], ...) are skipped
+        if not isinstance(node, KeywordCallStatement) or not node.keyword:
+            return None
+        negate = utils.normalize_robot_name(node.keyword, remove_prefix="builtin.") == "runkeywordunless"
+        replacement_node = format_utils.run_keyword_if_to_branched(node, separator="    ", indent="    ", negate=negate)
+        if replacement_node is node:  # keyword call could not be converted (for example, no arguments)
+            return None
+        replacement_text = StatementLinesCollector(replacement_node).text
+        return Fix(
+            edits=[
+                TextEdit.replace_lines(
+                    rule_id=self.rule_id,
+                    rule_name=self.name,
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    replacement=replacement_text,
+                )
+            ],
+            message=f"Replace '{diag.reported_arguments['statement_name']}' keyword with an IF block",
+            applicability=FixApplicability.SAFE,
+        )
 
 
 class DeprecatedLoopKeywordRule(Rule):

--- a/tests/linter/rules/deprecated/deprecated_run_keyword_if/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/deprecated/deprecated_run_keyword_if/expected_fixed/expected_output.txt
@@ -1,0 +1,28 @@
+actual_fixed${/}test_fix.robot:2:16 DEPR08 'Run Keyword If' is deprecated, use 'IF' instead
+   |
+ 1 | *** Settings ***
+ 2 | Suite Setup    Run Keyword If    ${condition}    Keyword
+   |                ^^^^^^^^^^^^^^ DEPR08
+   |
+
+actual_fixed${/}test_fix.robot:55:5 DEPR08 'Run Keyword If' is deprecated, use 'IF' instead
+    |
+ 53 |
+ 54 | Empty Run Keyword If
+ 55 |     Run Keyword If
+    |     ^^^^^^^^^^^^^^ DEPR08
+    |
+
+actual_fixed${/}test_fix.robot:58:19 DEPR08 'Run Keyword Unless' is deprecated, use 'IF' instead
+    |
+ 56 |
+ 57 | Templated Test
+ 58 |     [Template]    Run Keyword Unless
+    |                   ^^^^^^^^^^^^^^^^^^ DEPR08
+    |
+
+Fixed 7 issues:
+- actual_fixed${/}test_fix.robot:
+    7 x DEPR08 (deprecated-run-keyword-if)
+
+Found 10 issues (7 fixed, 3 remaining).

--- a/tests/linter/rules/deprecated/deprecated_run_keyword_if/expected_fixed/test_fix.robot
+++ b/tests/linter/rules/deprecated/deprecated_run_keyword_if/expected_fixed/test_fix.robot
@@ -1,0 +1,58 @@
+*** Settings ***
+Suite Setup    Run Keyword If    ${condition}    Keyword
+
+
+*** Test Cases ***
+Simple Run Keyword If
+    IF    ${condition}
+        Keyword    ${arg}
+    END
+
+Run Keyword If With Else If And Else
+    IF    ${condition}
+        Keyword
+    ELSE IF    ${other_condition}
+        Other Keyword    ${arg}
+    ELSE
+        Final Keyword
+    END
+
+Run Keyword If With Assign
+    IF    ${condition}
+        ${var}    Keyword    ${arg}
+    ELSE
+        ${var}    Keyword2
+    END
+
+Run Keyword If With Run Keywords
+    IF    ${condition}
+        First Keyword
+        Second Keyword    1    2
+    END
+
+Simple Run Keyword Unless
+    IF    not (${condition})
+        Keyword    ${arg}
+    END
+
+Run Keyword Unless With Assign
+    IF    not (${condition})
+        ${var}    Keyword    ${arg}
+    ELSE
+        ${var}    Set Variable    ${None}
+    END
+
+Nested In For And If
+    FOR    ${item}    IN    @{items}
+        IF    ${condition}
+            IF    ${other}
+                Keyword
+            END
+        END
+    END
+
+Empty Run Keyword If
+    Run Keyword If
+
+Templated Test
+    [Template]    Run Keyword Unless

--- a/tests/linter/rules/deprecated/deprecated_run_keyword_if/test_fix.robot
+++ b/tests/linter/rules/deprecated/deprecated_run_keyword_if/test_fix.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Suite Setup    Run Keyword If    ${condition}    Keyword
+
+
+*** Test Cases ***
+Simple Run Keyword If
+    Run Keyword If    ${condition}    Keyword    ${arg}
+
+Run Keyword If With Else If And Else
+    Run Keyword If    ${condition}    Keyword
+    ...    ELSE IF    ${other_condition}    Other Keyword    ${arg}
+    ...    ELSE    Final Keyword
+
+Run Keyword If With Assign
+    ${var}    Run Keyword If    ${condition}    Keyword    ${arg}    ELSE    Keyword2
+
+Run Keyword If With Run Keywords
+    Run Keyword If    ${condition}    Run Keywords    First Keyword    AND    Second Keyword    1    2
+
+Simple Run Keyword Unless
+    Run Keyword Unless    ${condition}    Keyword    ${arg}
+
+Run Keyword Unless With Assign
+    ${var}    Run Keyword Unless    ${condition}    Keyword    ${arg}
+
+Nested In For And If
+    FOR    ${item}    IN    @{items}
+        IF    ${condition}
+            Run Keyword If    ${other}    Keyword
+        END
+    END
+
+Empty Run Keyword If
+    Run Keyword If
+
+Templated Test
+    [Template]    Run Keyword Unless

--- a/tests/linter/rules/deprecated/deprecated_run_keyword_if/test_rule.py
+++ b/tests/linter/rules/deprecated/deprecated_run_keyword_if/test_rule.py
@@ -10,4 +10,12 @@ class TestRuleAcceptance(RuleAcceptance):
         )
 
     def test_extended(self):
-        self.check_rule(expected_file="expected_extended.txt", output_format="extended", test_on_version=">=4")
+        self.check_rule(
+            src_files=["test.robot", "templated_suite.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=4",
+        )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test_fix.robot"], expected_dir="expected_fixed", test_on_version=">=5")


### PR DESCRIPTION
Adds an automatic fix for the `deprecated-run-keyword-if` (DEPR08) rule. `Run Keyword If` / `Run Keyword Unless` calls in a keyword/test body are rewritten into a native `IF` block via `--fix`.

The `ReplaceRunKeywordIf` formatter transform was extracted into a shared `run_keyword_if_to_branched()` helper in `formatter/utils/misc.py` and is reused by both the formatter and the new rule fix.

Part of #1631.

- `fix_availability = SOMETIMES` (only body `KeywordCall` nodes are fixable; settings/empty calls are not).
- Added `test_fix` acceptance test + `expected_fixed/`.
- All tests, ruff, mypy pass.