### PR TITLE
feat: add args_with_test parameter to AlignTemplatedTestCases

### DIFF
--- a/docs/formatter/formatters/AlignTemplatedTestCases.md
+++ b/docs/formatter/formatters/AlignTemplatedTestCases.md
@@ -27,14 +27,20 @@ Examples:
     *** Settings ***
     Test Template    Templated Keyword
 
-    *** Test Cases ***      baz         qux
+    *** Test Cases ***    baz         qux
     # some comment
-    test1                   hi          hello
-    test2 long test name    asdfasdf    asdsdfgsdfg
-                            bar1        bar2
+    test1
+                          hi          hello
+    test2 long test name
+                          asdfasdf    asdsdfgsdfg
     ```
 
-Any argument in the same line as the test case name will be used as a column header for the alignment:
+By default (``args_with_test=split``) template arguments and settings are moved to their own line and the test case
+names are ignored when calculating the column widths. See the [args_with_test](#control-arguments-placement-with-args_with_test)
+section to keep arguments in the same line as the test case name.
+
+With ``args_with_test=keep`` any argument in the same line as the test case name is kept there and used as a column
+header for the alignment:
 
 === "Before"
 
@@ -58,12 +64,76 @@ Any argument in the same line as the test case name will be used as a column hea
     Test Template    Dummy
 
     *** Test Cases ***
-    Test1     ARG1
-              [Tags]              sanity
-              [Documentation]     Validate Test1
-    Test2     ARG2
-              [Tags]              smoke
-              [Documentation]     Validate Test2
+    Test1    ARG1
+             [Tags]    sanity
+             [Documentation]    Validate Test1
+    Test2    ARG2
+             [Tags]    smoke
+             [Documentation]    Validate Test2
+    ```
+
+## Control arguments placement with args_with_test
+
+Use the ``args_with_test`` parameter to control whether template arguments and settings stay in the same line as the
+test case name. Possible values are ``split`` (default), ``split_on_settings`` and ``keep``:
+
+- ``split`` always moves template arguments and settings to their own line, keeping only the test case name in the
+  first line. Test case names are ignored when calculating the column widths (header names are still respected) and
+  settings are not counted towards the column widths.
+- ``split_on_settings`` moves template arguments and settings to their own line only if the test case contains any
+  setting (such as ``[Tags]`` or ``[Documentation]``).
+- ``keep`` keeps template arguments and settings in the same line as the test case name. When header names are present,
+  the first body row is pulled up to the test case name line.
+
+Test cases that contain block structures (``FOR``, ``IF``, ``TRY``, ``WHILE``) are always split, regardless of the
+selected mode.
+
+=== ":octicons-command-palette-24: cli"
+
+    ```bash
+    robocop format --select AlignTemplatedTestCases -c AlignTemplatedTestCases.args_with_test=keep
+    ```
+
+=== ":material-file-cog-outline: toml"
+
+    ```toml
+    [tool.robocop.format]
+    select = [
+        "AlignTemplatedTestCases"
+    ]
+    configure = [
+        "AlignTemplatedTestCases.args_with_test=keep"
+    ]
+    ```
+
+=== "keep"
+
+    ```robotframework
+    *** Test Cases ***    baz       qux
+    Without settings      arg1      arg2
+    With setting          [Tags]    tag1
+                          arg1      arg2
+    ```
+
+=== "split_on_settings"
+
+    ```robotframework
+    *** Test Cases ***    baz     qux
+    Without settings      arg1    arg2
+    With setting
+        [Tags]    tag1
+                          arg1    arg2
+    ```
+
+=== "split"
+
+    ```robotframework
+    *** Test Cases ***    baz     qux
+    Without settings
+                          arg1    arg2
+    With setting
+        [Tags]    tag1
+                          arg1    arg2
     ```
 
 ## Align only the test case section with named headers
@@ -128,7 +198,9 @@ column.
     ```robotframework
     *** Test Cases ***            baz                           qux
     # some comment
-    test1                         hi                            hello
-    test2 long test name          asdfasdf                      asdsdfgsdfg
+    test1
+                                  hi                            hello
+    test2 long test name
+                                  asdfasdf                      asdsdfgsdfg
                                   bar1                          bar2
     ```

