### PR TITLE
feat: add too-many-required-arguments and too-many-optional-arguments rules

### DIFF
--- a/docs/rules_list.md
+++ b/docs/rules_list.md
@@ -5456,6 +5456,8 @@ Redesign the test and move complex logic to separate keywords to increase readab
 
 ### LEN07: too-many-arguments
 
+> Rule is disabled by default. Enable it by using ``--select too-many-arguments`` option.
+
 Added: `v1.0.0`
 
 Supported RF version `All`
@@ -5471,6 +5473,18 @@ Fix availability: There is no automatic fix.
 **Documentation**:
 
 Keyword has too many arguments.
+
+Keywords with many arguments can be hard to understand. A large number of arguments can
+indicate that the keyword does multiple different things and/or that it's complex.
+
+Try to reduce the number of arguments. For example:
+
+- Split the keyword into multiple keywords
+- Collect the required data in a different way
+
+This rule is disabled by default in favor of the ``too-many-required-arguments`` and
+``too-many-optional-arguments`` rules, which allow to configure separate limits for required and
+optional arguments.
 
 **Style guide**:
 
@@ -5511,7 +5525,7 @@ Keyword has too many arguments.
 
 ??? example "max_args"
 
-    Number of lines allowed in a file
+    Number of allowed keyword arguments
 
     **Default value:** 5
 
