### PR TITLE
feat: add fix for the inline-if-can-be-used rule

### DIFF
--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -367,6 +367,7 @@ to detect metadata without a name.
 TODO
 
 add fix for the deprecated-run-keyword-if rule (#TBD)
+add fix for the inline-if-can-be-used rule (#TBD)
 add fix for the duplicated-variable rule (#1857) (b7a87ed)
 add fix for the else-not-upper-case rule (#1854) (837a979)
 add fix for the empty-return rule (#1846) (f376046)

--- a/src/robocop/formatter/formatters/InlineIf.py
+++ b/src/robocop/formatter/formatters/InlineIf.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
-from itertools import chain
 from typing import TYPE_CHECKING
-
-from robot.api.parsing import Comment, ElseHeader, ElseIfHeader, End, If, IfHeader, KeywordCall, Token
-
-try:
-    from robot.api.parsing import Break, Continue, InlineIfHeader, ReturnStatement
-except ImportError:
-    ReturnStatement, Break, Continue, InlineIfHeader = None, None, None, None
 
 from robocop.formatter.disablers import skip_section_if_disabled
 from robocop.formatter.formatters import Formatter
-from robocop.formatter.utils import misc
+from robocop.formatter.utils.inline_if import InlineIfConverter
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
+    from robot.api.parsing import Comment, If
     from robot.parsing.model.blocks import Section
 
 
@@ -71,6 +62,14 @@ class InlineIf(Formatter):
         self.line_length = line_length
         self.skip_else = skip_else
 
+    def _converter(self) -> InlineIfConverter:
+        return InlineIfConverter(
+            separator=self.formatting_config.separator,
+            indent=self.formatting_config.indent,
+            line_length=self.line_length,
+            skip_else=self.skip_else,
+        )
+
     @skip_section_if_disabled
     def visit_Section(self, node: Section) -> Section:  # noqa: N802
         return self.generic_visit(node)
@@ -80,262 +79,13 @@ class InlineIf(Formatter):
             return node
         if self.disablers.is_node_disabled("InlineIf", node, full_match=False):
             return node
-        if self.is_inline(node):
-            return self.handle_inline(node)
+        converter = self._converter()
+        if converter.is_inline(node):
+            return converter.handle_inline(node)
         self.generic_visit(node)
-        if self.no_end(node):
+        if converter.no_end(node):
             return node
         indent = node.header.tokens[0]
-        if not (self.should_format(node) and self.assignment_identical(node)):
+        if not (converter.should_format(node) and converter.assignment_identical(node)):
             return node
-        return self.to_inline(node, indent.value)
-
-    def should_format(self, node: If) -> bool:
-        if node.header.errors:
-            return False
-        if (
-            len(node.body) > 1
-            or not node.body
-            or not isinstance(node.body[0], (KeywordCall, ReturnStatement, Break, Continue))
-        ):
-            return False
-        if node.orelse:
-            return self.should_format(node.orelse)
-        return True
-
-    @staticmethod
-    def if_to_branches(if_block: If | None) -> Generator[If, None, None]:
-        while if_block:
-            yield if_block
-            if_block = if_block.orelse
-
-    def assignment_identical(self, node: If) -> bool:
-        else_found = False
-        assigned: list[list[str]] = []
-        for branch in self.if_to_branches(node):
-            if isinstance(branch.header, ElseHeader):
-                else_found = True
-            if not isinstance(branch.body[0], KeywordCall) or not branch.body[0].assign:
-                assigned.append([])
-            else:
-                assigned.append([misc.normalize_name(assign).replace("=", "") for assign in branch.body[0].assign])
-            if len(assigned) > 1 and assigned[-1] != assigned[-2]:
-                return False
-        if any(x for x in assigned):
-            return else_found
-        return True
-
-    def is_shorter_than_limit(self, inline_if: If) -> bool:
-        line_len = sum(self.if_len(branch) for branch in self.if_to_branches(inline_if))
-        return line_len <= self.line_length
-
-    @staticmethod
-    def no_end(node: If) -> bool:
-        if not node.end:
-            return True
-        if len(node.end.tokens) != 1:
-            return False
-        return not node.end.tokens[0].value
-
-    @staticmethod
-    def is_inline(node: If) -> bool:
-        return isinstance(node.header, InlineIfHeader)
-
-    @staticmethod
-    def if_len(if_st: If) -> int:
-        return sum(
-            len(tok.value)
-            for tok in chain(if_st.body[0].tokens if if_st.body else [], if_st.header.tokens)
-            if tok.value != "\n"
-        )
-
-    def to_inline(self, node: If, indent: str) -> If | tuple[Comment | If, ...]:
-        tail = node
-        comments = self.collect_comments_from_if(indent, node)
-        if_block = head = self.inline_if_from_branch(node, indent)
-        while tail.orelse:
-            if self.skip_else:
-                return node
-            tail = tail.orelse
-            comments += self.collect_comments_from_if(indent, tail)
-            head.orelse = self.inline_if_from_branch(tail, self.formatting_config.separator)  # type: ignore[union-attr]
-            head = head.orelse  # type: ignore[union-attr]
-        if self.is_shorter_than_limit(if_block):
-            return (*comments, if_block)
-        return node
-
-    def inline_if_from_branch(self, node: If, indent: str) -> If | None:
-        if not node:
-            return None
-        separator = self.formatting_config.separator
-        last_token = Token(Token.EOL) if node.orelse is None else Token(Token.SEPARATOR, separator)
-        assigned = None
-
-        if isinstance(node.body[0], KeywordCall):
-            assigned = node.body[0].assign
-            keyword = self.to_inline_keyword(node.body[0], separator, last_token)
-        elif isinstance(node.body[0], ReturnStatement):
-            keyword = self.to_inline_return(node.body[0], separator, last_token)
-        elif isinstance(node.body[0], Break):
-            keyword = Break(self.to_inline_break_continue_tokens(Token.BREAK, separator, last_token))
-        elif isinstance(node.body[0], Continue):
-            keyword = Continue(self.to_inline_break_continue_tokens(Token.CONTINUE, separator, last_token))
-        else:
-            return node
-
-        # check for ElseIfHeader first since it's child of IfHeader class
-        if isinstance(node.header, ElseIfHeader):
-            header = ElseIfHeader(
-                [Token(Token.ELSE_IF), Token(Token.SEPARATOR, separator), Token(Token.ARGUMENT, node.header.condition)]
-            )
-        elif isinstance(node.header, IfHeader):
-            tokens = [Token(Token.SEPARATOR, indent)]
-            if assigned:
-                for assign in assigned:
-                    tokens.extend([Token(Token.ASSIGN, assign), Token(Token.SEPARATOR, separator)])
-            tokens.extend(
-                [
-                    Token(Token.INLINE_IF),
-                    Token(Token.SEPARATOR, separator),
-                    Token(Token.ARGUMENT, node.header.condition),
-                ]
-            )
-            header = InlineIfHeader(tokens)
-        elif isinstance(node.header, ElseHeader):
-            header = ElseHeader([Token(Token.ELSE)])
-        else:
-            return node
-        return If(header=header, body=[keyword])
-
-    @staticmethod
-    def to_inline_keyword(keyword: KeywordCall, separator: str, last_token: Token) -> KeywordCall:
-        tokens = [Token(Token.SEPARATOR, separator), Token(Token.KEYWORD, keyword.keyword)]
-        for arg in keyword.get_tokens(Token.ARGUMENT):
-            tokens.extend([Token(Token.SEPARATOR, separator), arg])
-        tokens.append(last_token)
-        return KeywordCall(tokens)
-
-    @staticmethod
-    def to_inline_return(node: ReturnStatement, separator: str, last_token: Token) -> ReturnStatement:
-        tokens = [Token(Token.SEPARATOR, separator), Token(Token.RETURN_STATEMENT)]
-        for value in node.values:
-            tokens.extend([Token(Token.SEPARATOR, separator), Token(Token.ARGUMENT, value)])
-        tokens.append(last_token)
-        return ReturnStatement(tokens)
-
-    @staticmethod
-    def to_inline_break_continue_tokens(token: int, separator: str, last_token: Token) -> list[Token]:
-        return [Token(Token.SEPARATOR, separator), Token(token), last_token]
-
-    @staticmethod
-    def join_on_separator(tokens: list[Token], separator: Token) -> Generator[Token, None, None]:
-        for token in tokens:
-            yield token
-            yield separator
-
-    @staticmethod
-    def collect_comments_from_if(indent: str, node: If) -> list[Comment]:
-        comments = misc.get_comments(node.header.tokens)
-        for statement in node.body:
-            comments += misc.get_comments(statement.tokens)
-        if node.end:
-            comments += misc.get_comments(node.end)
-        return [Comment.from_params(comment=comment.value, indent=indent) for comment in comments]
-
-    def create_keyword_for_inline(self, kw_tokens: list[Token], indent: str, assign: list[Token]) -> KeywordCall:
-        keyword_tokens: list[Token] = []
-        for token in kw_tokens:
-            keyword_tokens.append(Token(Token.SEPARATOR, self.formatting_config.separator))
-            keyword_tokens.append(token)
-        return KeywordCall.from_tokens(
-            [
-                Token(Token.SEPARATOR, indent + self.formatting_config.separator),
-                *assign,
-                *keyword_tokens[1:],
-                Token(Token.EOL),
-            ]
-        )
-
-    def flatten_if_block(self, node: If) -> If:
-        node.header.tokens = misc.flatten_multiline(
-            node.header.tokens, self.formatting_config.separator, remove_comments=True
-        )
-        for index, statement in enumerate(node.body):
-            node.body[index].tokens = misc.flatten_multiline(
-                statement.tokens, self.formatting_config.separator, remove_comments=True
-            )
-        return node
-
-    def is_if_multiline(self, node: If) -> bool:
-        for branch in self.if_to_branches(node):
-            if branch.header.get_token(Token.CONTINUATION):
-                return True
-            if any(statement.get_token(Token.CONTINUATION) for statement in branch.body):
-                return True
-        return False
-
-    def flatten_inline_if(self, node: If) -> tuple[list[Comment], If]:
-        indent = node.header.tokens[0].value
-        comments = self.collect_comments_from_if(indent, node)
-        node = self.flatten_if_block(node)
-        head = node
-        while head.orelse:
-            head = head.orelse
-            comments += self.collect_comments_from_if(indent, head)
-            head = self.flatten_if_block(head)
-        return comments, node
-
-    def handle_inline(self, node: If) -> tuple[Comment | If, ...]:
-        comments: list[Comment]
-        if self.is_if_multiline(node):
-            comments, node = self.flatten_inline_if(node)
-        else:
-            comments = []
-        if self.is_shorter_than_limit(node):  # TODO ignore comments?
-            return (*comments, node)
-        indent = node.header.tokens[0]
-        separator = self.formatting_config.separator
-        assign_tokens = node.header.get_tokens(Token.ASSIGN)
-        assign = [*self.join_on_separator(assign_tokens, Token(Token.SEPARATOR, separator))]
-        else_present = False
-        branches: list[If] = []
-        while node:
-            new_comments, if_block, else_found = self.handle_inline_if_create(node, indent.value, assign)
-            else_present = else_present or else_found
-            comments += new_comments
-            branches.append(if_block)
-            node = node.orelse
-        if not else_present and assign_tokens:
-            header = ElseHeader.from_params(indent=indent.value)
-            keyword = self.create_keyword_for_inline(
-                [
-                    Token(Token.KEYWORD, "Set Variable"),
-                    *[Token(Token.ARGUMENT, "${None}") for _ in range(len(assign_tokens))],
-                ],
-                indent.value,
-                assign,
-            )
-            branches.append(If(header=header, body=[keyword]))
-        if_block = head = branches[0]
-        for branch in branches[1:]:
-            head.orelse = branch
-            head = head.orelse
-        if_block.end = End([indent, Token(Token.END), Token(Token.EOL)])
-        return (*comments, if_block)
-
-    def handle_inline_if_create(self, node: If, indent: str, assign: list[Token]) -> tuple[list[Comment], If, bool]:
-        comments = self.collect_comments_from_if(indent, node)
-        body = [self.create_keyword_for_inline(node.body[0].data_tokens, indent, assign)]
-        else_found = False
-        if isinstance(node.header, InlineIfHeader):
-            header = IfHeader.from_params(
-                condition=node.condition, indent=indent, separator=self.formatting_config.separator
-            )
-        elif isinstance(node.header, ElseIfHeader):
-            header = ElseIfHeader.from_params(
-                condition=node.condition, indent=indent, separator=self.formatting_config.separator
-            )
-        else:
-            header = ElseHeader.from_params(indent=indent)
-            else_found = True
-        return comments, If(header=header, body=body), else_found
+        return converter.to_inline(node, indent.value)

--- a/src/robocop/formatter/utils/inline_if.py
+++ b/src/robocop/formatter/utils/inline_if.py
@@ -1,0 +1,281 @@
+"""
+Shared conversion logic between IF blocks and inline IF statements.
+
+Used by the ``InlineIf`` formatter and the fix for the ``inline-if-can-be-used`` rule.
+"""
+
+from __future__ import annotations
+
+from itertools import chain
+from typing import TYPE_CHECKING
+
+from robot.api.parsing import Comment, ElseHeader, ElseIfHeader, End, If, IfHeader, KeywordCall, Token
+
+try:
+    from robot.api.parsing import Break, Continue, InlineIfHeader, ReturnStatement
+except ImportError:
+    ReturnStatement, Break, Continue, InlineIfHeader = None, None, None, None
+
+from robocop.formatter.utils import misc
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class InlineIfConverter:
+    """
+    Convert between IF blocks and inline IF statements.
+
+    The converter is parameterized with the whitespace configuration so it can be reused outside of the formatter
+    (for example by a rule fix). ``separator`` is the whitespace between tokens, ``indent`` the block indentation,
+    ``line_length`` the maximum length of the resulting inline IF and ``skip_else`` controls whether IF blocks with
+    ELSE/ELSE IF branches are converted.
+    """
+
+    def __init__(self, separator: str, indent: str, line_length: int = 80, skip_else: bool = False) -> None:
+        self.separator = separator
+        self.indent = indent
+        self.line_length = line_length
+        self.skip_else = skip_else
+
+    def should_format(self, node: If) -> bool:
+        if node.header.errors:
+            return False
+        if (
+            len(node.body) > 1
+            or not node.body
+            or not isinstance(node.body[0], (KeywordCall, ReturnStatement, Break, Continue))
+        ):
+            return False
+        if node.orelse:
+            return self.should_format(node.orelse)
+        return True
+
+    @staticmethod
+    def if_to_branches(if_block: If | None) -> Generator[If, None, None]:
+        while if_block:
+            yield if_block
+            if_block = if_block.orelse
+
+    def assignment_identical(self, node: If) -> bool:
+        else_found = False
+        assigned: list[list[str]] = []
+        for branch in self.if_to_branches(node):
+            if isinstance(branch.header, ElseHeader):
+                else_found = True
+            if not isinstance(branch.body[0], KeywordCall) or not branch.body[0].assign:
+                assigned.append([])
+            else:
+                assigned.append([misc.normalize_name(assign).replace("=", "") for assign in branch.body[0].assign])
+            if len(assigned) > 1 and assigned[-1] != assigned[-2]:
+                return False
+        if any(x for x in assigned):
+            return else_found
+        return True
+
+    def is_shorter_than_limit(self, inline_if: If) -> bool:
+        line_len = sum(self.if_len(branch) for branch in self.if_to_branches(inline_if))
+        return line_len <= self.line_length
+
+    @staticmethod
+    def no_end(node: If) -> bool:
+        if not node.end:
+            return True
+        if len(node.end.tokens) != 1:
+            return False
+        return not node.end.tokens[0].value
+
+    @staticmethod
+    def is_inline(node: If) -> bool:
+        return isinstance(node.header, InlineIfHeader)
+
+    @staticmethod
+    def if_len(if_st: If) -> int:
+        return sum(
+            len(tok.value)
+            for tok in chain(if_st.body[0].tokens if if_st.body else [], if_st.header.tokens)
+            if tok.value != "\n"
+        )
+
+    def to_inline(self, node: If, indent: str) -> If | tuple[Comment | If, ...]:
+        tail = node
+        comments = self.collect_comments_from_if(indent, node)
+        if_block = head = self.inline_if_from_branch(node, indent)
+        while tail.orelse:
+            if self.skip_else:
+                return node
+            tail = tail.orelse
+            comments += self.collect_comments_from_if(indent, tail)
+            head.orelse = self.inline_if_from_branch(tail, self.separator)  # type: ignore[union-attr]
+            head = head.orelse  # type: ignore[union-attr]
+        if self.is_shorter_than_limit(if_block):
+            return (*comments, if_block)
+        return node
+
+    def inline_if_from_branch(self, node: If, indent: str) -> If | None:
+        if not node:
+            return None
+        separator = self.separator
+        last_token = Token(Token.EOL) if node.orelse is None else Token(Token.SEPARATOR, separator)
+        assigned = None
+
+        if isinstance(node.body[0], KeywordCall):
+            assigned = node.body[0].assign
+            keyword = self.to_inline_keyword(node.body[0], separator, last_token)
+        elif isinstance(node.body[0], ReturnStatement):
+            keyword = self.to_inline_return(node.body[0], separator, last_token)
+        elif isinstance(node.body[0], Break):
+            keyword = Break(self.to_inline_break_continue_tokens(Token.BREAK, separator, last_token))
+        elif isinstance(node.body[0], Continue):
+            keyword = Continue(self.to_inline_break_continue_tokens(Token.CONTINUE, separator, last_token))
+        else:
+            return node
+
+        # check for ElseIfHeader first since it's child of IfHeader class
+        if isinstance(node.header, ElseIfHeader):
+            header = ElseIfHeader(
+                [Token(Token.ELSE_IF), Token(Token.SEPARATOR, separator), Token(Token.ARGUMENT, node.header.condition)]
+            )
+        elif isinstance(node.header, IfHeader):
+            tokens = [Token(Token.SEPARATOR, indent)]
+            if assigned:
+                for assign in assigned:
+                    tokens.extend([Token(Token.ASSIGN, assign), Token(Token.SEPARATOR, separator)])
+            tokens.extend(
+                [
+                    Token(Token.INLINE_IF),
+                    Token(Token.SEPARATOR, separator),
+                    Token(Token.ARGUMENT, node.header.condition),
+                ]
+            )
+            header = InlineIfHeader(tokens)
+        elif isinstance(node.header, ElseHeader):
+            header = ElseHeader([Token(Token.ELSE)])
+        else:
+            return node
+        return If(header=header, body=[keyword])
+
+    @staticmethod
+    def to_inline_keyword(keyword: KeywordCall, separator: str, last_token: Token) -> KeywordCall:
+        tokens = [Token(Token.SEPARATOR, separator), Token(Token.KEYWORD, keyword.keyword)]
+        for arg in keyword.get_tokens(Token.ARGUMENT):
+            tokens.extend([Token(Token.SEPARATOR, separator), arg])
+        tokens.append(last_token)
+        return KeywordCall(tokens)
+
+    @staticmethod
+    def to_inline_return(node: ReturnStatement, separator: str, last_token: Token) -> ReturnStatement:
+        tokens = [Token(Token.SEPARATOR, separator), Token(Token.RETURN_STATEMENT)]
+        for value in node.values:
+            tokens.extend([Token(Token.SEPARATOR, separator), Token(Token.ARGUMENT, value)])
+        tokens.append(last_token)
+        return ReturnStatement(tokens)
+
+    @staticmethod
+    def to_inline_break_continue_tokens(token: int, separator: str, last_token: Token) -> list[Token]:
+        return [Token(Token.SEPARATOR, separator), Token(token), last_token]
+
+    @staticmethod
+    def join_on_separator(tokens: list[Token], separator: Token) -> Generator[Token, None, None]:
+        for token in tokens:
+            yield token
+            yield separator
+
+    @staticmethod
+    def collect_comments_from_if(indent: str, node: If) -> list[Comment]:
+        comments = misc.get_comments(node.header.tokens)
+        for statement in node.body:
+            comments += misc.get_comments(statement.tokens)
+        if node.end:
+            comments += misc.get_comments(node.end)
+        return [Comment.from_params(comment=comment.value, indent=indent) for comment in comments]
+
+    def create_keyword_for_inline(self, kw_tokens: list[Token], indent: str, assign: list[Token]) -> KeywordCall:
+        keyword_tokens: list[Token] = []
+        for token in kw_tokens:
+            keyword_tokens.append(Token(Token.SEPARATOR, self.separator))
+            keyword_tokens.append(token)
+        return KeywordCall.from_tokens(
+            [
+                Token(Token.SEPARATOR, indent + self.separator),
+                *assign,
+                *keyword_tokens[1:],
+                Token(Token.EOL),
+            ]
+        )
+
+    def flatten_if_block(self, node: If) -> If:
+        node.header.tokens = misc.flatten_multiline(node.header.tokens, self.separator, remove_comments=True)
+        for index, statement in enumerate(node.body):
+            node.body[index].tokens = misc.flatten_multiline(statement.tokens, self.separator, remove_comments=True)
+        return node
+
+    def is_if_multiline(self, node: If) -> bool:
+        for branch in self.if_to_branches(node):
+            if branch.header.get_token(Token.CONTINUATION):
+                return True
+            if any(statement.get_token(Token.CONTINUATION) for statement in branch.body):
+                return True
+        return False
+
+    def flatten_inline_if(self, node: If) -> tuple[list[Comment], If]:
+        indent = node.header.tokens[0].value
+        comments = self.collect_comments_from_if(indent, node)
+        node = self.flatten_if_block(node)
+        head = node
+        while head.orelse:
+            head = head.orelse
+            comments += self.collect_comments_from_if(indent, head)
+            head = self.flatten_if_block(head)
+        return comments, node
+
+    def handle_inline(self, node: If) -> tuple[Comment | If, ...]:
+        comments: list[Comment]
+        if self.is_if_multiline(node):
+            comments, node = self.flatten_inline_if(node)
+        else:
+            comments = []
+        if self.is_shorter_than_limit(node):  # TODO ignore comments?
+            return (*comments, node)
+        indent = node.header.tokens[0]
+        separator = self.separator
+        assign_tokens = node.header.get_tokens(Token.ASSIGN)
+        assign = [*self.join_on_separator(assign_tokens, Token(Token.SEPARATOR, separator))]
+        else_present = False
+        branches: list[If] = []
+        while node:
+            new_comments, if_block, else_found = self.handle_inline_if_create(node, indent.value, assign)
+            else_present = else_present or else_found
+            comments += new_comments
+            branches.append(if_block)
+            node = node.orelse
+        if not else_present and assign_tokens:
+            header = ElseHeader.from_params(indent=indent.value)
+            keyword = self.create_keyword_for_inline(
+                [
+                    Token(Token.KEYWORD, "Set Variable"),
+                    *[Token(Token.ARGUMENT, "${None}") for _ in range(len(assign_tokens))],
+                ],
+                indent.value,
+                assign,
+            )
+            branches.append(If(header=header, body=[keyword]))
+        if_block = head = branches[0]
+        for branch in branches[1:]:
+            head.orelse = branch
+            head = head.orelse
+        if_block.end = End([indent, Token(Token.END), Token(Token.EOL)])
+        return (*comments, if_block)
+
+    def handle_inline_if_create(self, node: If, indent: str, assign: list[Token]) -> tuple[list[Comment], If, bool]:
+        comments = self.collect_comments_from_if(indent, node)
+        body = [self.create_keyword_for_inline(node.body[0].data_tokens, indent, assign)]
+        else_found = False
+        if isinstance(node.header, InlineIfHeader):
+            header = IfHeader.from_params(condition=node.condition, indent=indent, separator=self.separator)
+        elif isinstance(node.header, ElseIfHeader):
+            header = ElseIfHeader.from_params(condition=node.condition, indent=indent, separator=self.separator)
+        else:
+            header = ElseHeader.from_params(indent=indent)
+            else_found = True
+        return comments, If(header=header, body=body), else_found

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -26,6 +26,7 @@ try:  # RF 7+
 except ImportError:
     Var = None
 
+from robocop.formatter.utils.inline_if import InlineIfConverter
 from robocop.linter import sonar_qube
 from robocop.linter.fix import (
     Fix,
@@ -43,6 +44,7 @@ from robocop.linter.rules import (
     SeverityThreshold,
 )
 from robocop.linter.utils import misc as utils
+from robocop.source_file import StatementLinesCollector
 
 if TYPE_CHECKING:
     from robot.parsing.model import File
@@ -623,7 +625,7 @@ class StatementOutsideLoopRule(Rule):
                 )
 
 
-class InlineIfCanBeUsedRule(Rule):
+class InlineIfCanBeUsedRule(FixableRule):
     """
     IF can be replaced with inline IF.
 
@@ -639,6 +641,7 @@ class InlineIfCanBeUsedRule(Rule):
 
         IF    $condition    BREAK
 
+    The fix replaces the ``IF`` block with an ``inline IF``.
 
     """
 
@@ -662,6 +665,7 @@ class InlineIfCanBeUsedRule(Rule):
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
     )
     deprecated_names = ("0916",)
+    fix_availability = FixAvailability.SOMETIMES
 
     def check(self, node: If) -> None:
         if (
@@ -681,6 +685,32 @@ class InlineIfCanBeUsedRule(Rule):
             col=token.col_offset + 1,
             end_col=token.end_col_offset + 1,
             sev_threshold_value=min_possible,
+        )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:  # noqa: ARG002
+        """Replace the IF block with an inline IF."""
+        node = diag.node
+        if node is None:
+            return None
+        converter = InlineIfConverter(separator="    ", indent="    ", line_length=self.max_width)
+        indent = node.header.tokens[0].value
+        result = converter.to_inline(node, indent)
+        if result is node:  # the inline IF would be longer than the limit
+            return None
+        statements = result if isinstance(result, tuple) else (result,)
+        replacement = "".join(StatementLinesCollector(statement).text for statement in statements)
+        return Fix(
+            edits=[
+                TextEdit.replace_lines(
+                    rule_id=self.rule_id,
+                    rule_name=self.name,
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    replacement=replacement,
+                )
+            ],
+            message="Replace IF block with an inline IF",
+            applicability=FixApplicability.SAFE,
         )
 
 

--- a/tests/linter/rules/misc/inline_if_can_be_used/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/misc/inline_if_can_be_used/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 4 issues:
+- actual_fixed${/}test_fix.robot:
+    4 x MISC09 (inline-if-can-be-used)
+
+Found 4 issues (4 fixed, 0 remaining).

--- a/tests/linter/rules/misc/inline_if_can_be_used/expected_fixed/test_fix.robot
+++ b/tests/linter/rules/misc/inline_if_can_be_used/expected_fixed/test_fix.robot
@@ -1,0 +1,24 @@
+*** Test Cases ***
+Short IF
+    IF    $condition    Keyword    ${var}
+
+IF With Return
+    IF    $condition    RETURN
+
+IF With Break And Continue
+    FOR    ${item}    IN    @{items}
+        IF    $stop    BREAK
+        IF    $skip    CONTINUE
+    END
+
+Long IF Not Reported
+    IF    $condition
+        ${variable}    Keyword That Should Go Over Limit    ${argument1}    something else
+    END
+
+IF With Else Not Reported
+    IF    $condition
+        Keyword
+    ELSE
+        Keyword
+    END

--- a/tests/linter/rules/misc/inline_if_can_be_used/test_fix.robot
+++ b/tests/linter/rules/misc/inline_if_can_be_used/test_fix.robot
@@ -1,0 +1,32 @@
+*** Test Cases ***
+Short IF
+    IF    $condition
+        Keyword    ${var}
+    END
+
+IF With Return
+    IF    $condition
+        RETURN
+    END
+
+IF With Break And Continue
+    FOR    ${item}    IN    @{items}
+        IF    $stop
+            BREAK
+        END
+        IF    $skip
+            CONTINUE
+        END
+    END
+
+Long IF Not Reported
+    IF    $condition
+        ${variable}    Keyword That Should Go Over Limit    ${argument1}    something else
+    END
+
+IF With Else Not Reported
+    IF    $condition
+        Keyword
+    ELSE
+        Keyword
+    END

--- a/tests/linter/rules/misc/inline_if_can_be_used/test_rule.py
+++ b/tests/linter/rules/misc/inline_if_can_be_used/test_rule.py
@@ -20,3 +20,6 @@ class TestRuleAcceptance(RuleAcceptance):
             expected_file="expected_output_severity.txt",
             test_on_version=">=5.0",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test_fix.robot"], expected_dir="expected_fixed", test_on_version=">=5.0")


### PR DESCRIPTION
Adds an automatic fix for the `inline-if-can-be-used` (MISC09) rule. Short single-branch `IF` blocks are rewritten into an `inline IF` via `--fix`.

The `InlineIf` formatter logic was extracted into a reusable `InlineIfConverter` class in `formatter/utils/inline_if.py` and is now shared by both the formatter and the new rule fix.

**The `InlineIf` formatter is kept** — it does more than the rule (bidirectional conversion, handles ELSE/ELSE IF and assignments, converts too-long inline IFs back to blocks). This matches the plan in #1631 (fix for MISC09 only; MISC11 stays with the formatter).

Part of #1631.

Stacked on #1899.

- `fix_availability = SOMETIMES` (returns None when the inline IF would exceed the limit).
- Preserves nested indentation.
- Added `test_fix` acceptance test + `expected_fixed/`; InlineIf formatter tests still pass.