### PR TITLE
test: assert cli version against package __version__

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,12 @@
 """Test CLI commands / options common for linter and formatter."""
 
-from importlib import metadata
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
+from robocop import __version__
 from robocop.run import app
 from robocop.version_handling import ROBOT_VERSION
 from tests import working_directory
@@ -15,7 +15,7 @@ from tests import working_directory
 def test_version():
     runner = CliRunner()
     result = runner.invoke(app, ["--version"])
-    assert result.stdout == f"robocop, version {metadata.version('robotframework-robocop')}\n"
+    assert result.stdout == f"robocop, version {__version__}\n"
 
 
 def test_print_docs_rule():


### PR DESCRIPTION
## What
Assert the CLI-reported version against `robocop.__version__` instead of `importlib.metadata.version("robotframework-robocop")`.

## Why
The old assertion compared the CLI output to the *installed package metadata*. With an editable install this drifts from the source (`src/robocop/__init__.py`) whenever the version is bumped but the package is not reinstalled, producing a false failure that has nothing to do with the CLI.

## What changed
- `tests/test_cli.py`: compare against `from robocop import __version__`.
- Removed the now-unused `from importlib import metadata` import.

## Tests
`tests/test_cli.py::test_version` passes; ruff + mypy clean.
