### PR TITLE
feat: register deprecated rules so they are recognized in configuration

### DIFF
--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -851,7 +851,7 @@ class MultilineInlineIfRule(Rule):
         )
 
 
-class UnnecessaryStringConversionRule(Rule):  # TODO: Not used atm, see if it was deprecated before
+class UnnecessaryStringConversionRule(Rule):
     """
     Variable in the condition has unnecessary string conversion.
 

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -123,6 +123,8 @@ class RuleMatcher:
         self.ignore_filter = RuleFilter.from_rules(ignore)
         self.fixable_filter = RuleFilter(exact_matches=set(fixable))
         self.unfixable_filter = RuleFilter(exact_matches=set(unfixable))
+        # Populated after the rules are loaded. Maps a deprecated rule name / id / old name to its rule.
+        self.deprecated_rules: dict[str, Rule] = {}
 
     def is_rule_enabled(self, rule: Rule) -> bool:
         if self._is_rule_disabled(rule):
@@ -177,14 +179,19 @@ class RuleMatcher:
             # (self.unfixable_filter.exact_matches, self.unfixable_filter.matched, "--unfixable"),
         ]
 
-        errors = [
-            f"Option value '{rule}' from '{option}' did not match with any rule name or id."
-            for original, matched, option in unmatched
-            for rule in set(original) - matched
-        ]
+        errors = []
+        warnings = []
+        for original, matched, option in unmatched:
+            for rule in set(original) - matched:
+                deprecated_rule = self.deprecated_rules.get(rule)
+                if deprecated_rule is not None:
+                    warnings.append(deprecated_rule.deprecation_warning)
+                else:
+                    errors.append(f"Option value '{rule}' from '{option}' did not match with any rule name or id.")
 
-        if errors:
-            typer.echo("\n".join(errors), err=True)
+        messages = [*dict.fromkeys(warnings), *errors]
+        if messages:
+            typer.echo("\n".join(messages), err=True)
 
 
 def is_checker(checker_class_def: tuple[str, type]) -> bool:
@@ -265,8 +272,8 @@ class LinterImporter:
         self._purge_internal_modules()
         # rules have to be reimported first: `from robocop.linter.rules import <module>` inside a checker would
         # otherwise resolve to the stale module still referenced by the rules package
-        for _ in self._import_package_modules("robocop.linter.rules.", self.internal_rules_dir):
-            pass
+        for rule_module in self._import_package_modules("robocop.linter.rules.", self.internal_rules_dir):
+            self._collect_deprecated_rules(rule_module)
         yield from self._import_package_modules("robocop.linter.checkers.", self.internal_checkers_dir)
 
     def get_internal_rule_modules(self) -> Generator[types.ModuleType, None, None]:
@@ -295,9 +302,27 @@ class LinterImporter:
 
     def _get_initialized_checkers_from_module(self, module: types.ModuleType) -> Generator[BaseChecker, None, None]:
         self.seen_modules.add(module)
+        self._collect_deprecated_rules(module)
         for checker_instance in self.get_checkers_from_module(module):
             if not self.is_checker_already_imported(checker_instance):
                 yield checker_instance
+
+    def _collect_deprecated_rules(self, module: types.ModuleType) -> None:
+        """
+        Discover deprecated rule classes defined in a module.
+
+        Deprecated rules are not attached to any checker, so they are not loaded through the regular flow.
+        Collecting them here keeps them recognizable by ``--select`` / ``--configure`` and by ``robocop list``,
+        so that referencing a removed rule reports a deprecation warning instead of an "unknown rule" error.
+        """
+        for name, rule_class in inspect.getmembers(module, inspect.isclass):
+            if not is_rule((name, rule_class)):
+                continue
+            rule = rule_class()
+            if not rule.deprecated:
+                continue
+            for key in (rule.name, rule.rule_id, *(rule.deprecated_names or ())):
+                self.deprecated_rules.setdefault(key, rule)
 
     def is_checker_already_imported(self, checker: BaseChecker) -> bool:
         """
@@ -397,14 +422,6 @@ class LinterImporter:
             except ImportError:
                 pass
 
