### PR TITLE
chore: enforce LF line endings via gitattributes and pre-commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings to LF for all text files in the repository.
+# Git auto-detects text vs binary; text files are stored as LF in the repo
+# and checked out as LF on every platform (including Windows), regardless of
+# a contributor's core.autocrlf / core.eol settings.
+* text=auto eol=lf
+
+# Explicitly treat common binary assets as binary so they are never altered.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg text eol=lf
+*.woff binary
+*.woff2 binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.8
     hooks:


### PR DESCRIPTION
## What

Introduce repo-wide LF line-ending enforcement:

- **.gitattributes** with `* text=auto eol=lf` so all text files are stored and checked out as LF, regardless of a contributor's `core.autocrlf` / `core.eol` settings. Common binary assets (images, fonts) are marked `binary` so they are never altered.
- **pre-commit `mixed-line-ending` hook** (`--fix=lf`) as defense-in-depth: any CRLF is converted to LF before it can be committed.

## Why

Recent formatter/rule work accidentally introduced CRLF/mixed line endings on Windows. This makes endings consistent going forward and blocks the regression at commit time.

## Scope note

This PR is intentionally **config-only** — it does **not** mass-renormalize the existing files (the repo currently has ~545 files committed with CRLF). Those will convert to LF gradually as files are touched. A one-time `git add --renormalize .` cleanup can be done as a follow-up once the in-flight PR stack (#1900–#1905) has merged, to avoid conflicts.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>