### PR TITLE
feat: add not-enough-whitespace-around-operator rule

### DIFF
--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -417,6 +417,19 @@ not available (for example, using ``${TEST_NAME}`` outside of a test case).
 New DOC05 ``variable-in-documentation`` rule (disabled by default) that detects unescaped variables used in
 documentation.
 
+#### Whitespace around comparison operator rule (#1762)
+
+New MISC16 ``not-enough-whitespace-around-operator`` rule that reports comparison operators (``==``, ``!=``, ``>``,
+``<``, ``>=``, ``<=``) used in conditions without surrounding whitespace. It inspects the conditions of ``IF`` and
+``WHILE`` blocks as well as the conditions passed to BuiltIn keywords such as ``Should Be True`` or ``Skip If``. The
+missing whitespace can be added automatically with the ``--fix`` option:
+
+    *** Test Cases ***
+    Test
+        IF    ${variable}==5    # reported: should be '${variable} == 5'
+            Log    Robocop
+        END
+
 ### New fixes for rules
 
 Several rules now have fixes:

--- a/src/robocop/linter/checkers/control_flow.py
+++ b/src/robocop/linter/checkers/control_flow.py
@@ -38,6 +38,7 @@ class ControlFlowChecker(VisitorChecker):
     statement_outside_loop: misc.StatementOutsideLoopRule
     expression_can_be_simplified: misc.ExpressionCanBeSimplifiedRule
     misplaced_negative_condition: misc.MisplacedNegativeConditionRule
