### PR TITLE
chore: remove unused rich_click mypy override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ ignore_missing_imports = true
 
 # External libraries that may have incomplete stubs or no stubs at all
 [[tool.mypy.overrides]]
-module = ["typer.*", "click.*", "rich.*", "rich_click.*", "platformdirs.*", "tomli.*", "tomli_w.*", "jinja2.*"]
+module = ["typer.*", "click.*", "rich.*", "platformdirs.*", "tomli.*", "tomli_w.*", "jinja2.*"]
 ignore_missing_imports = true
 
 # CLI module - intentionally passes None values to dataclasses which are handled by overwrite()


### PR DESCRIPTION
## What
Remove the `"rich_click.*"` entry from the mypy `ignore_missing_imports` override list.

## Why
`rich_click` is no longer imported anywhere, so the override is dead configuration.

## What changed
- `pyproject.toml`: drop the stale override entry.

## Tests
`mypy --strict` clean.
