### PR TITLE
feat: add fix for the inconsistent-assignment rule

### DIFF
--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -367,6 +367,7 @@ to detect metadata without a name.
 TODO
 
 add fix for the deprecated-run-keyword-if rule (#TBD)
+add fix for the inconsistent-assignment rule (#TBD)
 add fix for the inline-if-can-be-used rule (#TBD)
 add fix for the duplicated-variable rule (#1857) (b7a87ed)
 add fix for the else-not-upper-case rule (#1854) (837a979)

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -270,7 +270,7 @@ class NestedForLoopRule(Rule):
                 )
 
 
-class InconsistentAssignmentRule(Rule):
+class InconsistentAssignmentRule(FixableRule):
     """
     Not consistent assignment sign in the file.
 
@@ -323,6 +323,8 @@ class InconsistentAssignmentRule(Rule):
     - 'equal_sign' (``=``)
     - 'space_and_equal_sign' (`` =``).
 
+    The assignment sign can be replaced with the expected one automatically with the ``--fix`` option.
+
     """
 
     name = "inconsistent-assignment"
@@ -343,6 +345,7 @@ class InconsistentAssignmentRule(Rule):
         ),
     ]
     added_in_version = "1.7.0"
+    fix_availability = FixAvailability.ALWAYS
     sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
         clean_code=sonar_qube.CleanCodeAttribute.CONVENTIONAL,
         issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
@@ -361,6 +364,22 @@ class InconsistentAssignmentRule(Rule):
             lineno=token.lineno,
             col=token.col_offset + 1,
             end_col=token.end_col_offset + 1,
+        )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Replace the assignment sign with the expected one."""
+        line = source_lines[diag.range.start.line - 1]
+        variable = line[diag.range.start.character - 1 : diag.range.end.character - 1]
+        actual_sign = str(diag.reported_arguments["actual_sign"])
+        expected_sign = str(diag.reported_arguments["expected_sign"])
+        if actual_sign and not variable.endswith(actual_sign):
+            return None
+        base = variable[: len(variable) - len(actual_sign)] if actual_sign else variable
+        edit = TextEdit.replace_at_range(self.rule_id, self.name, diag.range, f"{base}{expected_sign}")
+        return Fix(
+            edits=[edit],
+            message=f"Replace the '{actual_sign}' assignment sign with '{expected_sign}'",
+            applicability=FixApplicability.SAFE,
         )
 
 

--- a/tests/linter/rules/misc/inconsistent_assignment/autodetect/expected_output.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/autodetect/expected_output.txt
@@ -1,3 +1,4 @@
 autodetect${/}test.robot:30:15 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got '=' instead
 
 Found 1 issue.
+1 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/inconsistent_assignment/const/expected_output.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/const/expected_output.txt
@@ -3,3 +3,4 @@ const${/}test.robot:28:15 [W] MISC04 The assignment sign is not consistent withi
 const${/}test.robot:31:15 [W] MISC04 The assignment sign is not consistent within the file. Expected ' =' but got '=' instead
 
 Found 3 issues.
+3 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/inconsistent_assignment/expected_extended.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/expected_extended.txt
@@ -17,3 +17,4 @@ test.robot:31:15 MISC04 The assignment sign is not consistent within the file. E
     |
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/inconsistent_assignment/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 2 issues:
+- actual_fixed${/}test.robot:
+    2 x MISC04 (inconsistent-assignment)
+
+Found 2 issues (2 fixed, 0 remaining).

--- a/tests/linter/rules/misc/inconsistent_assignment/expected_fixed/test.robot
+++ b/tests/linter/rules/misc/inconsistent_assignment/expected_fixed/test.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Documentation    This is suite doc
+
+
+*** Variables ***
+${var} =    1
+${var2} =   2
+${var3} =   3
+
+
+*** Test Cases ***
+Test without keyword
+    ${var}  ${var1}
+
+Test
+    ${var}    Keyword
+
+
+*** Keywords ***
+Keyword Without Assignments
+    Keyword
+    Log  ${1}
+
+Keyword With One Assignment
+    ${var}    Keyword
+
+Keyword With Multiple Assignments
+    ${var}    ${var2}    Keyword
+
+Keyword With Multiline Keyword
+    ${var}    ${var}    Keyword
+    ...    ${arg}
+    ...    ${1}

--- a/tests/linter/rules/misc/inconsistent_assignment/expected_output.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/expected_output.txt
@@ -2,3 +2,4 @@ test.robot:25:5 [W] MISC04 The assignment sign is not consistent within the file
 test.robot:31:15 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got '=' instead
 
 Found 2 issues.
+2 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/inconsistent_assignment/test_rule.py
+++ b/tests/linter/rules/misc/inconsistent_assignment/test_rule.py
@@ -34,3 +34,6 @@ class TestRuleAcceptance(RuleAcceptance):
             expected_file="variable_type_conversion_expected.txt",
             test_on_version=">7.2.1",
         )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"])

--- a/tests/linter/rules/misc/inconsistent_assignment/variable_type_conversion_expected.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/variable_type_conversion_expected.txt
@@ -1,3 +1,4 @@
 variable_type_conversion.robot:17:17 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got ' =' instead
 
 Found 1 issue.
+1 fixable with the '--fix' option.


### PR DESCRIPTION
Adds an automatic fix for the `inconsistent-assignment` (MISC04) rule, mirroring the existing fix for `inconsistent-assignment-in-variables` (MISC05). The assignment sign of keyword-call assignments is normalized to the expected/most-common sign via `--fix`.

Part of #1631 (which notes the `NormalizeAssignments` formatter could be replaced once MISC04 has a fix).

Stacked on #1900.

- `fix_availability = ALWAYS`.
- Added `test_fix` acceptance test + `expected_fixed/`; updated the non-fix expected outputs to include the `fixable with the '--fix' option` hint line.