### PR TITLE
refactor: merge project checkers sharing keyword usage iteration

### DIFF
--- a/src/robocop/linter/checkers/keyword_arguments.py
+++ b/src/robocop/linter/checkers/keyword_arguments.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from robocop.config.manager import ConfigManager
     from robocop.linter.diagnostics import Diagnostic
-    from robocop.project.context import ProjectContext
+    from robocop.project.context import ProjectContext, ProjectFile
     from robocop.project.definitions import ArgumentsMismatch, KeywordUsage
     from robocop.source_file import VirtualSourceFile
 
@@ -40,9 +40,10 @@ class ArgumentsChecker(VisitorChecker):
 
 
 class ProjectArgumentsChecker(ProjectChecker):
-    """Checker for keyword arguments validated against definitions from the whole project."""
+    """Checker for keyword arguments validated against keyword definitions from the whole project."""
 
     invalid_argument_count: arguments.InvalidArgumentCountRule
+    missing_argument_name: arguments.MissingArgumentNameRule
 
     def scan_project(
         self,
@@ -51,23 +52,61 @@ class ProjectArgumentsChecker(ProjectChecker):
         context: ProjectContext,
     ) -> list[Diagnostic]:
         self.issues = []
+        check_count = self.invalid_argument_count.enabled
+        check_names = self.missing_argument_name.enabled
         for project_file, usage in context.iter_usages():
-            mismatch = self._validate_usage(context, usage)
-            if mismatch is None:
-                continue
-            self.report(
-                self.invalid_argument_count,
-                source=SourceFile(path=project_file.path, config=project_source_file.config),
-                keyword_name=usage.name,
-                expected=mismatch.expected,
-                provided=mismatch.provided,
-                missing=self._describe_missing(mismatch),
-                lineno=usage.location.lineno,
-                col=usage.location.col,
-                end_lineno=usage.location.end_lineno,
-                end_col=usage.location.end_col,
-            )
+            if check_count:
+                self._check_argument_count(context, project_file, usage, project_source_file)
+            if check_names:
+                self._check_argument_names(context, project_file, usage, project_source_file)
         return self.issues
+
+    def _check_argument_count(
+        self,
+        context: ProjectContext,
+        project_file: ProjectFile,
+        usage: KeywordUsage,
+        project_source_file: SourceFile | VirtualSourceFile,
+    ) -> None:
+        mismatch = self._validate_usage(context, usage)
+        if mismatch is None:
+            return
+        self.report(
+            self.invalid_argument_count,
+            source=SourceFile(path=project_file.path, config=project_source_file.config),
+            keyword_name=usage.name,
+            expected=mismatch.expected,
+            provided=mismatch.provided,
+            missing=self._describe_missing(mismatch),
+            lineno=usage.location.lineno,
+            col=usage.location.col,
+            end_lineno=usage.location.end_lineno,
+            end_col=usage.location.end_col,
+        )
+
+    def _check_argument_names(
+        self,
+        context: ProjectContext,
+        project_file: ProjectFile,
+        usage: KeywordUsage,
+        project_source_file: SourceFile | VirtualSourceFile,
+    ) -> None:
+        named_arguments = self._find_positional_arguments(context, usage)
+        if len(named_arguments) < self.missing_argument_name.min_arguments:
+            return
+        source = SourceFile(path=project_file.path, config=project_source_file.config)
+        for index, argument_name in named_arguments:
+            lineno, col, end_col = usage.argument_positions[index]
+            self.report(
+                self.missing_argument_name,
+                source=source,
+                keyword_name=usage.name,
+                argument_name=argument_name,
+                lineno=lineno,
+                col=col,
+                end_lineno=lineno,
+                end_col=end_col,
+            )
 
     @staticmethod
     def _describe_missing(mismatch: ArgumentsMismatch) -> str:
@@ -88,38 +127,6 @@ class ProjectArgumentsChecker(ProjectChecker):
         if definition.has_embedded_arguments:
             return None
         return definition.arguments.validate_call(usage.arguments)