--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -300,6 +300,27 @@ There can be only one
 Enable it with ``robocop format --select AlignBDDStatements``. See
 [AlignBDDStatements](../formatter/formatters/AlignBDDStatements.md) documentation for more details.
 
+### AlignTemplatedTestCases arguments placement (``args_with_test``)
+
+``AlignTemplatedTestCases`` now exposes an ``args_with_test`` parameter that controls whether template arguments and
+settings stay in the same line as the test case name. Possible values are ``split`` (new default),
+``split_on_settings`` and ``keep``:
+
+- ``split`` always moves template arguments and settings to their own line, keeping only the test case name in the
+  first line. Test case names are ignored when calculating the column widths (header names are still respected) and
+  settings are no longer counted towards the column widths.
+- ``split_on_settings`` moves template arguments and settings to their own line only if the test case contains any
+  setting (such as ``[Tags]`` or ``[Documentation]``).
+- ``keep`` keeps template arguments and settings in the same line as the test case name (the previous behaviour). When
+  header names are present, the first body row is pulled up to the test case name line.
+
+Test cases that contain block structures (``FOR``, ``IF``, ``TRY``, ``WHILE``) are always split, regardless of the
+selected mode. Additionally, ``[Documentation]`` no longer affects the calculated column widths.
+
+Since the default changed to ``split``, updating Robocop may reformat existing templated test cases. Configure
+``AlignTemplatedTestCases.args_with_test=keep`` to preserve the previous layout. See
+[AlignTemplatedTestCases](../formatter/formatters/AlignTemplatedTestCases.md) documentation for more details.
+
 ### Support for test case metadata (Robot Framework 7.5)
 
 Upcoming Robot Framework 7.5 allows using the ``[Metadata]`` setting inside test cases:

--- a/src/robocop/formatter/formatters/AlignTemplatedTestCases.py
+++ b/src/robocop/formatter/formatters/AlignTemplatedTestCases.py
@@ -15,6 +15,7 @@ from robot.api.parsing import (
     Token,
 )
 
+from robocop.exceptions import InvalidParameterValueError
 from robocop.formatter.disablers import skip_if_disabled, skip_section_if_disabled
 from robocop.formatter.formatters import Formatter
 from robocop.formatter.utils import misc
@@ -26,6 +27,48 @@ if TYPE_CHECKING:
     from robocop.formatter.disablers import DisablersInFile
 
 UNSET = None
+
+# Statements that represent test case settings (``[Tags]``, ``[Documentation]`` and so on).
+SETTING_TYPES = frozenset(
+    {
+        Token.DOCUMENTATION,
+        Token.TAGS,
+        Token.SETUP,
+        Token.TEARDOWN,
+        Token.TEMPLATE,
+        Token.TIMEOUT,
+    }
+)
+
+SPLIT = "split"
+SPLIT_ON_SETTINGS = "split_on_settings"
+KEEP = "keep"
+ARGS_WITH_TEST_MODES = (SPLIT, SPLIT_ON_SETTINGS, KEEP)
+
+
+def is_setting(statement: Statement) -> bool:
+    return bool(getattr(statement, "data_tokens", None)) and statement.data_tokens[0].type in SETTING_TYPES
+
+
+def is_template_arguments(statement: Statement) -> bool:
+    return bool(getattr(statement, "data_tokens", None)) and statement.data_tokens[0].type == Token.ARGUMENT
+
+
+def has_control_structure(node: TestCase) -> bool:
+    """Return ``True`` if the test case contains a block (``FOR``, ``IF``, ``TRY``, ``WHILE``)."""
+    # Blocks expose a ``body`` attribute while plain statements do not.
+    return any(hasattr(statement, "body") for statement in node.body)
+
+
+def should_split(node: TestCase, mode: str) -> bool:
+    if mode == SPLIT:
+        return True
+    # ``FOR``/``IF`` blocks break the single-line layout, so they are always split.
+    if has_control_structure(node):
+        return True
+    if mode == SPLIT_ON_SETTINGS:
+        return any(is_setting(statement) for statement in node.body)
+    return False
 
 
 class AlignTemplatedTestCases(Formatter):
@@ -46,9 +89,10 @@ class AlignTemplatedTestCases(Formatter):
     ```robotframework
     *** Test Cases ***      baz         qux
     # some comment
-    test1                   hi          hello
-    test2 long test name    asdfasdf    asdsdfgsdfg
-                            bar1        bar2
+    test1
+                            hi          hello
+    test2 long test name
+                            asdfasdf    asdsdfgsdfg
     ```
 
     If you don't want to align test case section that does not contain header names (in above example baz and quz are
