### PR TITLE
chore: configure deptry for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,15 @@ mcp = [
     "pydantic>=2.13.4",
 ]
 
+[tool.deptry]
+# The distribution is named "robotframework-robocop" but the importable module is "robocop".
+known_first_party = ["robocop"]
+# Dev-only scripts that legitimately import dev/doc dependencies.
+extend_exclude = [
+    "docs",
+    "noxfile.py",
+]
+
 [tool.ruff]
 line-length = 120
 show-fixes = true


### PR DESCRIPTION
## What
Configure `deptry` for this src-layout project.

## Why
The distribution is `robotframework-robocop` but the import package is `robocop`, so deptry could not map imports to the first-party package and reported ~442 issues (almost entirely false-positive `DEP003 'robocop' transitive`).

## What changed
- `pyproject.toml`: add `[tool.deptry]` with `known_first_party = ["robocop"]` and `extend_exclude = ["docs", "noxfile.py"]` (dev-only tooling: `mkdocs_gen_files`, `nox`).

## Result
`deptry .` now reports **0 issues**.
