### PR TITLE
chore: remove stale TODO on unnecessary-string-conversion rule

### DIFF
--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -851,7 +851,7 @@ class MultilineInlineIfRule(Rule):
         )
 
 
-class UnnecessaryStringConversionRule(Rule):  # TODO: Not used atm, see if it was deprecated before
+class UnnecessaryStringConversionRule(Rule):
     """
     Variable in the condition has unnecessary string conversion.
 


### PR DESCRIPTION
## What
Remove a stale `# TODO: Not used atm` comment on `UnnecessaryStringConversionRule`.

## Why
The rule is a deprecated rule that is now properly surfaced (see the deprecated-rule registration work), so the "not used" note is no longer accurate.

## What changed
- `src/robocop/linter/rules/misc.py`: delete the stale comment.
