### PR TITLE
feat: check VAR assignment sign in inconsistent-assignment rule

### DIFF
--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -479,3 +479,6 @@ See the [configuration documentation](../configuration/index.md#generate-a-confi
 TODO
 
 allow to skip report file generation on empty results (#1835) (e198ea5), closes #1332
+
+The ``inconsistent-assignment`` (MISC04) rule now also checks the assignment sign in the ``VAR`` syntax
+(Robot Framework 7 and newer).

--- a/src/robocop/linter/checkers/variable_statements.py
+++ b/src/robocop/linter/checkers/variable_statements.py
@@ -94,6 +94,12 @@ class VariablesChecker(VisitorChecker):
         variable = node.get_token(Token.VARIABLE)
         if variable:
             self.missing_section_variable_type.check(node, variable)
+            self.check_var_assignment_sign(variable)
+
+    def check_var_assignment_sign(self, variable: Token) -> None:
+        if self.keyword_expected_sign_type is None:
+            return
+        self.inconsistent_assignment.check(variable, self.keyword_expected_sign_type)
 
     def check_var_scope(self, node: Var) -> None:
         if not node.scope:

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -274,7 +274,9 @@ class InconsistentAssignmentRule(FixableRule):
     """
     Not consistent assignment sign in the file.
 
-    Use only one type of assignment sign in a file.
+    Use only one type of assignment sign in a file. Assignment signs are checked in the keyword calls and in the
+    ``VAR`` syntax (Robot Framework 7 and newer). The ``*** Variables ***`` section is handled by the
+    ``inconsistent-assignment-in-variables`` rule.
 
     Incorrect code example:
 

--- a/src/robocop/linter/utils/misc.py
+++ b/src/robocop/linter/utils/misc.py
@@ -173,6 +173,12 @@ class AssignmentTypeDetector(ast.NodeVisitor):
             sign = self.get_assignment_sign(node.assign[-1])
             self.keyword_sign_counter[sign] += 1
 
+    def visit_Var(self, node: Var) -> None:
+        """Count assignment signs from the ``VAR`` syntax (Robot Framework 7+)."""
+        for token in node.get_tokens(Token.VARIABLE):
+            sign = self.get_assignment_sign(token.value)
+            self.keyword_sign_counter[sign] += 1
+
     def visit_VariableSection(self, node: VariableSection) -> VariableSection:
         for child in node.body:
             if not isinstance(child, Variable):

--- a/tests/linter/rules/misc/inconsistent_assignment/expected_fixed_var/expected_output.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/expected_fixed_var/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 4 issues:
+- actual_fixed${/}var_syntax.robot:
+    4 x MISC04 (inconsistent-assignment)
+
+Found 4 issues (4 fixed, 0 remaining).

--- a/tests/linter/rules/misc/inconsistent_assignment/expected_fixed_var/var_syntax.robot
+++ b/tests/linter/rules/misc/inconsistent_assignment/expected_fixed_var/var_syntax.robot
@@ -1,0 +1,12 @@
+*** Test Cases ***
+Test
+    VAR    ${var}    value
+    VAR    ${var2}    value2
+    VAR    ${var3}    value3
+    ${keyword_var}    Some Keyword
+
+
+*** Keywords ***
+Keyword
+    VAR    ${local}    value
+    VAR    ${local2}    value2

--- a/tests/linter/rules/misc/inconsistent_assignment/test_rule.py
+++ b/tests/linter/rules/misc/inconsistent_assignment/test_rule.py
@@ -37,3 +37,19 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_fix(self):
         self.check_rule_fix(src_files=["test.robot"])
+
+    def test_var_syntax(self):
+        self.check_rule(
+            configure=["inconsistent-assignment.assignment_sign_type=none"],
+            src_files=["var_syntax.robot"],
+            expected_file="var_syntax_expected.txt",
+            test_on_version=">=7",
+        )
+
+    def test_var_syntax_fix(self):
+        self.check_rule_fix(
+            src_files=["var_syntax.robot"],
+            expected_dir="expected_fixed_var",
+            configure=["inconsistent-assignment.assignment_sign_type=none"],
+            test_on_version=">=7",
+        )

--- a/tests/linter/rules/misc/inconsistent_assignment/var_syntax.robot
+++ b/tests/linter/rules/misc/inconsistent_assignment/var_syntax.robot
@@ -1,0 +1,12 @@
+*** Test Cases ***
+Test
+    VAR    ${var} =    value
+    VAR    ${var2}    value2
+    VAR    ${var3}=    value3
+    ${keyword_var} =    Some Keyword
+
+
+*** Keywords ***
+Keyword
+    VAR    ${local} =    value
+    VAR    ${local2}    value2

--- a/tests/linter/rules/misc/inconsistent_assignment/var_syntax_expected.txt
+++ b/tests/linter/rules/misc/inconsistent_assignment/var_syntax_expected.txt
@@ -1,0 +1,7 @@
+var_syntax.robot:3:12 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got ' =' instead
+var_syntax.robot:5:12 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got '=' instead
+var_syntax.robot:6:5 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got ' =' instead
+var_syntax.robot:11:12 [W] MISC04 The assignment sign is not consistent within the file. Expected '' but got ' =' instead
+
+Found 4 issues.
+4 fixable with the '--fix' option.


### PR DESCRIPTION
Extends the `inconsistent-assignment` (MISC04) rule to also count, report and fix assignment signs in the `VAR` syntax (Robot Framework 7+).

Previously the `NormalizeAssignments` formatter normalized `VAR` assignment signs but no rule covered them: the linter's `AssignmentTypeDetector` had no `visit_Var` and the checker never checked `VAR` statements. This closes that gap so the MISC04 fix reaches full parity with the formatter (the formatter is kept, as agreed).

Part of #1631.

Stacked on #1901.

- Added `visit_Var` to `AssignmentTypeDetector` (counts VAR signs into the keyword sign group, matching the formatter).
- `VariablesChecker.visit_Var` now checks the VAR variable token's assignment sign.
- Added `test_var_syntax` + `test_var_syntax_fix` acceptance tests (gated `>=7`); updated docstring and release notes.