### PR TITLE
fix: strip whitespace in comma-separated formatter parameters

### DIFF
--- a/docs/releasenotes/9.0.0.md
+++ b/docs/releasenotes/9.0.0.md
@@ -629,6 +629,7 @@ See the [configuration documentation](../configuration/index.md#generate-a-confi
 - replaced the deprecated GitWildMatchPattern with GitIgnoreSpec (#1887)
 - ``not-allowed-char-in-filename`` (file-wide rule) prints source code on report (#1871)
 - check the ``VAR`` assignment sign in the ``inconsistent-assignment`` rule (#1902)
+- strip whitespace in comma-separated formatter parameters so values like ``imports_order=library, resource, variables`` are accepted (#1922)
 
 ## Other
 

--- a/src/robocop/formatter/formatters/AlignVariablesSection.py
+++ b/src/robocop/formatter/formatters/AlignVariablesSection.py
@@ -69,6 +69,7 @@ class AlignVariablesSection(Formatter):
         if not skip_types:
             return ret
         for skip_type in skip_types.split(","):
+            skip_type = skip_type.strip()
             if skip_type not in allow_types:
                 raise InvalidParameterValueError(
                     self.__class__.__name__,

--- a/src/robocop/formatter/formatters/MergeAndOrderSections.py
+++ b/src/robocop/formatter/formatters/MergeAndOrderSections.py
@@ -84,7 +84,7 @@ class MergeAndOrderSections(Formatter):
         )
         if not order:
             return default_order
-        parts = order.lower().split(",")
+        parts = [part.strip() for part in order.lower().split(",")]
         map_names = {
             "comments": Token.COMMENT_HEADER,
             "comment": Token.COMMENT_HEADER,

--- a/src/robocop/formatter/formatters/OrderSettings.py
+++ b/src/robocop/formatter/formatters/OrderSettings.py
@@ -125,7 +125,7 @@ class OrderSettings(Formatter):
     def get_order(self, order: str, param_name: str, name_map: dict[str, str]) -> list[str]:
         if not order:
             return []
-        parts = order.lower().split(",")
+        parts = [part.strip() for part in order.lower().split(",")]
         try:
             return [name_map[part] for part in parts]
         except KeyError:

--- a/src/robocop/formatter/formatters/OrderSettingsSection.py
+++ b/src/robocop/formatter/formatters/OrderSettingsSection.py
@@ -108,7 +108,7 @@ class OrderSettingsSection(Formatter):
             return default
         if not order:
             return []
-        parts = order.lower().split(",")
+        parts = [part.strip() for part in order.lower().split(",")]
         if any(part not in default for part in parts):
             raise InvalidParameterValueError(
                 self.__class__.__name__,
@@ -128,7 +128,7 @@ class OrderSettingsSection(Formatter):
         if order == "preserved":
             self.disabled_group.add(name)
             return default
-        parts = order.lower().split(",")
+        parts = [part.strip() for part in order.lower().split(",")]
         try:
             return [mapping[part] for part in parts]
         except KeyError:

--- a/src/robocop/formatter/formatters/RenameVariables.py
+++ b/src/robocop/formatter/formatters/RenameVariables.py
@@ -279,7 +279,7 @@ class RenameVariables(Formatter):
     def get_ignored_variables_case(self, ignore_vars: str | None) -> set[str]:
         if ignore_vars is None:
             return self.DEFAULT_IGNORE_CASE
-        ignored_vars = set(ignore_vars.split(","))
+        ignored_vars = {var.strip() for var in ignore_vars.split(",")}
         return ignored_vars.union(self.DEFAULT_IGNORE_CASE)
 
     @skip_section_if_disabled

--- a/tests/formatter/formatters/AlignVariablesSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignVariablesSection/test_formatter.py
@@ -42,6 +42,13 @@ class TestAlignVariablesSection(FormatterAcceptanceTest):
             source="tests.robot", expected="tests_skip.robot", configure=[f"{self.FORMATTER_NAME}.skip_types=dict,list"]
         )
 
+    def test_align_variables_skip_with_spaces(self):
+        self.compare(
+            source="tests.robot",
+            expected="tests_skip.robot",
+            configure=[f"{self.FORMATTER_NAME}.skip_types=dict, list"],
+        )
+
     def test_align_variables_skip_scalar(self):
         self.compare(
             source="align_selected.robot",

--- a/tests/formatter/formatters/MergeAndOrderSections/test_formatter.py
+++ b/tests/formatter/formatters/MergeAndOrderSections/test_formatter.py
@@ -44,6 +44,16 @@ class TestMergeAndOrderSections(FormatterAcceptanceTest):
             configure=configure,
         )
 
+    def test_custom_order_with_spaces(self):
+        configure = [
+            f"{self.FORMATTER_NAME}.order=settings, comments, keyword, variables, testcases",
+        ]
+        self.compare(
+            source="order.robot",
+            expected="order_settings_comments_keywords_variables_testcases.robot",
+            configure=configure,
+        )
+
     def test_do_not_create_comment_section(self):
         self.compare(
             source="tests.robot",

--- a/tests/formatter/formatters/OrderSettings/test_formatter.py
+++ b/tests/formatter/formatters/OrderSettings/test_formatter.py
@@ -66,6 +66,20 @@ class TestOrderSettings(FormatterAcceptanceTest):
     def test_disablers(self):
         self.compare(source="disablers.robot", not_modified=True)
 
+    def test_custom_order_with_spaces(self):
+        configure = [
+            f"{self.FORMATTER_NAME}.keyword_before=documentation, tags, arguments, timeout, setup",
+            f"{self.FORMATTER_NAME}.keyword_after=teardown, return",
+            f"{self.FORMATTER_NAME}.test_before=documentation, tags, timeout, setup, template",
+            f"{self.FORMATTER_NAME}.test_after=teardown",
+        ]
+        expected = "custom_order_default"
+        if ROBOT_VERSION.major < 7:
+            expected += "_pre_rf7.robot"
+        else:
+            expected += ".robot"
+        self.compare(source="test.robot", expected=expected, configure=configure)
+
     # def test_custom_order_setting_twice_in_one(self):  # TODO check error output test
     #     result = self.run_tidy(
     #         select=[self.FORMATTER_NAME],

--- a/tests/formatter/formatters/OrderSettingsSection/test_formatter.py
+++ b/tests/formatter/formatters/OrderSettingsSection/test_formatter.py
@@ -54,6 +54,17 @@ class TestOrderSettingsSection(FormatterAcceptanceTest):
             configure=configure,
         )
 
+    def test_custom_group_order_import_ordered_with_spaces(self):
+        configure = [
+            f"{self.FORMATTER_NAME}.group_order=tags, documentation, imports, settings",
+            f"{self.FORMATTER_NAME}.imports_order=library, resource, variables",
+        ]
+        self.compare(
+            source="test.robot",
+            expected="test_group_order_import_ordered.robot",
+            configure=configure,
+        )
+
     def test_missing_group_from_param(self):
         self.compare(
             source="test.robot",


### PR DESCRIPTION
## Description

Order and skip parameters that accept comma-separated values previously rejected values containing spaces after commas (e.g. `imports_order=library, resource, variables`), raising an `InvalidParameterValueError`. This carried over from robotidy ([robotframework-tidy#717](https://github.com/MarketSquare/robotframework-tidy/issues/717)).

Each comma-separated part is now stripped before validation, so spaces added for readability are tolerated.

## Affected formatters / parameters

| Formatter | Parameter(s) |
| --- | --- |
| `OrderSettingsSection` | `group_order`, `imports_order`, `documentation_order`, `settings_order`, `tags_order` |
| `OrderSettings` | `keyword_before`, `keyword_after`, `test_before`, `test_after` |
| `MergeAndOrderSections` | `order` |
| `AlignVariablesSection` | `skip_types` |
| `RenameVariables` | `ignore_vars` (defensive) |

`AlignTestCasesSection` and `AlignKeywordsSection` widths were already tolerant.

## Tests

Added space-tolerance regression tests for the four validating formatters, reusing existing expected-output files. All affected suites pass.

Fixes MarketSquare/robotframework-tidy#717