+    not_enough_whitespace_around_operator: misc.NotEnoughWhitespaceAroundOperatorRule
 
     condition_keywords = frozenset(
         {
@@ -142,6 +143,7 @@ class ControlFlowChecker(VisitorChecker):
     def check_condition(self, node_name: str, condition_token: Token, condition: str) -> None:
         if not condition:
             return
+        self.not_enough_whitespace_around_operator.check(condition_token, node_name, condition)
         try:
             variables = list(VariableMatches(condition))
         except VariableError:  # for example ${variable which wasn't closed properly

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -65,6 +65,8 @@ FOR_LOOP_KEYWORDS = frozenset(
 COMPARISON_SIGNS = frozenset({"==", "!="})
 EMPTY_COMPARISON = frozenset({"${true}", "${false}", "true", "false", "[]", "{}", "set()", "list()", "dict()"})
 NEGATIVE_CONDITION_PARTS = 4  # not ${variable} is None
+# Two character operators need to be listed before the single character ones sharing a prefix (e.g. '>=' before '>').
+COMPARISON_OPERATORS = ("==", "!=", ">=", "<=", ">", "<")
 
 
 def tokens_length(tokens: list[Token]) -> int:
@@ -1076,6 +1078,129 @@ class MisplacedNegativeConditionRule(FixableRule):
         return Fix(
             edits=[edit],
             message=f"Rewrite '{original}' to '{proposed}'",
+            applicability=FixApplicability.SAFE,
+        )
+
+
+def find_unspaced_operators(condition: str) -> list[tuple[str, int]]:
+    """
+    Find comparison operators that are missing surrounding whitespace.
+
+    Returns a list of ``(operator, index)`` tuples where ``index`` is the 0-based position of the operator inside
+    the condition string. Operators found inside string literals are ignored to avoid false positives.
+    """
+    found: list[tuple[str, int]] = []
+    quote: str | None = None
+    index = 0
+    length = len(condition)
+    while index < length:
+        char = condition[index]
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in "\"'":
+            quote = char
+            index += 1
+            continue
+        operator = next((op for op in COMPARISON_OPERATORS if condition.startswith(op, index)), None)
+        if operator is None:
+            index += 1
+            continue
+        end = index + len(operator)
+        space_before = index == 0 or condition[index - 1] == " "
+        space_after = end >= length or condition[end] == " "
+        if not (space_before and space_after):
+            found.append((operator, index))
+        index = end
+    return found
+
+
+class NotEnoughWhitespaceAroundOperatorRule(FixableRule):
+    """
+    Not enough whitespace around a comparison operator.
+
+    Comparison operators (``==``, ``!=``, ``>``, ``<``, ``>=``, ``<=``) used in conditions are easier to read
+    when they are surrounded by spaces. The rule inspects conditions of ``IF`` and ``WHILE`` blocks together with
+    the conditions passed to the BuiltIn keywords that evaluate an expression
+    (such as ``Should Be True`` or ``Skip If``).
+
+    Incorrect code example:
+
+        *** Test Cases ***
+        Test
+            IF    ${variable}==5
+                Log    Robocop
+            END
+            WHILE    ${counter}>=${LIMIT}
+                ${counter}    Evaluate    ${counter} + 1
+            END
+            Should Be True    ${left}!=${right}
+
+    Correct code:
+
+        *** Test Cases ***
+        Test
+            IF    ${variable} == 5
+                Log    Robocop
+            END
+            WHILE    ${counter} >= ${LIMIT}
+                ${counter}    Evaluate    ${counter} + 1
+            END
+            Should Be True    ${left} != ${right}
+
+    The missing whitespace can be added automatically with the ``--fix`` option.
+
+    """
+
+    name = "not-enough-whitespace-around-operator"
+    rule_id = "MISC16"
+    message = "Not enough whitespace around '{operator}' operator in '{block_name}' condition"
+    severity = RuleSeverity.INFO
+    version = ">=4.0"
+    added_in_version = "9.0.0"
+    fix_availability = FixAvailability.ALWAYS
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.FORMATTED,
+        issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL,
+    )
+
+    def check(self, condition_token: Token, node_name: str, condition: str) -> None:
+        """Report comparison operators used in the condition without surrounding whitespace."""
+        for operator, index in find_unspaced_operators(condition):
+            col = condition_token.col_offset + index + 1
+            self.report(
+                operator=operator,
+                block_name=node_name,
+                node=condition_token,
+                col=col,
+                end_col=col + len(operator),
+            )
+
+    def fix(self, diag: Diagnostic, source_lines: list[str]) -> Fix | None:
+        """Insert the missing spaces around the comparison operator."""
+        operator = str(diag.reported_arguments["operator"])
+        line = source_lines[diag.range.start.line - 1]
+        start = diag.range.start.character - 1
+        end = diag.range.end.character - 1
+        if line[start:end] != operator:
+            return None
+        space_before = start == 0 or line[start - 1] == " "
+        space_after = end >= len(line) or line[end] == " "
+        replacement = f"{'' if space_before else ' '}{operator}{'' if space_after else ' '}"
+        edit = TextEdit(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            start_line=diag.range.start.line,
+            start_col=start + 1,
+            end_line=diag.range.start.line,
+            end_col=end + 1,
+            replacement=replacement,
+        )
+        return Fix(
+            edits=[edit],
+            message=f"Add missing whitespace around '{operator}' operator",
             applicability=FixApplicability.SAFE,
         )
 

--- a/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_extended.txt
+++ b/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_extended.txt
@@ -1,0 +1,107 @@
+test.robot:3:22 MISC16 Not enough whitespace around '==' operator in 'IF' condition
+   |
+ 1 | *** Test Cases ***
+ 2 | If condition
+ 3 |     IF    ${variable}==5
+   |                      ^^ MISC16
+ 4 |         Log    ${variable}
+ 5 |     ELSE IF    ${variable} !=5
+   |
+
+test.robot:5:28 MISC16 Not enough whitespace around '!=' operator in 'ELSE IF' condition
+   |
+ 3 |     IF    ${variable}==5
+ 4 |         Log    ${variable}
+ 5 |     ELSE IF    ${variable} !=5
+   |                            ^^ MISC16
+ 6 |         Log    ${variable}
+ 7 |     ELSE IF    ${variable}> 5
+   |
+
+test.robot:7:27 MISC16 Not enough whitespace around '>' operator in 'ELSE IF' condition
+   |
+ 5 |     ELSE IF    ${variable} !=5
+ 6 |         Log    ${variable}
+ 7 |     ELSE IF    ${variable}> 5
+   |                           ^ MISC16
+ 8 |         Log    ${variable}
+ 9 |     END
+   |
+
+test.robot:15:21 MISC16 Not enough whitespace around '<=' operator in 'INLINE IF' condition
+    |
+ 13 |
+ 14 | Inline if
+ 15 |     IF    ${counter}<=${LIMIT}    Log    ${counter}
+    |                     ^^ MISC16
+ 16 |     ${assign}    IF    ${x}>${y}    Set Variable    big    ELSE    Set Variable    small
+    |
+
+test.robot:16:28 MISC16 Not enough whitespace around '>' operator in 'INLINE IF' condition
+    |
+ 14 | Inline if
+ 15 |     IF    ${counter}<=${LIMIT}    Log    ${counter}
+ 16 |     ${assign}    IF    ${x}>${y}    Set Variable    big    ELSE    Set Variable    small
+    |                            ^ MISC16
+    |
+
+test.robot:19:24 MISC16 Not enough whitespace around '>=' operator in 'WHILE' condition
+    |
+ 17 |
+ 18 | While condition
+ 19 |     WHILE    ${counter}>=${LIMIT}
+    |                        ^^ MISC16
+ 20 |         ${counter}    Evaluate    ${counter} + 1
+ 21 |     END
+    |
+
+test.robot:27:12 MISC16 Not enough whitespace around '<' operator in 'IF' condition
+    |
+ 25 |
+ 26 | Chained condition
+ 27 |     IF    5<${a}<10
+    |            ^ MISC16
+ 28 |         Log    ${a}
+ 29 |     END
+    |
+
+test.robot:27:17 MISC16 Not enough whitespace around '<' operator in 'IF' condition
+    |
+ 25 |
+ 26 | Chained condition
+ 27 |     IF    5<${a}<10
+    |                 ^ MISC16
+ 28 |         Log    ${a}
+ 29 |     END
+    |
+
+test.robot:32:30 MISC16 Not enough whitespace around '!=' operator in 'Should Be True' condition
+    |
+ 30 |
+ 31 | Keywords with conditions
+ 32 |     Should Be True    ${left}!=${right}
+    |                              ^^ MISC16
+ 33 |     Skip If    ${status}==${FALSE}
+ 34 |     Pass Execution If    ${left} > ${right}    message
+    |
+
+test.robot:33:25 MISC16 Not enough whitespace around '==' operator in 'Skip If' condition
+    |
+ 31 | Keywords with conditions
+ 32 |     Should Be True    ${left}!=${right}
+ 33 |     Skip If    ${status}==${FALSE}
+    |                         ^^ MISC16
+ 34 |     Pass Execution If    ${left} > ${right}    message
+ 35 |     Set Variable If    ${x}<${y}    small    ${x} > ${y}    big
+    |
+
+test.robot:35:28 MISC16 Not enough whitespace around '<' operator in 'Set Variable If' condition
+    |
+ 33 |     Skip If    ${status}==${FALSE}
+ 34 |     Pass Execution If    ${left} > ${right}    message
+ 35 |     Set Variable If    ${x}<${y}    small    ${x} > ${y}    big
+    |                            ^ MISC16
+    |
+
+Found 11 issues.
+11 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_fixed/expected_output.txt
+++ b/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_fixed/expected_output.txt
@@ -1,0 +1,5 @@
+Fixed 11 issues:
+- actual_fixed${/}test.robot:
+    11 x MISC16 (not-enough-whitespace-around-operator)
+
+Found 11 issues (11 fixed, 0 remaining).

--- a/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_fixed/test.robot
+++ b/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_fixed/test.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+If condition
+    IF    ${variable} == 5
+        Log    ${variable}
+    ELSE IF    ${variable} != 5
+        Log    ${variable}
+    ELSE IF    ${variable} > 5
+        Log    ${variable}
+    END
+    IF    ${variable} == 5
+        Log    ${variable}
+    END
+
+Inline if
+    IF    ${counter} <= ${LIMIT}    Log    ${counter}
+    ${assign}    IF    ${x} > ${y}    Set Variable    big    ELSE    Set Variable    small
+
+While condition
+    WHILE    ${counter} >= ${LIMIT}
+        ${counter}    Evaluate    ${counter} + 1
+    END
+    WHILE    ${counter} < ${LIMIT}
+        ${counter}    Evaluate    ${counter} + 1
+    END
+
+Chained condition
+    IF    5 < ${a} < 10
+        Log    ${a}
+    END
+
+Keywords with conditions
+    Should Be True    ${left} != ${right}
+    Skip If    ${status} == ${FALSE}
+    Pass Execution If    ${left} > ${right}    message
+    Set Variable If    ${x} < ${y}    small    ${x} > ${y}    big
+
+Not a condition
+    Should Be True    ${left} == ${right}
+    Log    ${left}==${right}
+    IF    ${text} == "a<b"
+        Log    ${text}
+    END

--- a/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_output.txt
+++ b/tests/linter/rules/misc/not_enough_whitespace_around_operator/expected_output.txt
@@ -1,0 +1,14 @@
+test.robot:3:22 [I] MISC16 Not enough whitespace around '==' operator in 'IF' condition
+test.robot:5:28 [I] MISC16 Not enough whitespace around '!=' operator in 'ELSE IF' condition
+test.robot:7:27 [I] MISC16 Not enough whitespace around '>' operator in 'ELSE IF' condition
+test.robot:15:21 [I] MISC16 Not enough whitespace around '<=' operator in 'INLINE IF' condition
+test.robot:16:28 [I] MISC16 Not enough whitespace around '>' operator in 'INLINE IF' condition
+test.robot:19:24 [I] MISC16 Not enough whitespace around '>=' operator in 'WHILE' condition
+test.robot:27:12 [I] MISC16 Not enough whitespace around '<' operator in 'IF' condition
+test.robot:27:17 [I] MISC16 Not enough whitespace around '<' operator in 'IF' condition
+test.robot:32:30 [I] MISC16 Not enough whitespace around '!=' operator in 'Should Be True' condition
+test.robot:33:25 [I] MISC16 Not enough whitespace around '==' operator in 'Skip If' condition
+test.robot:35:28 [I] MISC16 Not enough whitespace around '<' operator in 'Set Variable If' condition
+
+Found 11 issues.
+11 fixable with the '--fix' option.

--- a/tests/linter/rules/misc/not_enough_whitespace_around_operator/test.robot
+++ b/tests/linter/rules/misc/not_enough_whitespace_around_operator/test.robot
@@ -1,0 +1,42 @@
+*** Test Cases ***
+If condition
+    IF    ${variable}==5
+        Log    ${variable}
+    ELSE IF    ${variable} !=5
+        Log    ${variable}
+    ELSE IF    ${variable}> 5
+        Log    ${variable}
+    END
+    IF    ${variable} == 5
+        Log    ${variable}
+    END
+
+Inline if
+    IF    ${counter}<=${LIMIT}    Log    ${counter}
+    ${assign}    IF    ${x}>${y}    Set Variable    big    ELSE    Set Variable    small
+
+While condition
+    WHILE    ${counter}>=${LIMIT}
+        ${counter}    Evaluate    ${counter} + 1
+    END
+    WHILE    ${counter} < ${LIMIT}
+        ${counter}    Evaluate    ${counter} + 1
+    END
+
+Chained condition
+    IF    5<${a}<10
+        Log    ${a}
+    END
+
+Keywords with conditions
+    Should Be True    ${left}!=${right}
+    Skip If    ${status}==${FALSE}
+    Pass Execution If    ${left} > ${right}    message
+    Set Variable If    ${x}<${y}    small    ${x} > ${y}    big
+
+Not a condition
+    Should Be True    ${left} == ${right}
+    Log    ${left}==${right}
+    IF    ${text} == "a<b"
+        Log    ${text}
+    END

--- a/tests/linter/rules/misc/not_enough_whitespace_around_operator/test_rule.py
+++ b/tests/linter/rules/misc/not_enough_whitespace_around_operator/test_rule.py
@@ -1,0 +1,17 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5")
+
+    def test_extended(self):
+        self.check_rule(
+            src_files=["test.robot"],
+            expected_file="expected_extended.txt",
+            output_format="extended",
+            test_on_version=">=5",
+        )
+
+    def test_fix(self):
+        self.check_rule_fix(src_files=["test.robot"], test_on_version=">=5")


### PR DESCRIPTION
Resolves #1762.

## Summary
Adds a new linter rule **`MISC16` `not-enough-whitespace-around-operator`** (severity `INFO`) that reports comparison operators used in conditions without surrounding whitespace, and can fix them automatically with `--fix`.

Detected operators: `==`, `!=`, `>`, `<`, `>=`, `<=`.

```robotframework
*** Test Cases ***
Test
    IF    ${variable}==5       # MISC16 -> IF    ${variable} == 5
        Log    Robocop
    END
    WHILE    ${counter}>=${LIMIT}   # MISC16 -> WHILE    ${counter} >= ${LIMIT}
        ${counter}    Evaluate    ${counter} + 1
    END
    Should Be True    ${left}!=${right}   # MISC16 -> Should Be True    ${left} != ${right}
```

## Scope
The rule reuses the existing `ControlFlowChecker.check_condition` pipeline, so it inspects:
- `IF` / `ELSE IF` / inline `IF` / `WHILE` conditions
- conditions passed to BuiltIn keywords that evaluate an expression (`Should Be True`, `Should Not Be True`, `Skip If`, `Pass Execution If`, `Set Variable If`)

It correctly handles:
- two-character operators taking precedence over single-character ones (`>=` before `>`)
- chained comparisons (`5<${a}<10`) and multiple operators per line
- operators inside string literals are ignored to avoid false positives (`${a} == "b<c"`)
- non-condition arguments (keyword call values) are not flagged

## Implementation
- `src/robocop/linter/rules/misc.py`: new `NotEnoughWhitespaceAroundOperatorRule` + `find_unspaced_operators()` helper and `COMPARISON_OPERATORS` constant. `FixAvailability.ALWAYS`, SAFE fix that inserts the missing space(s).
- `src/robocop/linter/checkers/control_flow.py`: wire the rule into `check_condition`.
- `docs/releasenotes/9.0.0.md`: release note entry.

## Tests
Added acceptance tests under `tests/linter/rules/misc/not_enough_whitespace_around_operator/` covering simple output, extended output and the `--fix` behaviour.

- New tests: 3 passed
- Full linter suite: 896 passed, 75 skipped
- `ruff check`, `ruff format`, `mypy --strict` all pass