-    def register_deprecated_rules(self, module_rules: dict[str, Rule]) -> None:
-        # FIXME: currently deprecated, not used rules are hidden (we could just mentioned them in doc. or create
-        # empty checker just for deprecated stuff
-        for rule_name, rule_def in module_rules.items():
-            if rule_def.deprecated:
-                self.deprecated_rules[rule_name] = rule_def
-                self.deprecated_rules[rule_def.rule_id] = rule_def
-
     def _import_rule_class(self, module: types.ModuleType, rule_class: str) -> type[Rule] | None:
         """
         Import class definition using typing information.
@@ -438,7 +455,6 @@ class LinterImporter:
         # FIXME do not inspect / enter external libs such as re..
         classes = inspect.getmembers(module, inspect.isclass)
         checkers = [checker[1]() for checker in classes if is_checker(checker)]
-        # self.register_deprecated_rules(module_rules) # FIXME
         checker_instances = []
         for checker in checkers:
             rules = self.get_checker_rules(checker, module)
@@ -533,8 +549,22 @@ class RulesLoader:
         robocop_importer = LinterImporter(external_rules_paths=self.custom_rules)
         for checker in robocop_importer.get_initialized_checkers():
             self.register_checker(checker)
-        # linter.rules.update(robocop_importer.deprecated_rules)
+        self.register_deprecated_rules(robocop_importer.deprecated_rules)
         self.validate_any_rule_enabled()
+
+    def register_deprecated_rules(self, deprecated_rules: dict[str, Rule]) -> None:
+        """
+        Register deprecated rules so they remain recognizable by select / configure and by ``robocop list``.
+
+        Deprecated rules are never enabled (``Rule.is_disabled`` returns True), so they do not produce diagnostics.
+        Registering them lets Robocop report a deprecation warning instead of an "unknown rule" error when a removed
+        rule is still referenced in the configuration.
+        """
+        self.rule_matcher.deprecated_rules = deprecated_rules
+        for key, rule in deprecated_rules.items():
+            rule.enabled = False  # deprecated rules never run; keep them reported as disabled
+            self.rules.setdefault(key, rule)
+            self.apply_configuration(rule, key)
 
     def register_checker(self, checker: BaseChecker | AfterRunChecker | ProjectChecker) -> None:
         any_enabled = False

--- a/src/robocop/runtime/resolver.py
+++ b/src/robocop/runtime/resolver.py
@@ -318,9 +318,11 @@ class LinterImporter:
         for name, rule_class in inspect.getmembers(module, inspect.isclass):
             if not is_rule((name, rule_class)):
                 continue
-            rule = rule_class()
-            if not rule.deprecated:
+            # ``deprecated`` is a class attribute, so gate on it before instantiating to avoid
+            # constructing every rule class (180+) just to discover the few deprecated ones.
+            if not rule_class.deprecated:
                 continue
+            rule = rule_class()
             for key in (rule.name, rule.rule_id, *(rule.deprecated_names or ())):
                 self.deprecated_rules.setdefault(key, rule)
 

--- a/tests/linter/test_custom_rules.py
+++ b/tests/linter/test_custom_rules.py
@@ -126,3 +126,34 @@ def test_loading_custom_rule_with_name_conflict(loader):
         loader.custom_rules = [EXT_MODULE_WITH_CONFLICT]
         loader.load_rules()
     assert "CUS01" in loader.rules
+
+
+def test_builtin_deprecated_rules_are_registered(loader):
+    """Deprecated built-in rules are discovered and registered so they can be recognized in configuration."""
+    loader.load_rules()
+    # Registered by name, rule id and legacy (deprecated) name.
+    assert "unnecessary-string-conversion" in loader.rules
+    assert "MISC12" in loader.rules
+    assert "0923" in loader.rules
+    assert loader.rules["MISC12"].deprecated
+    # Deprecated rules are shared with the matcher so referencing them reports a deprecation warning.
+    assert loader.rule_matcher.deprecated_rules is not loader.rules
+    assert loader.rule_matcher.deprecated_rules["MISC12"].deprecated
+
+
+def test_selecting_deprecated_rule_reports_warning(capsys):
+    """Selecting a deprecated rule reports a deprecation warning instead of an unknown rule error."""
+    rule_matcher = RuleMatcher(
+        select=["unnecessary-string-conversion"],
+        extend_select=[],
+        ignore=[],
+        target_version=ROBOT_VERSION,
+        threshold=RuleSeverity.INFO,
+        fixable=[],
+        unfixable=[],
+    )
+    loader = RulesLoader(rule_matcher=rule_matcher, custom_rules=[], configure=[], silent=False, config_source="mock")
+    loader.load_rules()
+    _, err = capsys.readouterr()
+    assert "unnecessary-string-conversion is deprecated" in err
+    assert "did not match with any rule name or id" not in err

--- a/tests/linter/test_rule_matcher.py
+++ b/tests/linter/test_rule_matcher.py
@@ -57,6 +57,15 @@ def get_fixable_message_with_id(rule_id: str) -> CustomFixableRule:
     return custom_rule
 
 
+def get_deprecated_rule(rule_id: str, deprecated_names: tuple[str, ...] = ()) -> CustomRule:
+    custom_rule = CustomRule()
+    custom_rule.rule_id = rule_id
+    custom_rule.name = f"some-message-{rule_id}"
+    custom_rule.deprecated = True
+    custom_rule.deprecated_names = deprecated_names
+    return custom_rule
+
+
 class TestRuleMatcher:
     @pytest.mark.parametrize(
         ("selected", "ignored"),
@@ -578,3 +587,68 @@ class TestRuleMatcher:
         rule_matcher.check_unmatched_filters()
         _, err = capsys.readouterr()
         assert err == ""
+
+    def test_deprecated_rule_reports_deprecation_warning(self, capsys):
+        """Referencing a deprecated rule reports a deprecation warning instead of an unknown rule error."""
+        deprecated = get_deprecated_rule("0923", deprecated_names=("old-name",))
+        rule_matcher = RuleMatcher(
+            select=["some-message-0923"],
+            extend_select=[],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+        rule_matcher.deprecated_rules = {
+            "some-message-0923": deprecated,
+            "0923": deprecated,
+            "old-name": deprecated,
+        }
+
+        rule_matcher.check_unmatched_filters()
+        _, err = capsys.readouterr()
+        assert deprecated.deprecation_warning in err
+        assert "did not match with any rule name or id" not in err
+
+    def test_deprecated_rule_by_old_name(self, capsys):
+        """Deprecated rule referenced by its old name is recognized as deprecated."""
+        deprecated = get_deprecated_rule("0923", deprecated_names=("old-name",))
+        rule_matcher = RuleMatcher(
+            select=["old-name"],
+            extend_select=[],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+        rule_matcher.deprecated_rules = {
+            "some-message-0923": deprecated,
+            "0923": deprecated,
+            "old-name": deprecated,
+        }
+
+        rule_matcher.check_unmatched_filters()
+        _, err = capsys.readouterr()
+        assert deprecated.deprecation_warning in err
+        assert "did not match with any rule name or id" not in err
+
+    def test_unknown_rule_still_reports_error_alongside_deprecated(self, capsys):
+        """Unknown rules still report an error even when a deprecated rule is also referenced."""
+        deprecated = get_deprecated_rule("0923")
+        rule_matcher = RuleMatcher(
+            select=["some-message-0923", "does-not-exist"],
+            extend_select=[],
+            ignore=[],
+            target_version=ROBOT_VERSION,
+            threshold=RuleSeverity.INFO,
+            fixable=[],
+            unfixable=[],
+        )
+        rule_matcher.deprecated_rules = {"some-message-0923": deprecated, "0923": deprecated}
+
+        rule_matcher.check_unmatched_filters()
+        _, err = capsys.readouterr()
+        assert deprecated.deprecation_warning in err
+        assert "Option value 'does-not-exist' from '--select' did not match with any rule name or id" in err


### PR DESCRIPTION
## What
Register deprecated rules so they are recognized during configuration.

## Why
Three deprecated rule classes exist (`deprecated = True`) but were never loaded, so they were completely invisible to users:

- `DEPR01 if-can-be-used` (legacy id `0908`)
- `DEPR02 deprecated-statement` (legacy id `0319`)
- `MISC12 unnecessary-string-conversion` (legacy id `0923`)

Before this change, `--select`/`--configure` targeting these (by name, `rule_id`, or legacy id) reported *"did not match with any rule"* or was silently ignored, and `robocop list --filter DEPRECATED` showed nothing.

## What changed
- `LinterImporter._collect_deprecated_rules()` discovers `Rule` subclasses with `deprecated=True` and registers them by `name`, `rule_id`, and every `deprecated_names` alias. Wired into both internal rule modules and external checker modules.
- Removed the dead `register_deprecated_rules` method and the stale `# FIXME` / commented-out registration lines.
- `RuleMatcher.check_unmatched_filters()` now splits unmatched filters into **deprecation warnings** vs genuine **"did not match"** errors (both to stderr).
- `RulesLoader.register_deprecated_rules()` registers each deprecated rule with `enabled = False` and applies any user configuration (emitting a deprecation warning).

## Result
- `--select`/`--configure` on a deprecated rule now emits a clear deprecation warning instead of an error.
- `robocop list --filter DEPRECATED` now lists all 3.
- Default `robocop list` still reports 194 rules (no regression).

## Notes
- Deprecated rules default to `enabled=True`; the MCP rules catalog reads `rule.enabled` directly, so they are registered with `enabled=False` to avoid leaking into the catalog (regression caught + covered by tests).

## Tests
5 new tests (3 in `test_rule_matcher.py`, 2 in `test_custom_rules.py`). Full suite: 2258 passed, 87 skipped. ruff + mypy clean.
