### PR TITLE
refactor: name fix-loop convergence limits

### DIFF
--- a/src/robocop/linter/runner.py
+++ b/src/robocop/linter/runner.py
@@ -32,6 +32,12 @@ if TYPE_CHECKING:
     from robocop.project.context import ProjectContext
 
 
+# Fixes can reveal or resolve other issues, so files are re-scanned and re-fixed until the results converge.
+# These caps bound that loop in case a pair of fixes keeps flipping the same issue.
+MAX_FILE_FIX_ITERATIONS = 20
+MAX_PROJECT_FIX_ITERATIONS = 5
+
+
 class RobocopLinter:
     def __init__(self, config_manager: ConfigManager) -> None:
         self.config_manager = config_manager
@@ -159,7 +165,7 @@ class RobocopLinter:
         templated = is_suite_templated(source_file.model)
         prev_fixable = 0
         # Iteratively scans, filters, applies fixes, and reloads model until convergence or no fixes remain
-        for _ in range(20):
+        for _ in range(MAX_FILE_FIX_ITERATIONS):
             found_diagnostics = []
             disablers = DisablersFinder(source_file.model)
             for checker in resolved_config.checkers:
@@ -239,7 +245,7 @@ class RobocopLinter:
             return diagnostics
         # Fixes may reveal or resolve other issues, so the project is scanned again until it converges.
         # In the diff mode files are not saved, so repeating the analysis would produce the same diagnostics.
-        attempts = 5 if config.linter.fix and not config.linter.diff else 1
+        attempts = MAX_PROJECT_FIX_ITERATIONS if config.linter.fix and not config.linter.diff else 1
         for _ in range(attempts):
             if not self.apply_project_fixes(diagnostics, fix_applier, checked_paths, save=not config.linter.diff):
                 break


### PR DESCRIPTION
## What
Replace magic numbers in the linter fix-loop convergence limits with named module constants.

## What changed
- `src/robocop/linter/runner.py`: add `MAX_FILE_FIX_ITERATIONS = 20` and `MAX_PROJECT_FIX_ITERATIONS = 5` and use them in the respective fix loops.

## Why
Improves readability and makes the convergence caps self-documenting. No behavior change.