-
-
-class ProjectArgumentNamesChecker(ProjectChecker):
-    """Checker for rules that require argument names from the keyword definitions in the whole project."""
-
-    missing_argument_name: arguments.MissingArgumentNameRule
-
-    def scan_project(
-        self,
-        project_source_file: SourceFile | VirtualSourceFile,
-        config_manager: ConfigManager,  # noqa: ARG002
-        context: ProjectContext,
-    ) -> list[Diagnostic]:
-        self.issues = []
-        for project_file, usage in context.iter_usages():
-            named_arguments = self._find_positional_arguments(context, usage)
-            if len(named_arguments) < self.missing_argument_name.min_arguments:
-                continue
-            source = SourceFile(path=project_file.path, config=project_source_file.config)
-            for index, argument_name in named_arguments:
-                lineno, col, end_col = usage.argument_positions[index]
-                self.report(
-                    self.missing_argument_name,
-                    source=source,
-                    keyword_name=usage.name,
-                    argument_name=argument_name,
-                    lineno=lineno,
-                    col=col,
-                    end_lineno=lineno,
-                    end_col=end_col,
-                )
-        return self.issues
 
     def _find_positional_arguments(self, context: ProjectContext, usage: KeywordUsage) -> list[tuple[int, str]]:
         """

--- a/src/robocop/linter/checkers/usage.py
+++ b/src/robocop/linter/checkers/usage.py
@@ -69,10 +69,12 @@ RESERVED_KEYWORD_NAMES = frozenset({"none"})
 """Values used in place of a keyword name that do not refer to any keyword."""
 
 
-class KeywordNotFound(ProjectChecker):
-    """Reports keyword calls that do not match any known keyword."""
+class KeywordUsageChecker(ProjectChecker):
+    """Checker for rules validated against every keyword call in the project."""
 
     keyword_not_found: usage.KeywordNotFoundRule
+    ambiguous_keyword_name: usage.AmbiguousKeywordNameRule
+    missing_keyword_prefix: usage.MissingKeywordPrefixRule
 
     def scan_project(
         self,
@@ -81,21 +83,107 @@ class KeywordNotFound(ProjectChecker):
         context: ProjectContext,
     ) -> list[Diagnostic]:
         self.issues = []
-        if context.library_loader is None:
-            return self.issues  # without libraries almost every call would be reported
+        # without libraries almost every call would be reported as not found
+        check_not_found = self.keyword_not_found.enabled and context.library_loader is not None
+        check_ambiguous = self.ambiguous_keyword_name.enabled
+        check_prefix = self.missing_keyword_prefix.enabled
         can_check: dict[Path, bool] = {}
         for project_file, keyword_usage in context.iter_usages():
-            if not self._is_known(context, keyword_usage) and self._can_be_checked(context, project_file, can_check):
-                self.report(
-                    self.keyword_not_found,
-                    source=SourceFile(path=project_file.path, config=project_source_file.config),
-                    keyword_name=keyword_usage.name,
-                    lineno=keyword_usage.location.lineno,
-                    col=keyword_usage.location.col,
-                    end_lineno=keyword_usage.location.end_lineno,
-                    end_col=keyword_usage.location.end_col,
-                )
+            if check_not_found:
+                self._check_not_found(context, project_file, keyword_usage, project_source_file, can_check)
+            if check_ambiguous:
+                self._check_ambiguous(context, project_file, keyword_usage, project_source_file)
+            if check_prefix:
+                self._check_prefix(context, project_file, keyword_usage, project_source_file)
         return self.issues
+
+    def _check_not_found(
+        self,
+        context: ProjectContext,
+        project_file: ProjectFile,
+        keyword_usage: KeywordUsage,
+        project_source_file: SourceFile | VirtualSourceFile,
+        can_check: dict[Path, bool],
+    ) -> None:
+        if self._is_known(context, keyword_usage) or not self._can_be_checked(context, project_file, can_check):
+            return
+        self.report(
+            self.keyword_not_found,
+            source=SourceFile(path=project_file.path, config=project_source_file.config),
+            keyword_name=keyword_usage.name,
+            lineno=keyword_usage.location.lineno,
+            col=keyword_usage.location.col,
+            end_lineno=keyword_usage.location.end_lineno,
+            end_col=keyword_usage.location.end_col,
+        )
+
+    def _check_ambiguous(
+        self,
+        context: ProjectContext,
+        project_file: ProjectFile,
+        keyword_usage: KeywordUsage,
+        project_source_file: SourceFile | VirtualSourceFile,
+    ) -> None:
+        candidates = self._ambiguous_definitions(context, keyword_usage)
+        if not candidates:
+            return
+        self.report(
+            self.ambiguous_keyword_name,
+            source=SourceFile(path=project_file.path, config=project_source_file.config),
+            keyword_name=keyword_usage.name,
+            sources=_describe_sources(candidates),
+            lineno=keyword_usage.location.lineno,
+            col=keyword_usage.location.col,
+            end_lineno=keyword_usage.location.end_lineno,
+            end_col=keyword_usage.location.end_col,
+        )
+
+    def _check_prefix(
+        self,
+        context: ProjectContext,
+        project_file: ProjectFile,
+        keyword_usage: KeywordUsage,
+        project_source_file: SourceFile | VirtualSourceFile,
+    ) -> None:
+        prefix = self._find_prefix(context, keyword_usage)
+        if prefix is None:
+            return
+        self.report(
+            self.missing_keyword_prefix,
+            source=SourceFile(path=project_file.path, config=project_source_file.config),
+            keyword_name=keyword_usage.name,
+            prefix=prefix,
+            prefix_offset=_bdd_prefix_offset(keyword_usage),
+            lineno=keyword_usage.location.lineno,
+            col=keyword_usage.location.col,
+            end_lineno=keyword_usage.location.end_lineno,
+            end_col=keyword_usage.location.end_col,
+        )
+
+    def _find_prefix(self, context: ProjectContext, keyword_usage: KeywordUsage) -> str | None:
+        """
+        Find the prefix the call should use.
+
+        Returns:
+            Name of the resource file or library, or None if the call should not be reported.
+
+        """
+        if keyword_usage.name_contains_variable or keyword_usage.is_template:
+            return None
+        name = keyword_usage.names_to_check()[-1]
+        if "." in name:
+            return None  # already prefixed, or the name contains a dot and cannot be prefixed safely
+        definitions = context.resolve_keyword(keyword_usage)
+        if len(definitions) != 1:
+            return None  # not defined in the project, or ambiguous
+        definition = definitions[0]
+        if definition.location.source == keyword_usage.location.source:
+            return None  # keyword defined in the file with the call, there is nothing to prefix it with
+        # keywords from the libraries imported with the ``AS`` syntax already use the alias as the library name
+        prefix = definition.library_name or definition.location.source.stem
+        if normalize_robot_name(prefix) in self.missing_keyword_prefix.ignored_sources:
+            return None
+        return prefix
 
     @staticmethod
     def _is_known(context: ProjectContext, keyword_usage: KeywordUsage) -> bool:
@@ -123,7 +211,7 @@ class KeywordNotFound(ProjectChecker):
         cached = cache.get(resolved)
         if cached is not None:
             return cached
-        can_check = KeywordNotFound._all_imports_known(context, project_file)
+        can_check = KeywordUsageChecker._all_imports_known(context, project_file)
         cache[resolved] = can_check
         return can_check
 
@@ -142,7 +230,7 @@ class KeywordNotFound(ProjectChecker):
         for visible_file in context.imported_files(project_file.path):
             if any(keyword_usage.normalized_name in DYNAMIC_IMPORT_KEYWORDS for keyword_usage in visible_file.usages):
                 return False
-            if not all(KeywordNotFound._import_known(context, imported) for imported in visible_file.imports):
+            if not all(KeywordUsageChecker._import_known(context, imported) for imported in visible_file.imports):
                 return False
         return True
 
@@ -165,35 +253,6 @@ class KeywordNotFound(ProjectChecker):
             return False
         spec = context.library_loader.load_import(imported)
         return spec is not None and spec.loaded
-
-
-class AmbiguousKeywordNames(ProjectChecker):
-    """Reports keyword calls matching keywords defined in more than one place."""
-
-    ambiguous_keyword_name: usage.AmbiguousKeywordNameRule
-
-    def scan_project(
-        self,
-        project_source_file: SourceFile | VirtualSourceFile,
-        config_manager: ConfigManager,  # noqa: ARG002
-        context: ProjectContext,
-    ) -> list[Diagnostic]:
-        self.issues = []
-        for project_file, keyword_usage in context.iter_usages():
-            candidates = self._ambiguous_definitions(context, keyword_usage)
-            if not candidates:
-                continue
-            self.report(
-                self.ambiguous_keyword_name,
-                source=SourceFile(path=project_file.path, config=project_source_file.config),
-                keyword_name=keyword_usage.name,
-                sources=_describe_sources(candidates),
-                lineno=keyword_usage.location.lineno,
-                col=keyword_usage.location.col,
-                end_lineno=keyword_usage.location.end_lineno,
-                end_col=keyword_usage.location.end_col,
-            )
-        return self.issues
 
     @staticmethod
     def _ambiguous_definitions(context: ProjectContext, keyword_usage: KeywordUsage) -> list[KeywordDefinition]:
@@ -278,61 +337,6 @@ def _describe_sources(definitions: list[KeywordDefinition]) -> str:
         if source not in sources:
             sources.append(source)
     return ", ".join(sources)
-
-
-class MissingKeywordPrefix(ProjectChecker):
-    """Reports keyword calls that do not use the name of the resource file or library the keyword comes from."""
-
-    missing_keyword_prefix: usage.MissingKeywordPrefixRule
-
-    def scan_project(
-        self,
-        project_source_file: SourceFile | VirtualSourceFile,
-        config_manager: ConfigManager,  # noqa: ARG002
-        context: ProjectContext,
-    ) -> list[Diagnostic]:
-        self.issues = []
-        for project_file, keyword_usage in context.iter_usages():
-            prefix = self._find_prefix(context, keyword_usage)
-            if prefix is None:
-                continue
-            self.report(
-                self.missing_keyword_prefix,
-                source=SourceFile(path=project_file.path, config=project_source_file.config),
-                keyword_name=keyword_usage.name,
-                prefix=prefix,
-                prefix_offset=_bdd_prefix_offset(keyword_usage),
-                lineno=keyword_usage.location.lineno,
-                col=keyword_usage.location.col,
-                end_lineno=keyword_usage.location.end_lineno,
-                end_col=keyword_usage.location.end_col,
-            )
-        return self.issues
-
-    def _find_prefix(self, context: ProjectContext, keyword_usage: KeywordUsage) -> str | None:
-        """
-        Find the prefix the call should use.
-
-        Returns:
-            Name of the resource file or library, or None if the call should not be reported.
-
-        """
-        if keyword_usage.name_contains_variable or keyword_usage.is_template:
-            return None
-        name = keyword_usage.names_to_check()[-1]
-        if "." in name:
-            return None  # already prefixed, or the name contains a dot and cannot be prefixed safely
-        definitions = context.resolve_keyword(keyword_usage)
-        if len(definitions) != 1:
-            return None  # not defined in the project, or ambiguous
-        definition = definitions[0]
-        if definition.location.source == keyword_usage.location.source:
-            return None  # keyword defined in the file with the call, there is nothing to prefix it with
-        # keywords from the libraries imported with the ``AS`` syntax already use the alias as the library name
-        prefix = definition.library_name or definition.location.source.stem
-        if normalize_robot_name(prefix) in self.missing_keyword_prefix.ignored_sources:
-            return None
-        return prefix
 
 
 def _bdd_prefix_offset(keyword_usage: KeywordUsage) -> int:


### PR DESCRIPTION
## Summary

Merges project checkers that iterate the same project data into single visitors, reusing one `context.iter_usages()` pass — mirroring the multi-rule `VisitorChecker` pattern already used elsewhere.

### `linter/checkers/usage.py`
Combined three checkers that each looped over every keyword call into one `KeywordUsageChecker` handling all three rules:
- `KeywordNotFound` + `AmbiguousKeywordNames` + `MissingKeywordPrefix` → `KeywordUsageChecker` (`keyword-not-found`, `ambiguous-keyword-name`, `missing-keyword-prefix`)
- `UnusedKeywords` left separate (it loops `iter_files()`, not `iter_usages()`).

### `linter/checkers/keyword_arguments.py`
- `ProjectArgumentsChecker` + `ProjectArgumentNamesChecker` → `ProjectArgumentsChecker` (`invalid-argument-count`, `missing-argument-name`)

### Notes
- Each rule's work is guarded by a per-rule `enabled` flag, preserving the previous behavior where a checker only did expensive keyword resolution when its rule was selected (including the "skip when no library loader" short-circuit for `keyword-not-found`).
- Per-usage decision logic stayed in the checkers via small `_check_*` helpers; the rules remain declarative.
- No rule IDs, names, messages, or user-facing behavior changed.

## Testing
- Affected rule acceptance tests (`keyword-not-found`, `ambiguous-keyword-name`, `missing-keyword-prefix`, `invalid-argument-count`, `missing-argument-name`, `unused-keyword`) pass.
- Full `tests/project` suite (179 tests) passes.
- `ruff check` and `mypy --strict` clean.