@@ -7060,6 +7074,186 @@ Correct code example:
         [tool.robocop.lint]
         configure = [
             "metadata-without-value.severity=W"
+        ]
+        ```
+
+---
+
+### LEN34: too-many-required-arguments
+
+Added: `v9.1.0`
+
+Supported RF version `All`
+
+Fix availability: There is no automatic fix.
+
+**Message**:
+
+`Keyword '{keyword_name}' has too many required arguments ({arguments_count}/{max_allowed_count})`
+
+**Documentation**:
+
+Keyword has too many required arguments.
+
+Keywords with many required arguments can be hard to understand. A large number of required
+arguments can indicate that the keyword does multiple different things and/or that it's complex.
+
+Optional arguments are less troublesome as they reduce the amount of things you need to
+understand to use a keyword.
+
+Try to reduce the number of required arguments. For example:
+
+- Split the keyword into multiple keywords
+- Make some arguments optional by giving them a default value
+- Collect the required data in a different way
+
+See also the ``too-many-arguments`` and ``too-many-optional-arguments`` rules.
+
+**Style guide**:
+
+- [#arguments](https://docs.robotframework.org/docs/style_guide#arguments)
+
+> **Note: Severity thresholds**
+>
+> This rule supports dynamic severity configurable using thresholds ([severity-threshold](linter/rules.md#severity-threshold)).
+> Parameter `max_args` will be used to determine issue severity depending on the thresholds.
+>
+> When configuring thresholds remember to also set `max_args` - its value should be lower or
+> equal to the lowest value in the threshold.
+
+**Parameters**:
+
+??? example "severity"
+
+    Rule severity (e = error, w = warning, i = info)
+
+    **Default value:** W
+
+    **Type:** severity
+
+    === ":octicons-command-palette-24: cli"
+
+        ``` bash
+        robocop check --configure too-many-required-arguments.severity=W
+        ```
+
+    === ":material-file-cog-outline: toml"
+
+        ``` toml
+        [tool.robocop.lint]
+        configure = [
+            "too-many-required-arguments.severity=W"
+        ]
+        ```
+
+??? example "max_args"
+
+    Number of allowed required keyword arguments
+
+    **Default value:** 5
+
+    **Type:** int
+
+    === ":octicons-command-palette-24: cli"
+
+        ``` bash
+        robocop check --configure too-many-required-arguments.max_args=5
+        ```
+
+    === ":material-file-cog-outline: toml"
+
+        ``` toml
+        [tool.robocop.lint]
+        configure = [
+            "too-many-required-arguments.max_args=5"
+        ]
+        ```
+
+---
+
+### LEN35: too-many-optional-arguments
+
+Added: `v9.1.0`
+
+Supported RF version `All`
+
+Fix availability: There is no automatic fix.
+
+**Message**:
+
+`Keyword '{keyword_name}' has too many optional arguments ({arguments_count}/{max_allowed_count})`
+
+**Documentation**:
+
+Keyword has too many optional arguments.
+
+Keywords with many optional arguments can be hard to understand. A large number of optional
+arguments can indicate that the keyword does multiple different things and/or that it's complex.
+
+Try to reduce the number of optional arguments. For example:
+
+- Split the keyword into multiple keywords
+- Collect the required data in a different way
+
+See also the ``too-many-arguments`` and ``too-many-required-arguments`` rules.
+
+**Style guide**:
+
+- [#arguments](https://docs.robotframework.org/docs/style_guide#arguments)
+
+> **Note: Severity thresholds**
+>
+> This rule supports dynamic severity configurable using thresholds ([severity-threshold](linter/rules.md#severity-threshold)).
+> Parameter `max_args` will be used to determine issue severity depending on the thresholds.
+>
+> When configuring thresholds remember to also set `max_args` - its value should be lower or
+> equal to the lowest value in the threshold.
+
+**Parameters**:
+
+??? example "severity"
+
+    Rule severity (e = error, w = warning, i = info)
+
+    **Default value:** W
+
+    **Type:** severity
+
+    === ":octicons-command-palette-24: cli"
+
+        ``` bash
+        robocop check --configure too-many-optional-arguments.severity=W
+        ```
+
+    === ":material-file-cog-outline: toml"
+
+        ``` toml
+        [tool.robocop.lint]
+        configure = [
+            "too-many-optional-arguments.severity=W"
+        ]
+        ```
+
+??? example "max_args"
+
+    Number of allowed optional keyword arguments
+
+    **Default value:** 10
+
+    **Type:** int
+
+    === ":octicons-command-palette-24: cli"
+
+        ``` bash
+        robocop check --configure too-many-optional-arguments.max_args=10
+        ```
+
+    === ":material-file-cog-outline: toml"
+
+        ``` toml
+        [tool.robocop.lint]
+        configure = [
+            "too-many-optional-arguments.max_args=10"
         ]
         ```
 

--- a/src/robocop/linter/checkers/test_case_keyword.py
+++ b/src/robocop/linter/checkers/test_case_keyword.py
@@ -27,6 +27,8 @@ class TestCaseKeywordChecker(VisitorChecker):
     too_few_calls_in_test_case: lengths.TooFewCallsInTestCaseRule
     too_many_calls_in_test_case: lengths.TooManyCallsInTestCaseRule
     too_many_arguments: lengths.TooManyArgumentsRule
+    too_many_required_arguments: lengths.TooManyRequiredArgumentsRule
+    too_many_optional_arguments: lengths.TooManyOptionalArgumentsRule
     not_allowed_char_in_filename: naming.NotAllowedCharInFilenameRule
     not_allowed_char_in_name: naming.NotAllowedCharInNameRule
     not_capitalized_test_case_title: naming.NotCapitalizedTestCaseTitleRule
@@ -64,6 +66,8 @@ class TestCaseKeywordChecker(VisitorChecker):
         self.keyword_section_out_of_order.check(node)
         if not node.name.lstrip().startswith("#"):
             self.too_many_arguments.check(node)
+            self.too_many_required_arguments.check(node)
+            self.too_many_optional_arguments.check(node)
             # a keyword that is already reported as too long is not additionally reported for the number of calls
             if not self.too_long_keyword.check(node):
                 keyword_count = count_keyword_calls(node)

--- a/src/robocop/linter/rules/lengths.py
+++ b/src/robocop/linter/rules/lengths.py
@@ -342,13 +342,28 @@ class FileTooLongRule(Rule):
 
 
 class TooManyArgumentsRule(Rule):
-    """Keyword has too many arguments."""
+    """
+    Keyword has too many arguments.
+
+    Keywords with many arguments can be hard to understand. A large number of arguments can
+    indicate that the keyword does multiple different things and/or that it's complex.
+
+    Try to reduce the number of arguments. For example:
+
+    - Split the keyword into multiple keywords
+    - Collect the required data in a different way
+
+    This rule is disabled by default in favor of the ``too-many-required-arguments`` and
+    ``too-many-optional-arguments`` rules, which allow to configure separate limits for required and
+    optional arguments.
+    """
 
     name = "too-many-arguments"
     rule_id = "LEN07"
     message = "Keyword '{keyword_name}' has too many arguments ({arguments_count}/{max_allowed_count})"
     severity = RuleSeverity.WARNING
-    parameters = [RuleParam(name="max_args", default=5, converter=int, desc="number of lines allowed in a file")]
+    enabled = False
+    parameters = [RuleParam(name="max_args", default=5, converter=int, desc="number of allowed keyword arguments")]
     severity_threshold = SeverityThreshold("max_args", compare_method="greater", substitute_value="max_allowed_count")
     added_in_version = "1.0.0"
     style_guide_ref = ["#arguments"]
@@ -364,6 +379,112 @@ class TooManyArgumentsRule(Rule):
             if not isinstance(child, Arguments):
                 continue
             args_number = len(child.values)
+            if args_number > self.max_args:
+                name_token = child.data_tokens[0]
+                self.report(
+                    keyword_name=node.name,
+                    arguments_count=args_number,
+                    max_allowed_count=self.max_args,
+                    node=name_token,
+                    end_lineno=child.end_lineno,
+                    end_col=child.end_col_offset,
+                    extended_disablers=(node.lineno, node.end_lineno),
+                    sev_threshold_value=args_number,
+                )
+            break
+
+
+class TooManyRequiredArgumentsRule(Rule):
+    """
+    Keyword has too many required arguments.
+
+    Keywords with many required arguments can be hard to understand. A large number of required
+    arguments can indicate that the keyword does multiple different things and/or that it's complex.
+
+    Optional arguments are less troublesome as they reduce the amount of things you need to
+    understand to use a keyword.
+
+    Try to reduce the number of required arguments. For example:
+
+    - Split the keyword into multiple keywords
+    - Make some arguments optional by giving them a default value
+    - Collect the required data in a different way
+
+    See also the ``too-many-arguments`` and ``too-many-optional-arguments`` rules.
+    """
+
+    name = "too-many-required-arguments"
+    rule_id = "LEN34"
+    message = "Keyword '{keyword_name}' has too many required arguments ({arguments_count}/{max_allowed_count})"
+    severity = RuleSeverity.WARNING
+    parameters = [
+        RuleParam(name="max_args", default=5, converter=int, desc="number of allowed required keyword arguments")
+    ]
+    severity_threshold = SeverityThreshold("max_args", compare_method="greater", substitute_value="max_allowed_count")
+    added_in_version = "9.1.0"
+    style_guide_ref = ["#arguments"]
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.FOCUSED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+
+    def check(self, node: Keyword) -> None:
+        if not self.enabled:
+            return
+        for child in node.body:
+            if not isinstance(child, Arguments):
+                continue
+            args_number = sum(1 for arg in child.values if "}=" not in arg)
+            if args_number > self.max_args:
+                name_token = child.data_tokens[0]
+                self.report(
+                    keyword_name=node.name,
+                    arguments_count=args_number,
+                    max_allowed_count=self.max_args,
+                    node=name_token,
+                    end_lineno=child.end_lineno,
+                    end_col=child.end_col_offset,
+                    extended_disablers=(node.lineno, node.end_lineno),
+                    sev_threshold_value=args_number,
+                )
+            break
+
+
+class TooManyOptionalArgumentsRule(Rule):
+    """
+    Keyword has too many optional arguments.
+
+    Keywords with many optional arguments can be hard to understand. A large number of optional
+    arguments can indicate that the keyword does multiple different things and/or that it's complex.
+
+    Try to reduce the number of optional arguments. For example:
+
+    - Split the keyword into multiple keywords
+    - Collect the required data in a different way
+
+    See also the ``too-many-arguments`` and ``too-many-required-arguments`` rules.
+    """
+
+    name = "too-many-optional-arguments"
+    rule_id = "LEN35"
+    message = "Keyword '{keyword_name}' has too many optional arguments ({arguments_count}/{max_allowed_count})"
+    severity = RuleSeverity.WARNING
+    parameters = [
+        RuleParam(name="max_args", default=10, converter=int, desc="number of allowed optional keyword arguments")
+    ]
+    severity_threshold = SeverityThreshold("max_args", compare_method="greater", substitute_value="max_allowed_count")
+    added_in_version = "9.1.0"
+    style_guide_ref = ["#arguments"]
+    sonar_qube_attrs = sonar_qube.SonarQubeAttributes(
+        clean_code=sonar_qube.CleanCodeAttribute.FOCUSED, issue_type=sonar_qube.SonarQubeIssueType.CODE_SMELL
+    )
+
+    def check(self, node: Keyword) -> None:
+        if not self.enabled:
+            return
+        for child in node.body:
+            if not isinstance(child, Arguments):
+                continue
+            args_number = sum(1 for arg in child.values if "}=" in arg)
             if args_number > self.max_args:
                 name_token = child.data_tokens[0]
                 self.report(

--- a/tests/linter/rules/lengths/too_many_optional_arguments/disablers.robot
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/disablers.robot
@@ -1,0 +1,22 @@
+*** Keywords ***
+Keyword
+    # robocop: off=too-many-optional-arguments
+    [Arguments]    ${too}=optional  ${many}=optional
+    Some keyword call
+    # robocop: off=some-rule
+    Other keyword call
+    # robocop: on=some-rule
+    and some more
+
+Keyword 2
+    # robocop: off=too-many-optional-arguments
+    [Arguments]    ${too}=optional  ${many}=optional
+    Some keyword call
+    # robocop: off=some-rule
+    Other keyword call
+    # robocop: on=some-rule
+    and some more
+
+Should Be Reported
+    [Arguments]    ${too}=optional  ${many}=optional
+    No Operation

--- a/tests/linter/rules/lengths/too_many_optional_arguments/expected_extended.txt
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/expected_extended.txt
@@ -1,0 +1,26 @@
+test.robot:17:5 LEN35 Keyword 'Keyword With Too Many Arguments' has too many optional arguments (11/10)
+    |
+ 15 | Keyword With Too Many Arguments
+ 16 |     [Documentation]  this is doc
+ 17 |     [Arguments]  ${var1}=optional  ${var2}=optional  ${var3}=optional  ${var4}=optional  ${var5}=optional  ${var6}=optional  ${var7}=optional  ${var8}=optional  ${var9}=optional  ${var10}=optional  ${var11}=optional
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ LEN35
+ 18 |     No Operation
+ 19 |     Pass
+    |
+
+test.robot:25:5 LEN35 Keyword 'Keyword With Too Many Arguments In Multi Lines' has too many optional arguments (11/10)
+    |
+ 23 |   Keyword With Too Many Arguments In Multi Lines
+ 24 |       [Documentation]  this is doc
+ 25 | /     [Arguments]  ${var1}=optional  ${var2}=optional
+ 26 | |     ...  ${var3}=optional  ${var4}=optional
+ 27 | |     ...  ${var5}=optional  ${var6}=optional
+ 28 | |     ...  ${var7}=optional  ${var8}=optional
+ 29 | |     ...  ${var9}=optional  ${var10}=optional
+ 30 | |     ...  ${var11}=optional
+    | |_^ LEN35
+ 31 |       No Operation
+ 32 |       Pass
+    |
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/too_many_optional_arguments/expected_output.txt
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/expected_output.txt
@@ -1,0 +1,4 @@
+test.robot:17:5 [W] LEN35 Keyword 'Keyword With Too Many Arguments' has too many optional arguments (11/10)
+test.robot:25:5 [W] LEN35 Keyword 'Keyword With Too Many Arguments In Multi Lines' has too many optional arguments (11/10)
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/too_many_optional_arguments/expected_output_disablers.txt
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/expected_output_disablers.txt
@@ -1,0 +1,3 @@
+disablers.robot:21:5 [W] LEN35 Keyword 'Should Be Reported' has too many optional arguments (2/1)
+
+Found 1 issue.

--- a/tests/linter/rules/lengths/too_many_optional_arguments/expected_output_severity.txt
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/expected_output_severity.txt
@@ -1,0 +1,4 @@
+severity.robot:17:5 [W] LEN35 Keyword 'Keyword With Too Many Arguments' has too many optional arguments (6/5)
+severity.robot:25:5 [E] LEN35 Keyword 'Keyword With Too Many Arguments In Multi Lines' has too many optional arguments (7/7)
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/too_many_optional_arguments/severity.robot
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/severity.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword With Too Many Arguments
+    [Documentation]  this is doc
+    [Arguments]  ${var1}=optional  ${var2}=optional  ${var3}=optional  ${var4}=optional  ${var5}=optional  ${var6}=optional
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Too Many Arguments In Multi Lines
+    [Documentation]  this is doc
+    [Arguments]  ${var1}=optional  ${var2}=optional
+    ...  ${var3}=optional  ${var4}=optional
+    ...  ${var5}=optional  ${var6}=optional
+    ...  ${var}=optional
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Allowed Number Of Arguments
+    [Documentation]  A keyword
+    [Arguments]     ${arg1}=optional   ${arg2}=optional  ${arg3}=optional   ${arg4}=optional   ${arg5}=optional
+    No Operation
+    No Operation

--- a/tests/linter/rules/lengths/too_many_optional_arguments/test.robot
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/test.robot
@@ -1,0 +1,48 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword With Too Many Arguments
+    [Documentation]  this is doc
+    [Arguments]  ${var1}=optional  ${var2}=optional  ${var3}=optional  ${var4}=optional  ${var5}=optional  ${var6}=optional  ${var7}=optional  ${var8}=optional  ${var9}=optional  ${var10}=optional  ${var11}=optional
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Too Many Arguments In Multi Lines
+    [Documentation]  this is doc
+    [Arguments]  ${var1}=optional  ${var2}=optional
+    ...  ${var3}=optional  ${var4}=optional
+    ...  ${var5}=optional  ${var6}=optional
+    ...  ${var7}=optional  ${var8}=optional
+    ...  ${var9}=optional  ${var10}=optional
+    ...  ${var11}=optional
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Allowed Number Of Arguments
+    [Documentation]  A keyword
+    [Arguments]     ${arg1}=optional   ${arg2}=optional  ${arg3}=optional   ${arg4}=optional   ${arg5}=optional  ${var6}=optional  ${var7}=optional  ${var8}=optional  ${var9}=optional  ${var10}=optional
+    No Operation
+    No Operation
+
+Keyword With Too Many Required Arguments
+    [Documentation]  this is doc
+    [Arguments]  ${var1}  @{var2}  ${var3}  ${var4}  ${var5}  ${var6}
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/too_many_optional_arguments/test_rule.py
+++ b/tests/linter/rules/lengths/too_many_optional_arguments/test_rule.py
@@ -1,0 +1,26 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
+
+    def test_extended(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_severity(self):
+        self.check_rule(
+            configure=[
+                "too-many-optional-arguments.max_args=5",
+                "too-many-optional-arguments.severity_threshold=warning=5:error=7",
+            ],
+            src_files=["severity.robot"],
+            expected_file="expected_output_severity.txt",
+        )
+
+    def test_disablers(self):
+        self.check_rule(
+            configure=["too-many-optional-arguments.max_args=1"],
+            src_files=["disablers.robot"],
+            expected_file="expected_output_disablers.txt",
+        )

--- a/tests/linter/rules/lengths/too_many_required_arguments/disablers.robot
+++ b/tests/linter/rules/lengths/too_many_required_arguments/disablers.robot
@@ -1,0 +1,22 @@
+*** Keywords ***
+Keyword
+    # robocop: off=too-many-required-arguments
+    [Arguments]    ${too}  ${many}
+    Some keyword call
+    # robocop: off=some-rule
+    Other keyword call
+    # robocop: on=some-rule
+    and some more
+
+Keyword 2
+    # robocop: off=too-many-required-arguments
+    [Arguments]    ${too}  ${many}
+    Some keyword call
+    # robocop: off=some-rule
+    Other keyword call
+    # robocop: on=some-rule
+    and some more
+
+Should Be Reported
+    [Arguments]    ${too}  ${many}
+    No Operation

--- a/tests/linter/rules/lengths/too_many_required_arguments/expected_extended.txt
+++ b/tests/linter/rules/lengths/too_many_required_arguments/expected_extended.txt
@@ -1,0 +1,23 @@
+test.robot:17:5 LEN34 Keyword 'Keyword With Too Many Arguments' has too many required arguments (6/5)
+    |
+ 15 | Keyword With Too Many Arguments
+ 16 |     [Documentation]  this is doc
+ 17 |     [Arguments]  ${var1}  @{var2}  ${var3}  ${var4}  ${var5}  ${var6}
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ LEN34
+ 18 |     No Operation
+ 19 |     Pass
+    |
+
+test.robot:25:5 LEN34 Keyword 'Keyword With Too Many Arguments In Multi Lines' has too many required arguments (6/5)
+    |
+ 23 |   Keyword With Too Many Arguments In Multi Lines
+ 24 |       [Documentation]  this is doc
+ 25 | /     [Arguments]  ${var1}  @{var2}
+ 26 | |     ...  ${var3}  ${var4}
+ 27 | |     ...  ${var5}  ${var6}
+    | |_^ LEN34
+ 28 |       No Operation
+ 29 |       Pass
+    |
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/too_many_required_arguments/expected_output.txt
+++ b/tests/linter/rules/lengths/too_many_required_arguments/expected_output.txt
@@ -1,0 +1,4 @@
+test.robot:17:5 [W] LEN34 Keyword 'Keyword With Too Many Arguments' has too many required arguments (6/5)
+test.robot:25:5 [W] LEN34 Keyword 'Keyword With Too Many Arguments In Multi Lines' has too many required arguments (6/5)
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/too_many_required_arguments/expected_output_disablers.txt
+++ b/tests/linter/rules/lengths/too_many_required_arguments/expected_output_disablers.txt
@@ -1,0 +1,3 @@
+disablers.robot:21:5 [W] LEN34 Keyword 'Should Be Reported' has too many required arguments (2/1)
+
+Found 1 issue.

--- a/tests/linter/rules/lengths/too_many_required_arguments/expected_output_severity.txt
+++ b/tests/linter/rules/lengths/too_many_required_arguments/expected_output_severity.txt
@@ -1,0 +1,4 @@
+severity.robot:17:5 [W] LEN34 Keyword 'Keyword With Too Many Arguments' has too many required arguments (6/5)
+severity.robot:25:5 [E] LEN34 Keyword 'Keyword With Too Many Arguments In Multi Lines' has too many required arguments (7/7)
+
+Found 2 issues.

--- a/tests/linter/rules/lengths/too_many_required_arguments/severity.robot
+++ b/tests/linter/rules/lengths/too_many_required_arguments/severity.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword With Too Many Arguments
+    [Documentation]  this is doc
+    [Arguments]  ${var1}  @{var2}  ${var3}  ${var4}  ${var5}  ${var6}
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Too Many Arguments In Multi Lines
+    [Documentation]  this is doc
+    [Arguments]  ${var1}  @{var2}
+    ...  ${var3}  ${var4}
+    ...  ${var5}  ${var6}
+    ...  ${var}
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Allowed Number Of Arguments
+    [Documentation]  A keyword
+    [Arguments]     ${arg1}=1   ${arg2}=2  ${arg3}=3   ${arg4}=4   ${arg5}=5
+    No Operation
+    No Operation

--- a/tests/linter/rules/lengths/too_many_required_arguments/test.robot
+++ b/tests/linter/rules/lengths/too_many_required_arguments/test.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Documentation  doc
+
+
+*** Test Cases ***
+Test
+    [Documentation]  doc
+    [Tags]  sometag
+    Pass
+    Keyword
+    One More
+
+
+*** Keywords ***
+Keyword With Too Many Arguments
+    [Documentation]  this is doc
+    [Arguments]  ${var1}  @{var2}  ${var3}  ${var4}  ${var5}  ${var6}
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Too Many Arguments In Multi Lines
+    [Documentation]  this is doc
+    [Arguments]  ${var1}  @{var2}
+    ...  ${var3}  ${var4}
+    ...  ${var5}  ${var6}
+    No Operation
+    Pass
+    No Operation
+    Fail
+
+Keyword With Allowed Number Of Arguments
+    [Documentation]  A keyword
+    [Arguments]     ${arg1}   ${arg2}  ${arg3}   ${arg4}   ${arg5}
+    No Operation
+    No Operation
+
+Keyword With Too Many Optional Arguments
+    [Documentation]  this is doc
+    [Arguments]  ${var1}=optional  ${var2}=optional  ${var3}=optional  ${var4}=optional  ${var5}=optional  ${var6}=optional
+    No Operation
+    Pass
+    No Operation
+    Fail

--- a/tests/linter/rules/lengths/too_many_required_arguments/test_rule.py
+++ b/tests/linter/rules/lengths/too_many_required_arguments/test_rule.py
@@ -1,0 +1,23 @@
+from tests.linter.utils import RuleAcceptance
+
+
+class TestRuleAcceptance(RuleAcceptance):
+    def test_rule(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
+
+    def test_extended(self):
+        self.check_rule(src_files=["test.robot"], expected_file="expected_extended.txt", output_format="extended")
+
+    def test_severity(self):
+        self.check_rule(
+            configure=["too-many-required-arguments.severity_threshold=warning=5:error=7"],
+            src_files=["severity.robot"],
+            expected_file="expected_output_severity.txt",
+        )
+
+    def test_disablers(self):
+        self.check_rule(
+            configure=["too-many-required-arguments.max_args=1"],
+            src_files=["disablers.robot"],
+            expected_file="expected_output_disablers.txt",
+        )


### PR DESCRIPTION
Adapts #1176 by @Lakitna to the current Robocop architecture (post robocop + robotidy merge) and re-opens it. Original authorship is preserved in the commit (authored by Sander van Beek).

Closes #1145

## What changed

Adds two new `lengths` rules:

- `too-many-required-arguments` (`LEN34`) - default limit `max_args=5`
- `too-many-optional-arguments` (`LEN35`) - default limit `max_args=10`

These allow configuring separate limits for required vs optional keyword arguments. As discussed in #1145, the existing `too-many-arguments` (`LEN07`) rule is now **disabled by default** in favor of the two new rules.

## Notes on adaptation

The original PR targeted the old rule/checker structure. In the new style:
- Rules are declarative classes in `src/robocop/linter/rules/lengths.py` with a `check()` method; wiring lives in `src/robocop/linter/checkers/test_case_keyword.py`.
- Rule IDs use the category prefix form (`LEN34`/`LEN35`) instead of the old numeric `0533`/`0534`.
- Acceptance tests moved to `tests/linter/rules/lengths/too_many_{required,optional}_arguments/` and now also cover `extended` output.
- `docs/rules_list.md` regenerated.

The main logic and test behavior mirror the original PR: required = arguments without a default, optional = arguments with a `}=` default; the `[Arguments]` setting is highlighted (already the behavior on `too-many-arguments`).