@@ -58,21 +102,48 @@ class AlignTemplatedTestCases(Formatter):
     robocop format -c AlignSettingsSection.only_with_headers:True <src>
     ```
 
+    Use ``args_with_test`` parameter to control whether template arguments and settings stay in the same line as the
+    test case name. Possible values are ``split`` (default), ``split_on_settings`` and ``keep``:
+
+    - ``split`` always moves template arguments and settings to their own line, keeping only the test case name in the
+      first line. Test case names are ignored when calculating the column widths (header names are still respected).
+    - ``split_on_settings`` moves template arguments and settings to their own line only if the test case contains any
+      setting (such as ``[Tags]`` or ``[Documentation]``).
+    - ``keep`` keeps template arguments and settings in the same line as the test case name.
+
     For non-templated test cases use ``AlignTestCasesSection`` formatter.
     """
 
     ENABLED = False
 
-    def __init__(self, only_with_headers: bool = False, min_width: int | str | None = None) -> None:
+    def __init__(
+        self,
+        only_with_headers: bool = False,
+        min_width: int | str | None = None,
+        args_with_test: str = SPLIT,
+    ) -> None:
         super().__init__()
         self.only_with_headers = only_with_headers
         # TODO: Replace Robot importer for formatter with our internal importer (like linter)
         # Robot import will not convert if any of types is None, so we need to do it manually
         self.min_width: int | None = int(min_width) if min_width is not None else None
+        self.args_with_test = args_with_test
+        self._validate_args_with_test()
         self.widths: list[int] = []
+        self.header_with_cols = False
         self.test_name_len = 0
         self.test_without_eol = False
+        self.split_current_test = False
         self.indent = 0
+
+    def _validate_args_with_test(self) -> None:
+        if self.args_with_test not in ARGS_WITH_TEST_MODES:
+            raise InvalidParameterValueError(
+                self.__class__.__name__,
+                "args_with_test",
+                self.args_with_test,
+                f"Supported values: {', '.join(ARGS_WITH_TEST_MODES)}.",
+            )
 
     def visit_File(self, node: File) -> File:  # noqa: N802
         if not misc.is_suite_templated(node):
@@ -90,9 +161,10 @@ class AlignTemplatedTestCases(Formatter):
 
     @skip_section_if_disabled
     def visit_TestCaseSection(self, node: TestCaseSection) -> TestCaseSection:  # noqa: N802
-        if len(node.header.data_tokens) == 1 and self.only_with_headers:
+        self.header_with_cols = len(node.header.data_tokens) > 1
+        if not self.header_with_cols and self.only_with_headers:
             return node
-        counter = ColumnWidthCounter(self.disablers)
+        counter = ColumnWidthCounter(self.disablers, self.args_with_test)
         counter.visit(node)
         self.widths = counter.widths
         return self.generic_visit(node)
@@ -101,15 +173,58 @@ class AlignTemplatedTestCases(Formatter):
         for statement in node.body:
             if isinstance(statement, Template) and statement.value is None:
                 return node
+        self.split_current_test = self.should_split(node)
+        self.prepare_test_name_line(node)
         return self.generic_visit(node)
+
+    def should_split(self, node: TestCase) -> bool:
+        return should_split(node, self.args_with_test)
+
+    def prepare_test_name_line(self, node: TestCase) -> None:
+        """Decide which statement (if any) stays in the same line as the test case name and update the name eol."""
+        header = node.header
+        name_token = header.data_tokens[0]
+        self.test_name_len = len(name_token.value)
+        on_name_line = self.get_statement_on_name_line(node)
+        self.test_without_eol = on_name_line is not None
+        if on_name_line is not None:
+            header.tokens = [name_token]
+        else:
+            header.tokens = [name_token, Token(Token.EOL)]
+
+    def get_statement_on_name_line(self, node: TestCase) -> Statement | None:
+        if self.split_current_test:
+            return None
+        first_statement = self.first_body_statement(node)
+        if first_statement is None:
+            return None
+        if first_statement.lineno == node.header.lineno:
+            return first_statement
+        # ``keep`` pulls the first body row (template arguments or a setting) up to the name line when header names
+        # are present.
+        if (
+            self.args_with_test == KEEP
+            and self.header_with_cols
+            and (is_template_arguments(first_statement) or is_setting(first_statement))
+        ):
+            return first_statement
+        return None
+
+    @staticmethod
+    def first_body_statement(node: TestCase) -> Statement | None:
+        for statement in node.body:
+            if not isinstance(statement, EmptyLine):
+                return statement
+        return None
 
     @skip_if_disabled
     def visit_Statement(self, statement: Statement) -> Statement:  # noqa: N802
         if statement.type == Token.TESTCASE_NAME:
-            self.test_name_len = len(statement.data_tokens[0].value) if statement.data_tokens else 0
-            self.test_without_eol = statement.tokens[-1].type != Token.EOL
-        elif statement.type == Token.TESTCASE_HEADER:
+            return statement
+        if statement.type == Token.TESTCASE_HEADER:
             self.align_header(statement)
+        elif self.split_current_test and is_setting(statement):
+            self.align_indented(statement)
         elif not isinstance(
             statement,
             (Comment, EmptyLine, ForHeader, IfHeader, ElseHeader, ElseIfHeader, End),
@@ -132,6 +247,20 @@ class AlignTemplatedTestCases(Formatter):
         tokens.append(statement.tokens[-1])  # eol
         statement.tokens = tokens
         return statement
+
+    def align_indented(self, statement: Statement) -> None:
+        """Align a statement using a fixed indentation instead of the column widths (used for split settings)."""
+        space_count = self.formatting_config.space_count
+        indent = (self.indent + 1) * space_count * " "
+        separator = space_count * " "
+        tokens = []
+        for line in statement.lines:
+            strip_line = [token for token in line if token.type not in (Token.SEPARATOR, Token.EOL)]
+            for index, token in enumerate(strip_line):
+                tokens.append(Token(Token.SEPARATOR, indent if index == 0 else separator))
+                tokens.append(token)
+            tokens.append(line[-1])
+        statement.tokens = tokens
 
     def align_statement(self, statement: Statement) -> None:
         tokens = []
@@ -170,9 +299,11 @@ class AlignTemplatedTestCases(Formatter):
 
 
 class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
-    def __init__(self, disablers: DisablersInFile) -> None:
+    def __init__(self, disablers: DisablersInFile, args_with_test: str) -> None:
         self.widths: list[int] = []
         self.disablers: DisablersInFile = disablers
+        self.args_with_test = args_with_test
+        self.split_current_test = False
         self.test_name_lineno: int = -1
         self.any_one_line_test: bool = False
         self.header_with_cols: bool = False
@@ -186,6 +317,7 @@ class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
         for statement in node.body:
             if isinstance(statement, Template) and statement.value is None:
                 return
+        self.split_current_test = should_split(node, self.args_with_test)
         self.generic_visit(node)
 
     @skip_if_disabled
@@ -197,14 +329,19 @@ class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
                 self.header_with_cols = True
                 self._count_widths_from_statement(statement)
         elif statement.type == Token.TESTCASE_NAME:
+            # Split test case names are moved to their own line, so they don't count towards the column widths.
+            name_len = 0 if self.split_current_test else len(statement.name)
             if self.widths:
-                self.widths[0] = max(self.widths[0], len(statement.name))
+                self.widths[0] = max(self.widths[0], name_len)
             else:
-                self.widths.append(len(statement.name))
+                self.widths.append(name_len)
             self.test_name_lineno = statement.lineno
         else:
-            if self.test_name_lineno == statement.lineno:
+            if not self.split_current_test and self.test_name_lineno == statement.lineno:
                 self.any_one_line_test = True
+            # Settings are aligned to columns only when they stay in place (i.e. the test case is not split).
+            if self.split_current_test and is_setting(statement):
+                return
             if not isinstance(statement, (ForHeader, IfHeader, ElseHeader, ElseIfHeader, End)):
                 self._count_widths_from_statement(statement, indent=1)
 

--- a/src/robocop/formatter/formatters/AlignTemplatedTestCases.py
+++ b/src/robocop/formatter/formatters/AlignTemplatedTestCases.py
@@ -148,7 +148,8 @@ class AlignTemplatedTestCases(Formatter):
                 if self.test_without_eol:
                     self.test_without_eol = False
                     exp_pos -= self.test_name_len
-                tokens.append(Token(Token.SEPARATOR, (exp_pos - line_pos) * " "))
+                sep_len = max(exp_pos - line_pos, self.formatting_config.space_count)
+                tokens.append(Token(Token.SEPARATOR, sep_len * " "))
                 tokens.append(token)
                 line_pos += len(token.value) + exp_pos - line_pos
             tokens.append(line[-1])
@@ -189,7 +190,7 @@ class ColumnWidthCounter(ModelVisitor):  # type: ignore[misc]
 
     @skip_if_disabled
     def visit_Statement(self, statement: Statement) -> None:  # noqa: N802
-        if statement.type == Token.COMMENT:
+        if statement.type in (Token.COMMENT, Token.DOCUMENTATION):
             return
         if statement.type == Token.TESTCASE_HEADER:
             if len(statement.data_tokens) > 1:

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_header_keep.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_header_keep.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***    FIRST_ARG    SECOND_ARG
+Without settings      arg1         arg2
+Multiline no sett     arg1         arg2
+                      arg3         arg4          arg5
+With setting          [Tags]       tag1          tag2
+                      arg1         arg2
+With doc              [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                      arg1         arg2
+New line              arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_header_split.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_header_split.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***    FIRST_ARG    SECOND_ARG
+Without settings
+                      arg1         arg2
+Multiline no sett
+                      arg1         arg2
+                      arg3         arg4          arg5
+With setting
+    [Tags]    tag1    tag2
+                      arg1         arg2
+With doc
+    [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                      arg1         arg2
+New line
+                      arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_header_split_on_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_header_split_on_settings.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***    FIRST_ARG    SECOND_ARG
+Without settings      arg1         arg2
+Multiline no sett     arg1         arg2
+                      arg3         arg4          arg5
+With setting
+    [Tags]    tag1    tag2
+                      arg1         arg2
+With doc
+    [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                      arg1         arg2
+New line
+                      arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_no_header_keep.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_no_header_keep.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***
+Without settings     arg1      arg2
+Multiline no sett    arg1      arg2
+                     arg3      arg4    arg5
+With setting         [Tags]    tag1    tag2
+                     arg1      arg2
+With doc             [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                     arg1      arg2
+New line
+                     arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_no_header_split.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_no_header_split.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***
+Without settings
+    arg1    arg2
+Multiline no sett
+    arg1    arg2
+    arg3    arg4    arg5
+With setting
+    [Tags]    tag1    tag2
+    arg1    arg2
+With doc
+    [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+    arg1    arg2
+New line
+    arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_no_header_split_on_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/args_with_test_no_header_split_on_settings.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***
+Without settings     arg1    arg2
+Multiline no sett    arg1    arg2
+                     arg3    arg4    arg5
+With setting
+    [Tags]    tag1    tag2
+                     arg1    arg2
+With doc
+    [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                     arg1    arg2
+New line
+                     arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/empty_line.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/empty_line.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+Test Template       bar
+
+*** Test Cases ***      baz         qux
+test1                   hi          hello
+test2 long test name    asdfasdf    asdsdfgsdfg
+
+*** Keywords ***
+bar
+    [Arguments]    ${baz}    ${qux}

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/tags_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/tags_settings.robot
@@ -5,8 +5,7 @@ Test Template    Login with invalid credentials should fail
 *** Test Cases ***                USERNAME         PASSWORD
 Invalid User Name                 [Tags]           foo
                                   invalid          ${VALID PASSWORD}
-Invalid Password
-                                  [Tags]           bar
+Invalid Password                  [Tags]           bar
                                   ${VALID USER}    invalid
 Invalid User Name and Password    [Tags]           baz
                                   invalid          invalid

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without.robot
@@ -4,13 +4,13 @@ Test Template    Dummy
 *** Test Cases ***
 Template with for loop
     FOR    ${item}    IN    @{ITEMS}
-                          ${item}     2nd arg
+                        ${item}     2nd arg
     END
     FOR    ${index}    IN RANGE    42
-                          1st arg     ${index}
+                        1st arg     ${index}
     END
-                          test        ${arg}
+                        test        ${arg}
 
 # some comment
-test1                     hi          hello
-test2 long test name      asdfasdf    asdsdfgsdfg
+test1                   hi          hello
+test2 long test name    asdfasdf    asdsdfgsdfg

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without_fixed.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_and_without_fixed.robot
@@ -4,13 +4,13 @@ Test Template    Dummy
 *** Test Cases ***
 Template with for loop
     FOR    ${item}    IN    @{ITEMS}
-                          ${item}                  2nd arg
+                         ${item}                  2nd arg
     END
     FOR    ${index}    IN RANGE    42
-                          1st arg                  ${index}
+                         1st arg                  ${index}
     END
-                          test                     ${arg}
+                         test                     ${arg}
 
 # some comment
-test1                     hi                       hello
-test2 long test name      asdfasdf                 asdsdfgsdfg
+test1                    hi                       hello
+test2 long test name     asdfasdf                 asdsdfgsdfg

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_header_cols.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/templated_for_loops_header_cols.robot
@@ -1,11 +1,11 @@
 *** Settings ***
 Test Template    Dummy
 
-*** Test Cases ***        foo        bar
+*** Test Cases ***    foo        bar
 Template with for loop
     FOR    ${item}    IN    @{ITEMS}
-                          ${item}    2nd arg
+                      ${item}    2nd arg
     END
     FOR    ${index}    IN RANGE    42
-                          1st arg    ${index}
+                      1st arg    ${index}
     END

--- a/tests/formatter/formatters/AlignTemplatedTestCases/expected/with_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/expected/with_settings.robot
@@ -3,14 +3,15 @@ Test Template    Dummy
 
 *** Test Cases ***
 Test1    ARG1
-         [Tags]             sanity
+         [Tags]    sanity
          [Documentation]    Validate Test1
 Test2    ARG2
-         [Tags]             smoke
+         [Tags]    smoke
          [Documentation]    Validate Test2
 Test3    ARG3
-         [Tags]             valid
+         [Tags]    valid
          [Documentation]    Validate Test3
 Test4    ARG4
-         [Tags]             sanity
+         [Tags]    sanity
          [Documentation]    Validate Test4
+Test5    ARG5      ARG_SUB

--- a/tests/formatter/formatters/AlignTemplatedTestCases/source/args_with_test_header.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/source/args_with_test_header.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***    FIRST_ARG    SECOND_ARG
+Without settings      arg1         arg2
+Multiline no sett     arg1         arg2
+                      arg3         arg4          arg5
+With setting          [Tags]       tag1          tag2
+                      arg1         arg2
+With doc              [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                      arg1         arg2
+New line
+                      arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/source/args_with_test_no_header.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/source/args_with_test_no_header.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Test Template    Keyword
+
+*** Test Cases ***
+Without settings      arg1         arg2
+Multiline no sett     arg1         arg2
+                      arg3         arg4          arg5
+With setting          [Tags]       tag1          tag2
+                      arg1         arg2
+With doc              [Documentation]    This is multiline doc, currently it affects alignment but I will ignore it in the future
+                      arg1         arg2
+New line
+                      arg1

--- a/tests/formatter/formatters/AlignTemplatedTestCases/source/with_settings.robot
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/source/with_settings.robot
@@ -14,3 +14,4 @@ Test3    ARG3
 Test4    ARG4
     [Tags]    sanity
     [Documentation]  Validate Test4
+Test5    ARG5    ARG_SUB

--- a/tests/formatter/formatters/AlignTemplatedTestCases/test_formatter.py
+++ b/tests/formatter/formatters/AlignTemplatedTestCases/test_formatter.py
@@ -5,6 +5,7 @@ from tests.formatter import FormatterAcceptanceTest
 
 class TestAlignTemplatedTestCases(FormatterAcceptanceTest):
     FORMATTER_NAME = "AlignTemplatedTestCases"
+    KEEP = f"{FORMATTER_NAME}.args_with_test=keep"
 
     @pytest.mark.parametrize(
         "source",
@@ -15,39 +16,72 @@ class TestAlignTemplatedTestCases(FormatterAcceptanceTest):
             "templated_for_loops.robot",
             "templated_for_loops_and_without.robot",
             "templated_for_loops_header_cols.robot",
+            "empty_line.robot",
         ],
     )
     def test_formatter(self, source):
-        self.compare(source=source, expected=source, not_modified=source == "templated_for_loops.robot")
+        self.compare(
+            source=source,
+            expected=source,
+            configure=[self.KEEP],
+            not_modified=source == "templated_for_loops.robot",
+        )
 
-    @pytest.mark.parametrize("source", ["for_loops.robot", "empty_line.robot"])
+    @pytest.mark.parametrize("source", ["for_loops.robot"])
     def test_should_not_modify(self, source):
-        self.compare(source=source, not_modified=True)
+        self.compare(source=source, not_modified=True, configure=[self.KEEP])
 
     def test_only_with_headers(self):
         self.compare(
             source="no_header_col.robot",
             not_modified=True,
-            configure=[f"{self.FORMATTER_NAME}.only_with_headers=True"],
+            configure=[f"{self.FORMATTER_NAME}.only_with_headers=True", self.KEEP],
         )
 
     def test_fixed(self):
         self.compare(
-            source="test.robot", expected="test_fixed.robot", configure=[f"{self.FORMATTER_NAME}.min_width=30"]
+            source="test.robot",
+            expected="test_fixed.robot",
+            configure=[f"{self.FORMATTER_NAME}.min_width=30", self.KEEP],
         )
 
     def test_for_fixed(self):
         self.compare(
             source="templated_for_loops_and_without.robot",
             expected="templated_for_loops_and_without_fixed.robot",
-            configure=[f"{self.FORMATTER_NAME}.min_width=25"],
+            configure=[f"{self.FORMATTER_NAME}.min_width=25", self.KEEP],
         )
 
     def test_disablers(self):
-        self.compare(source="disablers.robot", not_modified=True)
+        self.compare(source="disablers.robot", not_modified=True, configure=[self.KEEP])
 
     def test_tags(self):
-        self.compare(source="tags_settings.robot", configure=[f"{self.FORMATTER_NAME}.enabled=True"], run_all=True)
+        self.compare(
+            source="tags_settings.robot",
+            configure=[f"{self.FORMATTER_NAME}.enabled=True", self.KEEP],
+            run_all=True,
+        )
 
     def test_partly_templated(self):
-        self.compare(source="partly_templated.robot")
+        self.compare(source="partly_templated.robot", configure=[self.KEEP])
+
+    @pytest.mark.parametrize("headers", ["header", "no_header"])
+    @pytest.mark.parametrize("mode", ["split", "split_on_settings", "keep"])
+    def test_args_with_test(self, mode, headers):
+        source = f"args_with_test_{headers}.robot"
+        self.compare(
+            source=source,
+            expected=f"args_with_test_{headers}_{mode}.robot",
+            configure=[f"{self.FORMATTER_NAME}.args_with_test={mode}"],
+        )
+
+    def test_invalid_args_with_test(self):
+        result = self.run_tidy(
+            select=[self.FORMATTER_NAME],
+            configure=[f"{self.FORMATTER_NAME}.args_with_test=invalid"],
+            source="args_with_test_header.robot",
+            exit_code=2,
+        )
+        expected_output = "Supported values: split, split_on_settings, keep."
+        assert "args_with_test" in str(result.value)
+        assert expected_output in str(result.value)


### PR DESCRIPTION
## Description

Refactors the `AlignTemplatedTestCases` formatter and adds a new `args_with_test` parameter that controls whether template arguments and settings stay in the same line as the test case name.

### `args_with_test` values

- **`split`** (new default): always moves template arguments and settings to their own line, keeping only the test case name in the first line. Test case names **and** settings are ignored when calculating column widths (header names are still respected).
- **`split_on_settings`**: moves arguments/settings to their own line only if the test case contains a setting (e.g. `[Tags]`, `[Documentation]`).
- **`keep`** (previous behaviour): keeps arguments/settings in the same line as the test case name. When header names are present, the first body row is pulled up to the name line.

### Other behaviour changes

- Test cases containing block structures (`FOR`, `IF`, `TRY`, `WHILE`) are always split, regardless of mode (they don't align well when kept).
- `[Documentation]` no longer affects the calculated column widths.

### Notes

- The default changed to `split`, which is a **breaking change** for existing templated suites. Configure `AlignTemplatedTestCases.args_with_test=keep` to preserve the old layout. Documented in the 9.0.0 release notes.
- Docs and release notes updated; new acceptance fixtures cover all mode/header combinations.

Partially addresses #1507.
