### PR TITLE
chore: add context7 url and public key to claim the library

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/marketsquare/robotframework-robocop",
+  "public_key": "pk_oD2T1uAaCx7gs6z8qeDot",
   "projectTitle": "Robocop",
   "description": "Static code analysis tool (linter) and code formatter for Robot Framework",
   "folders": ["docs"],


### PR DESCRIPTION
Adds the `url` and `public_key` fields to `context7.json` so the Robocop library can be **claimed/verified** on Context7.

Claiming the library unlocks:
- a web-based admin panel to manage configuration
- version management for the docs
- higher refresh limits

Follow-up to #1915 (which added Context7 support and the initial `context7.json`).
